### PR TITLE
fix: Switch to canary branch before checking for tag.yaml

### DIFF
--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -30,7 +30,10 @@ CANARY_STACKS = {
         "stack": "dev-keboola-canary-orion",
         "base_branch": "canary-orion",
     },
-    "canary-ursa": {"stack": "dev-keboola-canary-ursa", "base_branch": "canary-ursa"},
+    "canary-ursa": {
+        "stack": "dev-keboola-canary-ursa",
+        "base_branch": "canary-ursa"
+    },
 }
 IGNORED_FOLDERS = {".venv", "aws", ".git", ".github"}
 GITHUB_REPO = os.getenv("GITHUB_REPOSITORY", "keboola/kbc-stacks")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ otherwise uses a default set of requirements.
 Example:
     To install the package:
         $ pip install .
-    
+
     To build the package:
         $ python setup.py sdist bdist_wheel
 

--- a/tests/test_cli_functional.py
+++ b/tests/test_cli_functional.py
@@ -15,21 +15,17 @@ file operations with temporary directories.
 """
 
 import os
-import sys
 import pytest
-import io
 import yaml
-import git
 from unittest.mock import Mock, patch, MagicMock
-from pathlib import Path
-from contextlib import ExitStack
 
 # Import the modules we'll need
-from helm_image_updater import cli, config
+from helm_image_updater import cli
 
 # -----------------------------------------------------------------------------
 # Fixtures
 # -----------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_github():
@@ -37,15 +33,15 @@ def mock_github():
     github_mock = MagicMock()
     repo_mock = MagicMock()
     github_mock.get_repo.return_value = repo_mock
-    
+
     # Mock pull request creation
     pull_mock = MagicMock()
     repo_mock.create_pull.return_value = pull_mock
-    
+
     # Return values for the PR creation
     pull_mock.html_url = "https://github.com/mock-org/mock-repo/pull/123"
     pull_mock.number = 123
-    
+
     return github_mock, repo_mock, pull_mock
 
 
@@ -69,36 +65,42 @@ def cli_test_env(mock_repo, mock_github_repo, tmp_path):
     # Create test stack structure
     base_dir = tmp_path
     setup_test_stacks(base_dir)
-    
+
     # Store original environment and directory
     orig_env = os.environ.copy()
     orig_dir = os.getcwd()
-    
+
     # Change to test directory
     os.chdir(base_dir)
-    
+
     # Setup patches for external dependencies
-    with patch('helm_image_updater.config.GITHUB_REPO', 'mock-org/mock-repo'), \
-         patch('git.Repo', return_value=mock_repo), \
-         patch('helm_image_updater.cli.Repo', return_value=mock_repo), \
-         patch('github.Github', return_value=Mock(get_repo=lambda x: mock_github_repo)), \
-         patch('helm_image_updater.cli.Github', return_value=Mock(get_repo=lambda x: mock_github_repo)), \
-         patch('helm_image_updater.pr_manager.create_pr', return_value=None):
-        
+    with (
+        patch("helm_image_updater.config.GITHUB_REPO", "mock-org/mock-repo"),
+        patch("git.Repo", return_value=mock_repo),
+        patch("helm_image_updater.cli.Repo", return_value=mock_repo),
+        patch("github.Github", return_value=Mock(get_repo=lambda x: mock_github_repo)),
+        patch(
+            "helm_image_updater.cli.Github",
+            return_value=Mock(get_repo=lambda x: mock_github_repo),
+        ),
+        patch("helm_image_updater.pr_manager.create_pr", return_value=None),
+    ):
         # Clear environment and set basic variables
         os.environ.clear()
         os.environ["GH_TOKEN"] = "fake-token"
-        
+
         yield base_dir, mock_repo, mock_github_repo
-    
+
     # Restore original environment and directory
     os.chdir(orig_dir)
     os.environ.clear()
     os.environ.update(orig_env)
 
+
 # -----------------------------------------------------------------------------
 # Helper Functions
 # -----------------------------------------------------------------------------
+
 
 def setup_test_stacks(base_path):
     """Create test stack structure with tag.yaml files."""
@@ -144,19 +146,20 @@ def read_tag_yaml(path):
 # Environment Variable Handling Tests
 # -----------------------------------------------------------------------------
 
+
 def test_cli_environment_variables(cli_test_env, capsys):
     """Test CLI environment variable handling."""
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
     os.environ["AUTOMERGE"] = "false"
     os.environ["DRY_RUN"] = "true"
-    
+
     # Run CLI
     cli.main()
-    
+
     # Check output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
@@ -169,46 +172,52 @@ def test_cli_environment_variables(cli_test_env, capsys):
 # Tag Workflow Tests
 # -----------------------------------------------------------------------------
 
+
 def test_dev_tag_update(cli_test_env, capsys):
     """Test updating dev stacks with a dev tag.
-    
+
     This test verifies that:
     1. Only dev stacks are updated with dev tags
     2. The tag.yaml file content is correctly modified
     3. Console output correctly reports the updates
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables for dev tag update
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
     os.environ["AUTOMERGE"] = "true"
-    
+
     # Mock create_pr to track PRs created
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base})")
-    
+
     # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "Updating dev stacks (dev- tag)" in captured.out
-    
+
     # Verify tag.yaml was updated in dev stack
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "dev-1.2.3"
-    
+
     # Verify tag.yaml was NOT updated in prod stack
-    prod_tag_yaml = read_tag_yaml(base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml")
+    prod_tag_yaml = read_tag_yaml(
+        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+    )
     assert prod_tag_yaml["image"]["tag"] == "old-tag"
-    
+
     # Verify PR was created
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
@@ -216,43 +225,48 @@ def test_dev_tag_update(cli_test_env, capsys):
 
 def test_production_tag_update(cli_test_env, capsys):
     """Test updating all stacks with a production tag.
-    
+
     This test verifies that:
     1. All stacks are updated with production tags
     2. The tag.yaml files are correctly modified
     3. Console output correctly reports the updates
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables for production tag update
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "production-1.2.3"
     os.environ["AUTOMERGE"] = "true"
-    
+
     # Mock create_pr to track PRs created
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base})")
-    
+
     # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "Updating all stacks (production- tag)" in captured.out
-    
+
     # Verify tag.yaml was updated in both dev and prod stacks
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "production-1.2.3"
-    
-    prod_tag_yaml = read_tag_yaml(base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml")
+
+    prod_tag_yaml = read_tag_yaml(
+        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+    )
     assert prod_tag_yaml["image"]["tag"] == "production-1.2.3"
-    
+
     # Verify PR was created
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
@@ -260,51 +274,121 @@ def test_production_tag_update(cli_test_env, capsys):
 
 def test_canary_tag_update(cli_test_env, capsys):
     """Test updating canary stack with a canary tag.
-    
-    This test verifies that:
-    1. Only canary stack is updated with canary tags
-    2. The tag.yaml file is correctly modified
-    3. Console output correctly reports the updates
+
+    This test verifies canary tag handling in two scenarios:
+    1. Regular services: Chart exists in multiple environments (test-chart)
+    2. Canary-only services: Chart exists only in canary branches (metastore)
+
+    Both scenarios should:
+    - Switch to the correct canary branch before file checks
+    - Only update the appropriate canary stack
+    - Create PR against the correct canary branch
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
-    # Set environment variables for canary tag update
-    os.environ["HELM_CHART"] = "test-chart"
-    os.environ["IMAGE_TAG"] = "canary-orion-1.2.3"
-    os.environ["AUTOMERGE"] = "true"
-    
+
+    # Setup mock repo to track git operations and simulate branch switching
+    git_calls = []
+
+    def track_git_call(*args, **kwargs):
+        git_calls.append(args)
+        return Mock()
+
+    mock_repo.git.checkout = Mock(side_effect=track_git_call)
+    mock_repo.git.pull = Mock(side_effect=track_git_call)
+    mock_repo.active_branch = Mock()
+    mock_repo.active_branch.name = "canary-orion"
+
     # Mock create_pr to track PRs created
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base})")
-    
-    # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
-        # Run CLI
+
+    # Test Case 1: Regular service that exists in multiple environments
+    os.environ["HELM_CHART"] = "test-chart"
+    os.environ["IMAGE_TAG"] = "canary-orion-1.2.3"
+    os.environ["AUTOMERGE"] = "true"
+
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         cli.main()
-    
-    # Check console output
+
+    # Check console output for branch switching
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
+    assert "Detected canary tag with prefix 'canary-orion'" in captured.out
+    assert "switching to branch 'canary-orion'" in captured.out
+    assert "Successfully switched to branch 'canary-orion'" in captured.out
+    assert "Current branch: canary-orion" in captured.out
     assert "Updating canary stack" in captured.out
-    
+
     # Verify tag.yaml was updated only in canary stack
-    canary_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-canary-orion" / "test-chart" / "tag.yaml")
+    canary_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-canary-orion" / "test-chart" / "tag.yaml"
+    )
     assert canary_tag_yaml["image"]["tag"] == "canary-orion-1.2.3"
-    
+
     # Verify other stacks were NOT updated
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "old-tag"
-    
-    prod_tag_yaml = read_tag_yaml(base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml")
+
+    prod_tag_yaml = read_tag_yaml(
+        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+    )
     assert prod_tag_yaml["image"]["tag"] == "old-tag"
-    
-    # Verify PR was created
+
+    # Verify PR was created against canary branch
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
-    # Canary PRs should be created against canary branches
+    assert created_prs[0]["base"] == "canary-orion"
+
+    # Verify git operations were called for branch switching
+    checkout_calls = [call for call in git_calls if "canary-orion" in str(call)]
+    assert len(checkout_calls) >= 1, (
+        "Should have called git checkout for canary-orion branch"
+    )
+
+    # Test Case 2: Canary-only service (like metastore)
+    # Reset environment and tracking variables
+    created_prs.clear()
+    git_calls.clear()
+    os.environ.clear()
+    os.environ["GH_TOKEN"] = "fake-token"
+    os.environ["HELM_CHART"] = "metastore"  # Chart that only exists in canary
+    os.environ["IMAGE_TAG"] = "canary-orion-metastore-0.0.5"
+    os.environ["AUTOMERGE"] = "true"
+
+    # Create metastore chart only in canary stack (simulating canary-only service)
+    metastore_canary_dir = base_dir / "dev-keboola-canary-orion" / "metastore"
+    metastore_canary_dir.mkdir()
+    create_tag_yaml(metastore_canary_dir / "tag.yaml", "old-canary-tag")
+
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
+        cli.main()
+
+    # Check console output shows proper branch switching before file checks
+    captured = capsys.readouterr()
+    assert "Processing Helm chart: metastore" in captured.out
+    assert "Detected canary tag with prefix 'canary-orion'" in captured.out
+    assert "switching to branch 'canary-orion'" in captured.out
+    assert "Successfully switched to branch 'canary-orion'" in captured.out
+
+    # Most importantly: verify it didn't exit early due to missing files
+    assert (
+        "tag.yaml for chart metastore does not exist in any stack" not in captured.out
+    )
+    assert "Updating canary stack" in captured.out
+
+    # Verify the canary-only service was updated
+    metastore_tag_yaml = read_tag_yaml(metastore_canary_dir / "tag.yaml")
+    assert metastore_tag_yaml["image"]["tag"] == "canary-orion-metastore-0.0.5"
+
+    # Verify PR was created for canary-only service
+    assert len(created_prs) == 1
+    assert "metastore" in created_prs[0]["title"]
     assert created_prs[0]["base"] == "canary-orion"
 
 
@@ -312,30 +396,31 @@ def test_canary_tag_update(cli_test_env, capsys):
 # Target path Tests
 # -----------------------------------------------------------------------------
 
+
 def test_cli_target_path(cli_test_env, tmp_path, capsys):
     """Test CLI target path handling."""
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Create a subdirectory with test stacks
     target_dir = tmp_path / "target_dir"
     target_dir.mkdir()
-    
+
     # Setup test stacks in the target directory
     setup_test_stacks(target_dir)
-    
+
     # Set environment variables with target path
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
     os.environ["TARGET_PATH"] = str(target_dir)
-    
+
     # Mock os.chdir to verify it's called with the correct path
-    with patch('os.chdir') as mock_chdir:
+    with patch("os.chdir") as mock_chdir:
         # Run CLI
         cli.main()
-        
+
         # Verify chdir was called with correct path
         mock_chdir.assert_called_with(str(target_dir))
-    
+
     # Verify output
     captured = capsys.readouterr()
     assert f"Changing to target directory: {target_dir}" in captured.out
@@ -345,39 +430,43 @@ def test_cli_target_path(cli_test_env, tmp_path, capsys):
 # Error Handling Tests
 # -----------------------------------------------------------------------------
 
+
 def test_missing_required_env_var(cli_test_env, capsys):
     """Test error handling for missing environment variables.
-    
+
     This test verifies that:
     1. Missing HELM_CHART env var is detected
-    2. The script raises a KeyError 
+    2. The script raises a KeyError
     3. No PRs are created
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Don't set HELM_CHART
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
-    
+
     # Track PRs
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
-    
+
     # Run CLI expecting an KeyError
-    with pytest.raises(KeyError) as e, \
-         patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with (
+        pytest.raises(KeyError) as e,
+        patch("helm_image_updater.tag_updater.create_pr", mock_create_pr),
+    ):
         cli.main()
-    
+
     # Verify the missing key is HELM_CHART
     assert str(e.value) == "'HELM_CHART'"
-    
+
     # Verify PR was not created
     assert len(created_prs) == 0
 
 
 def test_invalid_tag_format(cli_test_env, capsys):
     """Test error handling for invalid tag format.
-    
+
     This test verifies that:
     1. Invalid tag format is detected
     2. The script exits with the correct error code
@@ -385,75 +474,83 @@ def test_invalid_tag_format(cli_test_env, capsys):
     4. No PRs are created
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables with invalid tag
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "invalid-format"  # Not starting with dev- or production-
-    
+
     # Track PRs
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
-    
+
     # Run CLI expecting an error
-    with pytest.raises(SystemExit) as e, \
-         patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with (
+        pytest.raises(SystemExit) as e,
+        patch("helm_image_updater.tag_updater.create_pr", mock_create_pr),
+    ):
         cli.main()
-    
+
     # Check error message
     captured = capsys.readouterr()
     assert "Invalid image tag format" in captured.out
-    
+
     # Verify exit code
     assert e.value.code == 1
-    
+
     # Verify no files were changed
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "old-tag"
-    
+
     # Verify PR was not created
     assert len(created_prs) == 0
 
 
 def test_invalid_extra_tag_format(cli_test_env, capsys):
     """Test error handling for invalid extra tag format.
-    
+
     This test verifies that:
     1. Invalid extra tag format is detected
     2. The script exits with the correct error code
     3. Appropriate error message is displayed
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables with invalid extra tag format
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
     os.environ["EXTRA_TAG1"] = "invalid-format"  # Missing colon separator
-    
+
     # Track PRs
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
-    
+
     # Run CLI expecting an error
-    with pytest.raises(SystemExit) as e, \
-         patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with (
+        pytest.raises(SystemExit) as e,
+        patch("helm_image_updater.tag_updater.create_pr", mock_create_pr),
+    ):
         cli.main()
-    
+
     # Check error message
     captured = capsys.readouterr()
     assert "EXTRA_TAG1 must be in format" in captured.out
-    
+
     # Verify exit code
     assert e.value.code == 1
-    
+
     # Verify PR was not created
     assert len(created_prs) == 0
 
 
 def test_valid_extra_tag_formats(cli_test_env, capsys):
     """Test valid extra tag formats including semver.
-    
+
     This test verifies that:
     1. Extra tags with valid formats are accepted:
        - dev- prefix
@@ -464,56 +561,57 @@ def test_valid_extra_tag_formats(cli_test_env, capsys):
     3. PRs are created as expected
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables with valid extra tag formats
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
     os.environ["EXTRA_TAG1"] = "path1:dev-1.2.3"  # Standard dev format
-    os.environ["EXTRA_TAG2"] = "path2:1.2.3"      # Semver format without v
-    
+    os.environ["EXTRA_TAG2"] = "path2:1.2.3"  # Semver format without v
+
     # Track PRs
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base})")
-    
+
     # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "Extra tags to update:" in captured.out
     assert "  - path1: dev-1.2.3" in captured.out
     assert "  - path2: 1.2.3" in captured.out
-    
+
     # Verify PR was created (dev tag should trigger a PR for dev stacks)
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
-    
+
     # Run another test with v-prefixed semver
     os.environ.clear()
     os.environ["GH_TOKEN"] = "fake-token"
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "production-1.2.3"
     os.environ["EXTRA_TAG1"] = "path1:v1.2.3"  # Semver format with v prefix
-    
+
     created_prs.clear()
-    
+
     # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "Extra tags to update:" in captured.out
     assert "  - path1: v1.2.3" in captured.out
-    
+
     # Verify PR was created (production tag should trigger a PR for all stacks)
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
@@ -521,7 +619,7 @@ def test_valid_extra_tag_formats(cli_test_env, capsys):
 
 def test_nonexistent_stack_override(cli_test_env, capsys):
     """Test error handling for non-existent override stack.
-    
+
     This test verifies that:
     1. Non-existent override stack is detected
     2. Console output correctly reports the error
@@ -529,37 +627,40 @@ def test_nonexistent_stack_override(cli_test_env, capsys):
     4. No PRs are created
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables with non-existent override stack
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
     os.environ["OVERRIDE_STACK"] = "non-existent-stack"
-    
+
     # Track PRs
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
-    
+
     # Only mock create_pr, use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Stack non-existent-stack does not exist" in captured.out
-    
+
     # Verify tag.yaml files were not modified
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "old-tag"
-    
+
     # Verify PR was not created
     assert len(created_prs) == 0
 
 
 def test_multi_stage_automerge_true(cli_test_env, capsys):
     """Test multi-stage deployment with automerge=true.
-    
+
     This test verifies that:
     1. With multi-stage=true and automerge=true
     2. For production tags, it creates:
@@ -571,62 +672,77 @@ def test_multi_stage_automerge_true(cli_test_env, capsys):
        (This allows workflow to find it even though the PR itself won't auto-merge)
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables for multi-stage deployment
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "production-1.2.3"
     os.environ["MULTI_STAGE"] = "true"
     os.environ["AUTOMERGE"] = "true"
-    
+
     # Track PRs with their automerge setting
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
-        created_prs.append({
-            "branch": branch_name, 
-            "title": pr_title, 
-            "base": base,
-            "automerge": config.automerge
-        })
-        print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base}, automerge: {config.automerge})")
-    
+        created_prs.append(
+            {
+                "branch": branch_name,
+                "title": pr_title,
+                "base": base,
+                "automerge": config.automerge,
+            }
+        )
+        print(
+            f"Created PR: {pr_title} (branch: {branch_name}, base: {base}, automerge: {config.automerge})"
+        )
+
     # Mock create_pr but use real config to capture automerge setting
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Multi-stage deployment: True" in captured.out
     assert "Automerge: True" in captured.out
-    
+
     # Verify 2 PRs were created
     assert len(created_prs) == 2, "Should create exactly 2 PRs"
-    
+
     # Debug: Print all PR titles for inspection
     print("DEBUG: All PR titles:")
     for pr in created_prs:
         print(f"  - '{pr['title']}' (automerge: {pr['automerge']})")
-    
+
     # Find dev and prod PRs
-    dev_pr = next((pr for pr in created_prs if "[multi-stage] [test sync]" in pr["title"]), None)
-    prod_pr = next((pr for pr in created_prs if "[multi-stage] [prod sync]" in pr["title"]), None)
-    
+    dev_pr = next(
+        (pr for pr in created_prs if "[multi-stage] [test sync]" in pr["title"]), None
+    )
+    prod_pr = next(
+        (pr for pr in created_prs if "[multi-stage] [prod sync]" in pr["title"]), None
+    )
+
     # Verify PRs exist with correct settings
     assert dev_pr is not None, "Should create a dev PR with [multi-stage] [test sync]"
     assert prod_pr is not None, "Should create a prod PR with [multi-stage] [prod sync]"
-    
+
     # Verify automerge settings
     assert dev_pr["automerge"] is True, "Dev PR should have automerge=True"
-    assert prod_pr["automerge"] is False, "Prod PR should have automerge=False (forced by multi-stage)"
-    
+    assert prod_pr["automerge"] is False, (
+        "Prod PR should have automerge=False (forced by multi-stage)"
+    )
+
     # Verify complete PR title prefixes
-    assert dev_pr["title"].startswith("[multi-stage] [test sync]"), "Dev PR should start with [multi-stage] [test sync]"
-    assert prod_pr["title"].startswith("[multi-stage] [prod sync]"), "Prod PR should start with [multi-stage] [prod sync]"
+    assert dev_pr["title"].startswith("[multi-stage] [test sync]"), (
+        "Dev PR should start with [multi-stage] [test sync]"
+    )
+    assert prod_pr["title"].startswith("[multi-stage] [prod sync]"), (
+        "Prod PR should start with [multi-stage] [prod sync]"
+    )
 
 
 def test_multi_stage_with_automerge_false(cli_test_env, capsys):
     """Test multi-stage deployment with automerge=false.
-    
+
     This test verifies that:
     1. With multi-stage=true and automerge=false
     2. For production tags, it creates:
@@ -638,135 +754,165 @@ def test_multi_stage_with_automerge_false(cli_test_env, capsys):
        (This prevents automated workflows from finding these PRs)
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables for multi-stage deployment with automerge=false
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "production-1.2.3"
     os.environ["MULTI_STAGE"] = "true"
     os.environ["AUTOMERGE"] = "false"
-    
+
     # Track PRs with their automerge setting
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
-        created_prs.append({
-            "branch": branch_name, 
-            "title": pr_title, 
-            "base": base,
-            "automerge": config.automerge
-        })
-        print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base}, automerge: {config.automerge})")
-    
+        created_prs.append(
+            {
+                "branch": branch_name,
+                "title": pr_title,
+                "base": base,
+                "automerge": config.automerge,
+            }
+        )
+        print(
+            f"Created PR: {pr_title} (branch: {branch_name}, base: {base}, automerge: {config.automerge})"
+        )
+
     # Mock create_pr but use real config to capture automerge setting
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Multi-stage deployment: True" in captured.out
     assert "Automerge: False" in captured.out
-    
+
     # Verify 2 PRs were created
     assert len(created_prs) == 2, "Should create exactly 2 PRs"
-    
+
     # Debug: Print all PR titles for inspection
     print("DEBUG: All PR titles:")
     for pr in created_prs:
         print(f"  - '{pr['title']}' (automerge: {pr['automerge']})")
-    
+
     # Find dev and prod PRs
-    dev_pr = next((pr for pr in created_prs if "[multi-stage] [test sync manual]" in pr["title"]), None)
-    prod_pr = next((pr for pr in created_prs if "[multi-stage] [prod sync manual]" in pr["title"]), None)
-    
+    dev_pr = next(
+        (pr for pr in created_prs if "[multi-stage] [test sync manual]" in pr["title"]),
+        None,
+    )
+    prod_pr = next(
+        (pr for pr in created_prs if "[multi-stage] [prod sync manual]" in pr["title"]),
+        None,
+    )
+
     # Verify PRs exist with correct settings
-    assert dev_pr is not None, "Should create a dev PR with [multi-stage] [test sync manual]"
-    assert prod_pr is not None, "Should create a prod PR with [multi-stage] [prod sync manual]"
-    
+    assert dev_pr is not None, (
+        "Should create a dev PR with [multi-stage] [test sync manual]"
+    )
+    assert prod_pr is not None, (
+        "Should create a prod PR with [multi-stage] [prod sync manual]"
+    )
+
     # Verify automerge settings
     assert dev_pr["automerge"] is False, "Dev PR should have automerge=False"
     assert prod_pr["automerge"] is False, "Prod PR should have automerge=False"
-    
+
     # Verify complete PR title prefixes
-    assert dev_pr["title"].startswith("[multi-stage] [test sync manual]"), "Dev PR should start with [multi-stage] [test sync manual]"
-    assert prod_pr["title"].startswith("[multi-stage] [prod sync manual]"), "Prod PR should start with [multi-stage] [prod sync manual]"
+    assert dev_pr["title"].startswith("[multi-stage] [test sync manual]"), (
+        "Dev PR should start with [multi-stage] [test sync manual]"
+    )
+    assert prod_pr["title"].startswith("[multi-stage] [prod sync manual]"), (
+        "Prod PR should start with [multi-stage] [prod sync manual]"
+    )
 
 
 def test_dry_run(cli_test_env, capsys):
     """Test dry run mode doesn't change files.
-    
+
     This test verifies that:
     1. Dry run mode correctly reports what would be changed
     2. No actual file changes are made
     3. PRs are only simulated but not actually created
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables for dry run
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3-dry-run"
     os.environ["DRY_RUN"] = "true"
-    
+
     # Run CLI without any mocks for PR creation - we want to validate that
     # create_pr is called but only in dry run mode
     cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Dry run: True" in captured.out
     assert "Would update" in captured.out
-    
+
     # Verify the simulated PR creation was reported
     assert "Would create PR:" in captured.out
-    
+
     # Verify no tag.yaml files were actually changed
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "old-tag"
-    
+
     # Verify git commands were not called (which would happen if PR was actually created)
     assert not mock_repo.git.push.called, "Git push should not be called in dry run"
-    assert not mock_github_repo.create_pull.called, "GitHub create_pull should not be called in dry run"
+    assert not mock_github_repo.create_pull.called, (
+        "GitHub create_pull should not be called in dry run"
+    )
 
 
 def test_custom_tag_with_override_stack(cli_test_env, capsys):
     """Test that custom tag formats can be used with override stack.
-    
+
     This test verifies that:
     1. Non-standard tag formats (like connection-dev-tag-1) can be used when OVERRIDE_STACK is defined
     2. Only the specified stack is updated
     3. PR is created with the correct information
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables with custom tag and override stack
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-tag-1"  # Non-standard tag format
-    os.environ["OVERRIDE_STACK"] = "dev-keboola-gcp-us-east1-e2e"  # Explicitly target a dev stack
-    
+    os.environ["OVERRIDE_STACK"] = (
+        "dev-keboola-gcp-us-east1-e2e"  # Explicitly target a dev stack
+    )
+
     # Track PRs
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base})")
-    
+
     # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "Override stack: dev-keboola-gcp-us-east1-e2e" in captured.out
-    
+
     # Verify tag.yaml was updated in the specified stack
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-east1-e2e" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-east1-e2e" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "dev-tag-1"
-    
+
     # Verify other stacks were NOT updated
-    prod_tag_yaml = read_tag_yaml(base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml")
+    prod_tag_yaml = read_tag_yaml(
+        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+    )
     assert prod_tag_yaml["image"]["tag"] == "old-tag"
-    
+
     # Verify PR was created
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
@@ -775,7 +921,7 @@ def test_custom_tag_with_override_stack(cli_test_env, capsys):
 
 def test_dev_tag_with_production_override_stack(cli_test_env, capsys):
     """Test that dev tags cannot be used with production stack override.
-    
+
     This test verifies that:
     1. When targeting a production stack with OVERRIDE_STACK
     2. Using a dev tag is rejected
@@ -783,40 +929,43 @@ def test_dev_tag_with_production_override_stack(cli_test_env, capsys):
     4. No PRs are created
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables with dev tag and production stack override
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-123-tag"  # Dev tag
     os.environ["OVERRIDE_STACK"] = "com-keboola-prod"  # Production stack
-    
+
     # Track PRs
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base})")
-    
+
     # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "Cannot apply non-production tag to production stack" in captured.out
-    
+
     # Verify tag.yaml was NOT updated in the production stack
-    prod_tag_yaml = read_tag_yaml(base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml")
+    prod_tag_yaml = read_tag_yaml(
+        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+    )
     assert prod_tag_yaml["image"]["tag"] == "old-tag"
-    
+
     # Verify no PR was created
     assert len(created_prs) == 0
 
 
 def test_happy_path_production_update(cli_test_env, capsys):
     """Test the most common happy path - production tag with automerge.
-    
+
     This test verifies the complete flow for the most common production scenario:
     1. Production tag is applied to all stacks
     2. Automerge is enabled (default)
@@ -825,33 +974,36 @@ def test_happy_path_production_update(cli_test_env, capsys):
     5. PR is created and auto-merged
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables for production update
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "production-2.0.0"
     os.environ["AUTOMERGE"] = "true"  # this is default, but being explicit
     # DRY_RUN is not set, which defaults to false
-    
+
     # Set up mock repo to track git operations
     mock_repo.git.reset_mock()
-    
+
     # Set up mock PR that simulates a successful PR creation and merge
     mock_pr = MagicMock()
     mock_pr.html_url = "https://github.com/mock-org/mock-repo/pull/999"
     mock_pr.mergeable = True  # PR is mergeable
     mock_github_repo.create_pull.return_value = mock_pr
-    
+
     # Track PR creation calls
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation with auto-merge functionality."""
-        created_prs.append({
-            "branch": branch_name, 
-            "title": pr_title, 
-            "base": base,
-            "automerge": config.automerge
-        })
-        
+        created_prs.append(
+            {
+                "branch": branch_name,
+                "title": pr_title,
+                "base": base,
+                "automerge": config.automerge,
+            }
+        )
+
         # Simulate the non-dry-run behavior that would occur in create_pr
         config.repo.git.push("origin", branch_name)
         pr = config.github_repo.create_pull(
@@ -860,49 +1012,55 @@ def test_happy_path_production_update(cli_test_env, capsys):
             head=branch_name,
             base=base,
         )
-        
+
         # Auto-merge if configured
         if config.automerge:
             pr.merge()
-            print(f"Created and auto-merged PR: {pr_title} (branch: {branch_name}, base: {base})")
+            print(
+                f"Created and auto-merged PR: {pr_title} (branch: {branch_name}, base: {base})"
+            )
         else:
             print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base})")
-            
+
         return pr
-    
+
     # Mock create_pr function
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "New image tag: production-2.0.0" in captured.out
     assert "Updating all stacks (production- tag)" in captured.out
-    
+
     # Verify tag.yaml was updated in both dev and prod stacks
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "production-2.0.0"
-    
-    prod_tag_yaml = read_tag_yaml(base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml")
+
+    prod_tag_yaml = read_tag_yaml(
+        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+    )
     assert prod_tag_yaml["image"]["tag"] == "production-2.0.0"
-    
+
     # Verify Git operations were performed
     assert mock_repo.git.checkout.called, "git checkout should be called"
     assert mock_repo.git.add.called, "git add should be called"
     assert mock_repo.git.commit.called, "git commit should be called"
     assert mock_repo.git.push.called, "git push should be called"
-    
+
     # Verify PR was created with correct parameters
     assert mock_github_repo.create_pull.called, "create_pull should be called"
     call_args = mock_github_repo.create_pull.call_args[1]
     assert "test-chart" in call_args["title"]
     assert call_args["base"] == "main"
-    
+
     # Verify PR auto-merge was attempted
     assert mock_pr.merge.called, "PR merge should be called for auto-merge"
-    
+
     # Verify our tracking shows PR was created with automerge enabled
     assert len(created_prs) == 1
     assert created_prs[0]["automerge"] is True
@@ -910,72 +1068,81 @@ def test_happy_path_production_update(cli_test_env, capsys):
 
 def test_semver_main_image_tag(cli_test_env, capsys):
     """Test that semver formats are accepted for the main IMAGE_TAG.
-    
+
     This test verifies that:
     1. IMAGE_TAG can be a semver with or without v prefix (0.1.2 or v0.1.2)
     2. Semver tags are treated like production tags and update all stacks
     3. PRs are created with the correct information
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
-    
+
     # Set environment variables with semver image tag (no v prefix)
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "1.2.3"  # Semver without v prefix
-    
+
     # Track PRs
     created_prs = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base})")
-    
+
     # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "New image tag: 1.2.3" in captured.out
-    
+
     # Verify tag.yaml was updated in both dev and prod stacks (like production tag)
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "1.2.3"
-    
-    prod_tag_yaml = read_tag_yaml(base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml")
+
+    prod_tag_yaml = read_tag_yaml(
+        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+    )
     assert prod_tag_yaml["image"]["tag"] == "1.2.3"
-    
+
     # Verify PR was created
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
-    
+
     # Test with v-prefixed semver
     os.environ.clear()
     os.environ["GH_TOKEN"] = "fake-token"
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "v2.3.4"  # Semver with v prefix
-    
+
     # Reset mocks and stacks
     created_prs.clear()
-    
+
     # Mock create_pr but use real config
-    with patch('helm_image_updater.tag_updater.create_pr', mock_create_pr):
+    with patch("helm_image_updater.tag_updater.create_pr", mock_create_pr):
         # Run CLI
         cli.main()
-    
+
     # Check console output
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "New image tag: v2.3.4" in captured.out
-    
+
     # Verify tag.yaml was updated in both dev and prod stacks (like production tag)
-    dev_tag_yaml = read_tag_yaml(base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml")
+    dev_tag_yaml = read_tag_yaml(
+        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
+    )
     assert dev_tag_yaml["image"]["tag"] == "v2.3.4"
-    
-    prod_tag_yaml = read_tag_yaml(base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml")
+
+    prod_tag_yaml = read_tag_yaml(
+        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+    )
     assert prod_tag_yaml["image"]["tag"] == "v2.3.4"
-    
+
     # Verify PR was created
     assert len(created_prs) == 1
-    assert "test-chart" in created_prs[0]["title"] 
+    assert "test-chart" in created_prs[0]["title"]

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -79,9 +79,10 @@ def test_setup_git_client_success(mock_repo, mock_github):
             * GitHub client is created with token
             * Correct repository is accessed
     """
-    with patch("helm_image_updater.git_operations.Repo") as mock_repo_class, patch(
-        "helm_image_updater.git_operations.Github"
-    ) as mock_github_class:
+    with (
+        patch("helm_image_updater.git_operations.Repo") as mock_repo_class,
+        patch("helm_image_updater.git_operations.Github") as mock_github_class,
+    ):
         mock_repo_class.return_value = mock_repo
         mock_github_class.return_value = mock_github
         mock_github.get_repo.return_value = Mock()

--- a/tests/test_tag_updater.py
+++ b/tests/test_tag_updater.py
@@ -129,7 +129,7 @@ def create_tag_yaml(path, tag):
             "expected_stacks": [
                 "dev-keboola-gcp-us-central1",
                 "com-keboola-prod",
-                "cloud-keboola-prod"
+                "cloud-keboola-prod",
             ],
             "expected_base": "main",
         },
@@ -142,7 +142,7 @@ def create_tag_yaml(path, tag):
             "expected_stacks": [
                 "dev-keboola-gcp-us-central1",
                 "com-keboola-prod",
-                "cloud-keboola-prod"
+                "cloud-keboola-prod",
             ],
             "expected_base": "main",
         },
@@ -235,7 +235,7 @@ def test_tag_update_strategy(
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
-        print(f"\nCreated PR:")
+        print("\nCreated PR:")
         print(f"  - Branch: {branch_name}")
         print(f"  - Title: {pr_title}")
         print(f"  - Base: {base}")
@@ -341,7 +341,7 @@ def test_missing_tag_yaml(test_stacks):
     result = update_tag_yaml(test_stacks["dev_stack"], "test-chart", "dev-1.2.3")
 
     print("\nVerifying result...")
-    print(f"  - Expected: None (file missing)")
+    print("  - Expected: None (file missing)")
     print(f"  - Actual: {result}")
     assert result is None, "Should return None for missing tag.yaml"
 
@@ -490,7 +490,7 @@ def test_canary_tag_with_extra_tags(
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base})
-        print(f"\nCreated PR:")
+        print("\nCreated PR:")
         print(f"  - Branch: {branch_name}")
         print(f"  - Title: {pr_title}")
         print(f"  - Base: {base}")
@@ -529,24 +529,20 @@ def test_update_stack_by_id(test_stacks, mock_repo, mock_github_repo, monkeypatc
     print("\n" + "=" * 80)
     print("Running test: Update stack by ID")
     print("=" * 80)
-    
-    from helm_image_updater.tag_updater import update_stack_by_id
-    
+
     # Mock the create_pr function to avoid actual PR creation
     pr_created = []
+
     def mock_create_pr(config, branch_name, pr_title, base="main"):
         print(f"Would create PR: {pr_title} (branch: {branch_name}, base: {base})")
-        pr_created.append({
-            "branch": branch_name,
-            "title": pr_title,
-            "base": base
-        })
-    
+        pr_created.append({"branch": branch_name, "title": pr_title, "base": base})
+
     # Apply the mocks
     monkeypatch.setattr("helm_image_updater.tag_updater.create_pr", mock_create_pr)
-   
+
     # Create test config
     from helm_image_updater.config import UpdateConfig
+
     config = UpdateConfig(
         repo=mock_repo,
         github_repo=mock_github_repo,
@@ -554,25 +550,29 @@ def test_update_stack_by_id(test_stacks, mock_repo, mock_github_repo, monkeypatc
         image_tag="dev-1.2.3",
         automerge=True,
     )
-    
+
     # Test updating a dev stack with a dev tag
     print("\nUpdating dev stack with dev tag:")
-    updated_stacks, failed_stacks = update_stack_by_id(config, "dev-keboola-gcp-us-central1")
+    updated_stacks, failed_stacks = update_stack_by_id(
+        config, "dev-keboola-gcp-us-central1"
+    )
     assert len(updated_stacks) == 1, "Should return one updated stack"
     assert len(failed_stacks) == 0, "Should not have any failed stacks"
     assert updated_stacks[0]["stack"] == "dev-keboola-gcp-us-central1"
     assert len(pr_created) == 1, "Should create a PR"
-    
+
     # Test updating a dev stack with a custom tag (not starting with dev- or production-)
     print("\nUpdating dev stack with custom tag:")
     config.image_tag = "custom-1.2.3"
     pr_created.clear()
-    updated_stacks, failed_stacks = update_stack_by_id(config, "dev-keboola-gcp-us-central1")
+    updated_stacks, failed_stacks = update_stack_by_id(
+        config, "dev-keboola-gcp-us-central1"
+    )
     assert len(updated_stacks) == 1, "Should return one updated stack"
     assert len(failed_stacks) == 0, "Should not have any failed stacks"
     assert updated_stacks[0]["stack"] == "dev-keboola-gcp-us-central1"
     assert len(pr_created) == 1, "Should create a PR"
-    
+
     # Test updating a production stack with a production tag
     print("\nUpdating production stack with production tag:")
     config.image_tag = "production-1.2.3"
@@ -582,21 +582,27 @@ def test_update_stack_by_id(test_stacks, mock_repo, mock_github_repo, monkeypatc
     assert len(failed_stacks) == 0, "Should not have any failed stacks"
     assert updated_stacks[0]["stack"] == "com-keboola-prod"
     assert len(pr_created) == 1, "Should create a PR"
-    
+
     # Test incompatible tag and stack (non-production tag with production stack)
     print("\nTesting incompatible tag and stack:")
     config.image_tag = "custom-1.2.3"
     pr_created.clear()
     updated_stacks, failed_stacks = update_stack_by_id(config, "com-keboola-prod")
-    assert len(updated_stacks) == 0, "Should not have any updated stacks for incompatible tag and stack"
-    assert len(failed_stacks) == 0, "Should not have any failed stacks for incompatible tag and stack"
+    assert len(updated_stacks) == 0, (
+        "Should not have any updated stacks for incompatible tag and stack"
+    )
+    assert len(failed_stacks) == 0, (
+        "Should not have any failed stacks for incompatible tag and stack"
+    )
     assert len(pr_created) == 0, "Should not create a PR"
-    
+
     # Test updating a E2E stack with a build tag
     print("\nUpdating E2E stack with build tag:")
     config.image_tag = "martin-dev-1.2.3"
     pr_created.clear()
-    updated_stacks, failed_stacks = update_stack_by_id(config, "dev-keboola-gcp-us-east1-e2e")
+    updated_stacks, failed_stacks = update_stack_by_id(
+        config, "dev-keboola-gcp-us-east1-e2e"
+    )
     assert len(updated_stacks) == 1, "Should return one updated stack"
     assert len(failed_stacks) == 0, "Should not have any failed stacks"
     assert updated_stacks[0]["stack"] == "dev-keboola-gcp-us-east1-e2e"


### PR DESCRIPTION
Small bug - if a canary tag is detected, the script should switch to the appropriate branch before checking for `tag.yaml` files. [Happened with metastore.](https://keboolaglobal.slack.com/archives/C055K9CRFDX/p1751351737270349?thread_ts=1750411503.835759&cid=C055K9CRFDX)

I also _ruffied_ it to clean the code up a small bit.

Test canary-only app:
- https://github.com/keboola/sre-playground/actions/runs/15994593176/job/45115599190
- https://github.com/keboola/sre-playground/pull/379

Test regular app:
- https://github.com/keboola/sre-playground/actions/runs/15994823532/job/45115739776
- https://github.com/keboola/sre-playground/pull/380