### PR TITLE
Exclude e2e stack from automatic deploy - Connection GitOps #1.e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Helm Image Updater is a Python tool that automates image tag updates across Helm charts in different Kubernetes stacks. It creates pull requests for updates and can optionally auto-merge them. The tool is designed to work with three types of environments: development, production, and canary deployments.
+
+## Development Commands
+
+### Installation and Setup
+```bash
+# Create virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+pip install -e .
+```
+
+### Testing
+```bash
+# Run all tests
+pytest tests/
+
+# Run tests with verbose output
+pytest -sv tests/
+
+# Run specific test file
+pytest -sv tests/test_tag_updater.py
+
+# Run with coverage
+pytest --cov=helm_image_updater tests/
+```
+
+### Building and Distribution
+```bash
+# Build package
+python setup.py sdist bdist_wheel
+
+# Test installation locally
+pip install -e .
+```
+
+### Running the Tool
+```bash
+# Basic usage (requires environment variables)
+helm-image-updater
+
+# With environment variables
+HELM_CHART=dummy-service IMAGE_TAG=dev-b10536c41180e420eaf083451a1ddee132f512c6 GH_TOKEN=xxx helm-image-updater
+
+# Dry run mode
+DRY_RUN=true HELM_CHART=dummy-service IMAGE_TAG=dev-b10536c41180e420eaf083451a1ddee132f512c6 GH_TOKEN=xxx helm-image-updater
+```
+
+## Architecture
+
+### Core Components
+
+- **cli.py**: Main entry point that orchestrates the entire update process
+- **tag_updater.py**: Core logic for updating tag.yaml files across different stacks
+- **pr_manager.py**: Handles GitHub pull request creation and management
+- **git_operations.py**: Git-related operations like branch creation and commits
+- **config.py**: Configuration settings and constants (stack definitions, GitHub repo)
+- **utils.py**: Utility functions for metadata handling and logging
+- **exceptions.py**: Custom exception classes
+
+### Tag Update Strategy
+
+The tool determines update strategy based on image tag prefix:
+
+1. **Development tags** (`dev-*`): Updates only development stacks defined in `DEV_STACKS`
+2. **Production tags** (`production-*` or semver): Updates all non-canary stacks
+3. **Canary tags** (`canary-orion-*`): Updates specific canary stacks with their own base branches
+
+### Stack Management
+
+- Stacks are organized as directories containing Helm chart configurations
+- Each stack has a `{helm-chart}/tag.yaml` file that gets updated
+- Stack types are defined in `config.py` as constants (`DEV_STACKS`, `CANARY_STACKS`)
+- Ignored folders and excluded stacks are also configured in `config.py`
+
+### Multi-Stage Deployment
+
+When `MULTI_STAGE=true`:
+1. Creates and auto-merges PR for dev stacks (if automerge is enabled)
+2. Creates separate PR for production stacks (without auto-merge)
+
+### GitHub Actions Integration
+
+The tool is designed to run as a GitHub Action via `action.yaml`. It:
+- Downloads the latest release package
+- Sets up Python 3.13 environment
+- Configures git with canary branch support
+- Runs the update process with environment variables
+
+## Key Environment Variables
+
+- `HELM_CHART`: Name of the Helm chart to update (required)
+- `IMAGE_TAG`: New image tag (must match specific prefixes)
+- `GH_TOKEN`: GitHub access token (required)
+- `AUTOMERGE`: Auto-merge PRs (default: "true")
+- `DRY_RUN`: Perform dry run (default: "false")
+- `MULTI_STAGE`: Enable multi-stage deployment (default: "false")
+- `OVERRIDE_STACK`: Target specific stack bypassing automatic selection
+- `EXTRA_TAG1`, `EXTRA_TAG2`: Additional tags in format "path.in.yaml:value"
+
+## Testing Strategy
+
+The test suite covers:
+- Development tag handling and single stack updates
+- Production tag handling with multiple stack updates
+- Canary tag handling with stack-specific updates
+- Multi-stage deployment scenarios
+- Git operations and PR creation
+- Configuration validation and error handling
+
+Tests use pytest with fixtures defined in `conftest.py` for common setup like mock repositories and GitHub clients.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Required:
 
 - `HELM_CHART`: Name of the Helm chart to update
 - `GH_TOKEN`: GitHub access token for authentication
-- `IMAGE_TAG`: New image tag to set (must start with 'dev-', 'production-', 'canary-orion-', or 'canary-ursa-')
+- `IMAGE_TAG`: New image tag to set (must start with 'dev-', 'production-', or 'canary-orion-')
 
 Optional:
 
@@ -188,7 +188,7 @@ Image tags must follow these formats:
 
 - Development: `dev-*` (e.g., `dev-b10536c41180e420eaf083451a1ddee132f512c6`)
 - Production: `production-*` (e.g., `production-b10536c41180e420eaf083451a1ddee132f512c6`)
-- Canary: `canary-*` (e.g., `canary-orion-b10536c41180e420eaf083451a1ddee132f512c6`, `canary-ursa-b10536c41180e420eaf083451a1ddee132f512c6`)
+- Canary: `canary-*` (e.g., `canary-orion-b10536c41180e420eaf083451a1ddee132f512c6`)
 
 ## Stack Types
 
@@ -213,7 +213,7 @@ Image tags must follow these formats:
 
 - Updates only the specific canary stack matching the tag prefix
 - Always auto-merges regardless of the `automerge` setting
-- Uses stack-specific base branches (e.g., `canary-orion`, `canary-ursa`)
+- Uses stack-specific base branches (e.g., `canary-orion`)
 - Supports extra tags for complex configurations
 
 ## Multi-Stage Deployment

--- a/action.yaml
+++ b/action.yaml
@@ -68,7 +68,7 @@ runs:
         git fetch --all --prune
         
         # Setup canary branches
-        for branch in canary-orion canary-ursa; do
+        for branch in canary-orion; do
           if git ls-remote --heads origin $branch | grep -q "$branch"; then
             git checkout -B $branch origin/$branch
           fi

--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -30,10 +30,6 @@ CANARY_STACKS = {
         "stack": "dev-keboola-canary-orion",
         "base_branch": "canary-orion",
     },
-    "canary-ursa": {
-        "stack": "dev-keboola-canary-ursa",
-        "base_branch": "canary-ursa"
-    },
 }
 IGNORED_FOLDERS = {".venv", "aws", ".git", ".github"}
 GITHUB_REPO = os.getenv("GITHUB_REPOSITORY", "keboola/kbc-stacks")

--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -24,7 +24,7 @@ from github.Repository import Repository
 
 # Constants
 DEV_STACKS = ["dev-keboola-gcp-us-central1"]
-EXCLUDED_STACKS = ["dev-keboola-gcp-us-east1-e2e"]
+EXCLUDED_STACKS = ["dev-keboola-gcp-us-east1-e2e", "dev-keboola-azure-east-us-2-e2e", "dev-keboola-aws-us-east-1-e2e"]
 CANARY_STACKS = {
     "canary-orion": {
         "stack": "dev-keboola-canary-orion",

--- a/tests/test_tag_updater.py
+++ b/tests/test_tag_updater.py
@@ -74,10 +74,6 @@ def test_stacks(tmp_path):
     (canary_orion / "test-chart").mkdir()
     create_tag_yaml(canary_orion / "test-chart" / "tag.yaml", "old-tag")
 
-    canary_ursa = tmp_path / "dev-keboola-canary-ursa"
-    canary_ursa.mkdir()
-    (canary_ursa / "test-chart").mkdir()
-    create_tag_yaml(canary_ursa / "test-chart" / "tag.yaml", "old-tag")
 
     return {
         "base_dir": tmp_path,
@@ -85,7 +81,6 @@ def test_stacks(tmp_path):
         "com_stack": com_stack,
         "cloud_stack": cloud_stack,
         "canary_orion": canary_orion,
-        "canary_ursa": canary_ursa,
     }
 
 
@@ -168,15 +163,6 @@ def create_tag_yaml(path, tag):
             "expected_stacks": ["dev-keboola-canary-orion"],
             "expected_base": "canary-orion",
         },
-        {
-            "name": "Canary Ursa tag should create a PR targeting the canary-ursa branch",
-            "image_tag": "canary-ursa-1.2.3",
-            "automerge": False,  # Should be ignored for canary (always auto-merges)
-            "multi_stage": False,
-            "expected_pr_count": 1,
-            "expected_stacks": ["dev-keboola-canary-ursa"],
-            "expected_base": "canary-ursa",
-        },
     ],
 )
 def test_tag_update_strategy(
@@ -212,7 +198,6 @@ def test_tag_update_strategy(
             "com-keboola-prod",
             "cloud-keboola-prod",
             "dev-keboola-canary-orion",
-            "dev-keboola-canary-ursa",
             ".git",
         ]
 


### PR DESCRIPTION
Part of: https://keboola.atlassian.net/browse/PAT-557

## Release Notes
- Exclude e2e stack from automatic deploy. E2E testing stack are updated from connection build pipeline.
- Remove support of deleted `dev-keboola-canary-ursa` stack

## Plans for customer communication
- No

## Impact analysis
- Low - changes in config and testing only, no changes in logic.

## Justification
GitOps migration

## Deployment
- Merge

## Rollback plan
- Revert of this PR.

## Post release support plan
None.
