### PR TITLE
respect automerge for multistage

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Image tags must follow these formats:
 
 When `MULTI_STAGE=true`:
 
-1. Creates and auto-merges PR for dev stacks (if automerge is also true, otherwise won't merges the dev PR)
+1. Creates and auto-merges PR for dev stacks (if automerge is also true, otherwise won't merge the dev PR)
 2. Creates a separate PR (without auto-merge) for production stacks
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Image tags must follow these formats:
 
 When `MULTI_STAGE=true`:
 
-1. Creates and auto-merges PR for dev stacks
+1. Creates and auto-merges PR for dev stacks (if automerge is also true, otherwise won't merges the dev PR)
 2. Creates a separate PR (without auto-merge) for production stacks
 
 ## Development

--- a/helm_image_updater/cli.py
+++ b/helm_image_updater/cli.py
@@ -167,6 +167,7 @@ def main():
             multi_stage=multi_stage,
             extra_tags=extra_tags if extra_tags else None,
             commit_sha=commit_sha,
+            user_requested_automerge=automerge,
         )
 
         # Group extra tags by value and join paths with the same value

--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -50,3 +50,4 @@ class UpdateConfig:
     multi_stage: bool = False
     extra_tags: Optional[List[dict]] = None
     commit_sha: bool = False
+    user_requested_automerge: Optional[bool] = None

--- a/helm_image_updater/pr_manager.py
+++ b/helm_image_updater/pr_manager.py
@@ -55,11 +55,16 @@ def create_pr_body(config: UpdateConfig) -> str:
         repo_url = source.get("repository_url", "")
         workflow_url = source.get("workflow_url", "")
         sha = source.get("sha", "Unknown")
+        pr_url = source.get("pr_url", "")
+        
+        # Build PR line for insertion only if it exists
+        pr_line = f"- **Pull Request:** [{pr_url}]({pr_url})\n" if pr_url else ""
 
         trigger_info = (
             "### 🔄 Pipeline Trigger\n"
             "#### Source Details\n"
             f"- **Repository:** [{repo}]({repo_url})\n"
+            f"{pr_line}"
             f"- **Commit:** [`{sha[:7]}`]({repo_url}/commit/{sha})\n"
             f"- **Actor:** {source.get('actor', 'Unknown')}\n\n"
             "#### Workflow Information\n"

--- a/helm_image_updater/tag_updater.py
+++ b/helm_image_updater/tag_updater.py
@@ -197,9 +197,15 @@ def update_dev_stack(config: UpdateConfig):
                     "-m",
                     f"Update {config.helm_chart} to {image_tag_str} in dev stacks",
                 )
-            pr_title_prefix = (
-                "[multi-stage] [test sync]" if config.multi_stage else "[test sync]"
-            )
+            # Set PR title prefix based on automerge setting
+            if config.multi_stage:
+                if config.automerge:
+                    pr_title_prefix = "[multi-stage] [test sync]"
+                else:
+                    pr_title_prefix = "[multi-stage] [test sync manual]"
+            else:
+                pr_title_prefix = "[test sync]"
+                
             create_pr(
                 config,
                 branch_name,
@@ -316,13 +322,21 @@ def update_stack(config: UpdateConfig, stack_folder: str):
 
             # Determine PR title prefix based on stack type
             if is_dev_stack(stack_folder):
-                pr_title_prefix = (
-                    "[multi-stage] [test sync]" if config.multi_stage else "[test sync]"
-                )
+                if config.multi_stage:
+                    if config.automerge:
+                        pr_title_prefix = "[multi-stage] [test sync]"
+                    else:
+                        pr_title_prefix = "[multi-stage] [test sync manual]"
+                else:
+                    pr_title_prefix = "[test sync]"
             else:
-                pr_title_prefix = (
-                    "[multi-stage] [prod sync]" if config.multi_stage else "[prod sync]"
-                )
+                if config.multi_stage:
+                    if config.automerge:
+                        pr_title_prefix = "[multi-stage] [prod sync]"
+                    else:
+                        pr_title_prefix = "[multi-stage] [prod sync manual]"
+                else:
+                    pr_title_prefix = "[prod sync]"
 
             create_pr(
                 config,

--- a/helm_image_updater/tag_updater.py
+++ b/helm_image_updater/tag_updater.py
@@ -274,10 +274,14 @@ def update_production_stacks(config: UpdateConfig):
         
         # Use a different PR title prefix when automerge is false in multi-stage mode
         if config.multi_stage:
-            if config.automerge:
+            # In multi-stage, check if the user requested automerge (user intent)
+            user_requested_automerge = os.environ.get("AUTOMERGE", "true").lower() == "true"
+            if user_requested_automerge:
+                # If user wanted automerge, use regular prod sync format (workflow will find it)
                 pr_title_prefix = "[multi-stage] [prod sync]"
             else:
-                pr_title_prefix = "[multi-stage] [prod sync manual]"  # Different format that won't match the workflow search
+                # If user didn't want automerge, use manual format (workflow won't find it)
+                pr_title_prefix = "[multi-stage] [prod sync manual]"
         else:
             pr_title_prefix = "[prod sync]"
             

--- a/helm_image_updater/tag_updater.py
+++ b/helm_image_updater/tag_updater.py
@@ -199,7 +199,7 @@ def update_dev_stack(config: UpdateConfig):
                 )
             # Set PR title prefix based on automerge setting
             if config.multi_stage:
-                if config.automerge:
+                if config.user_requested_automerge:
                     pr_title_prefix = "[multi-stage] [test sync]"
                 else:
                     pr_title_prefix = "[multi-stage] [test sync manual]"
@@ -274,9 +274,8 @@ def update_production_stacks(config: UpdateConfig):
         
         # Use a different PR title prefix when automerge is false in multi-stage mode
         if config.multi_stage:
-            # In multi-stage, check if the user requested automerge (user intent)
-            user_requested_automerge = os.environ.get("AUTOMERGE", "true").lower() == "true"
-            if user_requested_automerge:
+            # In multi-stage, check the original user automerge intent
+            if config.user_requested_automerge:
                 # If user wanted automerge, use regular prod sync format (workflow will find it)
                 pr_title_prefix = "[multi-stage] [prod sync]"
             else:
@@ -327,7 +326,7 @@ def update_stack(config: UpdateConfig, stack_folder: str):
             # Determine PR title prefix based on stack type
             if is_dev_stack(stack_folder):
                 if config.multi_stage:
-                    if config.automerge:
+                    if config.user_requested_automerge:
                         pr_title_prefix = "[multi-stage] [test sync]"
                     else:
                         pr_title_prefix = "[multi-stage] [test sync manual]"
@@ -335,7 +334,7 @@ def update_stack(config: UpdateConfig, stack_folder: str):
                     pr_title_prefix = "[test sync]"
             else:
                 if config.multi_stage:
-                    if config.automerge:
+                    if config.user_requested_automerge:
                         pr_title_prefix = "[multi-stage] [prod sync]"
                     else:
                         pr_title_prefix = "[multi-stage] [prod sync manual]"
@@ -550,11 +549,12 @@ def handle_production_tag(config: UpdateConfig):
         github_repo=config.github_repo,
         helm_chart=config.helm_chart,
         image_tag=config.image_tag,
-        automerge=config.automerge,  # Use user's automerge setting instead of forcing True
+        automerge=config.automerge,  # Use user's automerge setting
         dry_run=config.dry_run,
         multi_stage=config.multi_stage,
         extra_tags=config.extra_tags,
         commit_sha=config.commit_sha,
+        user_requested_automerge=config.user_requested_automerge,  # Pass through original setting
     )
     dev_changes, dev_missing = update_dev_stack(dev_config)
 
@@ -569,6 +569,7 @@ def handle_production_tag(config: UpdateConfig):
         multi_stage=config.multi_stage,
         extra_tags=config.extra_tags,
         commit_sha=config.commit_sha,
+        user_requested_automerge=config.user_requested_automerge,  # Pass through original setting
     )
     prod_changes, prod_missing = update_production_stacks(prod_config)
 

--- a/tests/test_cli_functional.py
+++ b/tests/test_cli_functional.py
@@ -532,11 +532,11 @@ def test_multi_stage_with_automerge_false(cli_test_env, capsys):
     This test verifies that:
     1. With multi-stage=true and automerge=false
     2. For production tags, it creates:
-       - Dev PR with [multi-stage] [test sync] that respects the automerge=false setting
+       - Dev PR with [multi-stage] [test sync manual] that respects the automerge=false setting
        - Prod PR with [multi-stage] [prod sync manual] that is NOT auto-merged
     3. The automerge setting for dev stacks respects user's setting
     4. The automerge setting for prod stacks is always forced to false
-    5. The prod PR uses a different title format that won't match automated workflows
+    5. The PR titles use different formats that won't match automated workflows
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
     
@@ -570,12 +570,16 @@ def test_multi_stage_with_automerge_false(cli_test_env, capsys):
     # Verify 2 PRs were created
     assert len(created_prs) == 2, "Should create exactly 2 PRs"
     
+    # Debug: Print all PR titles
+    for pr in created_prs:
+        print(f"DEBUG - Created PR title: '{pr['title']}', automerge: {pr['automerge']}")
+    
     # Find dev and prod PRs
-    dev_pr = next((pr for pr in created_prs if "[test sync]" in pr["title"]), None)
+    dev_pr = next((pr for pr in created_prs if "[test sync manual]" in pr["title"]), None)
     prod_pr = next((pr for pr in created_prs if "[prod sync manual]" in pr["title"]), None)
     
     # Verify PRs exist with correct settings
-    assert dev_pr is not None, "Should create a dev PR with [test sync]"
+    assert dev_pr is not None, "Should create a dev PR with [test sync manual]"
     assert prod_pr is not None, "Should create a prod PR with [prod sync manual]"
     
     # Verify automerge settings
@@ -586,7 +590,9 @@ def test_multi_stage_with_automerge_false(cli_test_env, capsys):
     assert "[multi-stage]" in dev_pr["title"], "Dev PR should have [multi-stage] prefix"
     assert "[multi-stage]" in prod_pr["title"], "Prod PR should have [multi-stage] prefix"
     
-    # Verify prod PR has the manual format that won't match workflow searches
+    # Verify PR titles have the manual format that won't match workflow searches
+    assert "[test sync]" not in dev_pr["title"], "Dev PR should NOT have [test sync] in title"
+    assert "[test sync manual]" in dev_pr["title"], "Dev PR should have [test sync manual] in title"
     assert "[prod sync]" not in prod_pr["title"], "Prod PR should NOT have [prod sync] in title"
     assert "[prod sync manual]" in prod_pr["title"], "Prod PR should have [prod sync manual] in title"
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-13
Tato uprava zariadi ze pre multi-stage deploy sa bude respektovat parameter automerge, to znamena:
-  ak je `multi-stage:true` a `automerge:false`, tak:
   - vytvori PR na dev stacku s title `[multi-stage] [test sync manual]` ktory nemergne
   - vytvori PR na prod stacku s title `[multi-stage] [prod sync manual]` ktore nemergne (to nemerguje ani teraz)
-  ak je `multi-stage:true` a `automerge:true`, tak je to ako doteraz tj:
    - vytvori PR na dev stacku s title `[multi-stage] [test sync]` ktory mergne
    - vytvori PR na prod stacku s title `[multi-stage] [prod sync]` ktore nemergne 

Zbytok by mal byt rovnaky. Pridal som zaroven k tomu testy aby sa to poriadne otestovalo. Tym ze tie testy presli by som povedal ze to je cajk ale ak Michal myslis ze je lepsie to este otestovat cez sre-playground tak to urobim :) 

Este som upravil vytvaranie PR a pridal do neho link na source PR ktory tu zmenu vytrigeroval takze by sa to malo prelinkovat.
