### PR TITLE
fix: Retry also for when merge is in progress, PR titles determination

### DIFF
--- a/helm_image_updater/tag_updater.py
+++ b/helm_image_updater/tag_updater.py
@@ -302,20 +302,28 @@ def update_stack(config: UpdateConfig, stack_folder: str):
                 "-m",
                 f"Update {config.helm_chart} to {config.image_tag} in {stack_folder}",
             )
-            pr_title_prefix = (
-                "[multi-stage] [test sync]" if config.multi_stage else "[test sync]"
-            )
+
+            # Determine PR title prefix based on stack type
+            if is_dev_stack(stack_folder):
+                pr_title_prefix = (
+                    "[multi-stage] [test sync]" if config.multi_stage else "[test sync]"
+                )
+            else:
+                pr_title_prefix = (
+                    "[multi-stage] [prod sync]" if config.multi_stage else "[prod sync]"
+                )
+
             create_pr(
                 config,
                 branch_name,
                 f"{pr_title_prefix} {config.helm_chart}@{config.image_tag} in {stack_folder}",
             )
-        return {
-            "stack": stack_folder,
-            "chart": config.helm_chart,
-            "tag": config.image_tag,
-            "automerge": config.automerge,
-        }
+            return {
+                "stack": stack_folder,
+                "chart": config.helm_chart,
+                "tag": config.image_tag,
+                "automerge": config.automerge,
+            }
     return None
 
 
@@ -325,7 +333,9 @@ def update_all_stacks_separately(config: UpdateConfig):
     missing_tags = []
 
     for stack in os.listdir("."):
-        if not config.multi_stage and is_dev_stack(stack) or is_production_stack(stack):
+        if not config.multi_stage and (
+            is_dev_stack(stack) or is_production_stack(stack)
+        ):
             result = update_stack(config, stack)
             if result:
                 changes.append(result)


### PR DESCRIPTION
V poslednim PR jsem prestal hlidat "Merge in progress," a zacal hlidat jen "mergeability", coz jsem si myslel, jestli nebude stejnej jako status. Ale neni zjevne.

Takze ted ten tool bude retryovat merge pokud:
- GitHub jeste nevi, jestli se da merge provest.
- GitHub merge provadi (coz byl fail [tady](https://github.com/keboola/kbc-stacks/actions/runs/13367818549/job/37329460508)).

Plus jsem si vsiml, ze to vyrabelo spatny nazvy PR, to je snad taky opraveny.