### PR TITLE
feat: Add option to add app pipeline's commit to the tag.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: 'Enable multi-stage deployment'
     required: false
     default: 'false'
+  commit-sha:
+    description: 'Store commit SHA in tag.yaml'
+    required: false
+    default: 'false'
   extra-tag1:
     description: 'Extra tag 1 to update (format: path.in.yaml:value)'
     required: false
@@ -65,6 +69,7 @@ runs:
         EXTRA_TAG2: ${{ inputs.extra-tag2 }}
         METADATA: ${{ inputs.metadata }}
         GH_TOKEN: ${{ inputs.github-token }}
+        COMMIT_PIPELINE_SHA: ${{ inputs.commit-sha }}
       run: |
         pip install helm_image_updater-*.tar.gz
         helm-image-updater

--- a/helm_image_updater/cli.py
+++ b/helm_image_updater/cli.py
@@ -59,6 +59,7 @@ def main():
         dry_run = os.environ.get("DRY_RUN", "false").lower() == "true"
         multi_stage = os.environ.get("MULTI_STAGE", "false").lower() == "true"
         target_path = os.environ.get("TARGET_PATH", ".")
+        commit_sha = os.environ.get("COMMIT_PIPELINE_SHA", "false").lower() == "true"
 
         # Change to target directory if specified
         if target_path != ".":
@@ -159,6 +160,7 @@ def main():
             dry_run=dry_run,
             multi_stage=multi_stage,
             extra_tags=extra_tags if extra_tags else None,
+            commit_sha=commit_sha,
         )
 
         # Group extra tags by value and join paths with the same value

--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -40,3 +40,4 @@ class UpdateConfig:
     dry_run: bool = False
     multi_stage: bool = False
     extra_tags: Optional[List[dict]] = None
+    commit_sha: bool = False


### PR DESCRIPTION
Relates to [ST-2598](https://keboola.atlassian.net/browse/ST-2598?atlOrigin=eyJpIjoiMDk2NjcwM2E2OTU2NDU0OGI0ZjhlZGQxZDllZDA2OWUiLCJwIjoiaiJ9).

Adds new flag `commit-sha`, which will take service build pipeline commit SHA, and commit it alongside the tag into `tag.yaml`. Defaults to false.

[ST-2598]: https://keboola.atlassian.net/browse/ST-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ