### PR TITLE
Multi cloud support in multi-stage deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,7 @@ To see detailed test execution logs:
     │   └── test_tag_updater.py     # Tests for tag update logic
     ├── requirements.txt
     └── setup.py
+
+
+### e2e tests
+You can test a branch from this repo via running e2e tests in https://github.com/keboola/helm-image-updater-testing/actions/workflows/test-suite.yaml - just trigger the "Test suite" workflow and provide name of branch from this repo.

--- a/helm_image_updater/cloud_detection.py
+++ b/helm_image_updater/cloud_detection.py
@@ -1,19 +1,14 @@
 """
 Cloud Provider Detection Module
 
-This module provides functionality to detect and classify cloud providers for stacks
-based on their shared-values.yaml configuration and static development stack mapping.
-
-Classes:
-    StackCloudInfo: Data class containing stack cloud information
+This module provides functionality to detect cloud providers for stacks
+based on their shared-values.yaml configuration.
 
 Functions:
     get_stack_cloud_provider: Detect cloud provider for a single stack
-    classify_stacks_by_cloud: Group multiple stacks by cloud provider
 """
 
-from dataclasses import dataclass
-from typing import Dict, List, Optional, Protocol
+from typing import Dict, Optional, Protocol
 from .config import DEV_STACK_MAPPING, SUPPORTED_CLOUD_PROVIDERS
 
 
@@ -23,15 +18,6 @@ class IOLayerProtocol(Protocol):
     def read_shared_values_yaml(self, stack: str) -> Optional[Dict]:
         """Read and parse shared-values.yaml for a stack."""
         ...
-
-
-@dataclass
-class StackCloudInfo:
-    """Information about a stack's cloud provider and classification."""
-    
-    stack: str
-    cloud_provider: str
-    is_dev: bool
 
 
 def get_stack_cloud_provider(stack: str, io_layer: IOLayerProtocol) -> str:
@@ -45,14 +31,8 @@ def get_stack_cloud_provider(stack: str, io_layer: IOLayerProtocol) -> str:
         Cloud provider name (aws, azure, or gcp)
         
     Raises:
-        ValueError: If cloudProvider is missing, invalid, or inconsistent with dev mapping
+        ValueError: If cloudProvider is missing or invalid.
     """
-    # For dev stacks: check static mapping
-    dev_cloud = None
-    for cloud, dev_stack in DEV_STACK_MAPPING.items():
-        if stack == dev_stack:
-            dev_cloud = cloud
-            break
     
     # Read shared-values.yaml for all stacks (validation for dev, requirement for prod)
     shared_values = io_layer.read_shared_values_yaml(stack)
@@ -63,36 +43,6 @@ def get_stack_cloud_provider(stack: str, io_layer: IOLayerProtocol) -> str:
     if yaml_cloud not in SUPPORTED_CLOUD_PROVIDERS:
         raise ValueError(f"Unsupported cloudProvider '{yaml_cloud}' in {stack}/shared-values.yaml")
     
-    # For dev stacks: validate consistency between mapping and YAML
-    if dev_cloud and dev_cloud != yaml_cloud:
-        raise ValueError(f"Dev stack {stack} cloud mismatch: expected {dev_cloud}, found {yaml_cloud}")
-    
     return yaml_cloud
 
 
-def classify_stacks_by_cloud(stacks: List[str], io_layer: IOLayerProtocol) -> Dict[str, List[StackCloudInfo]]:
-    """Group stacks by cloud provider with dev/prod classification.
-    
-    Args:
-        stacks: List of stack names to classify
-        io_layer: IO layer instance for reading files
-        
-    Returns:
-        Dictionary mapping cloud providers to lists of StackCloudInfo objects
-        
-    Raises:
-        ValueError: If any stack has invalid cloud provider configuration
-    """
-    result = {"aws": [], "azure": [], "gcp": []}
-    
-    for stack in stacks:
-        cloud = get_stack_cloud_provider(stack, io_layer)
-        is_dev = stack in DEV_STACK_MAPPING.values()
-        
-        result[cloud].append(StackCloudInfo(
-            stack=stack,
-            cloud_provider=cloud,
-            is_dev=is_dev
-        ))
-    
-    return result

--- a/helm_image_updater/cloud_detection.py
+++ b/helm_image_updater/cloud_detection.py
@@ -9,7 +9,7 @@ Functions:
 """
 
 from typing import Dict, Optional, Protocol
-from .config import DEV_STACK_MAPPING, SUPPORTED_CLOUD_PROVIDERS
+from .config import SUPPORTED_CLOUD_PROVIDERS
 
 
 class IOLayerProtocol(Protocol):

--- a/helm_image_updater/cloud_detection.py
+++ b/helm_image_updater/cloud_detection.py
@@ -1,0 +1,98 @@
+"""
+Cloud Provider Detection Module
+
+This module provides functionality to detect and classify cloud providers for stacks
+based on their shared-values.yaml configuration and static development stack mapping.
+
+Classes:
+    StackCloudInfo: Data class containing stack cloud information
+
+Functions:
+    get_stack_cloud_provider: Detect cloud provider for a single stack
+    classify_stacks_by_cloud: Group multiple stacks by cloud provider
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Protocol
+from .config import DEV_STACK_MAPPING, SUPPORTED_CLOUD_PROVIDERS
+
+
+class IOLayerProtocol(Protocol):
+    """Protocol for IO layer operations needed by cloud detection."""
+    
+    def read_shared_values_yaml(self, stack: str) -> Optional[Dict]:
+        """Read and parse shared-values.yaml for a stack."""
+        ...
+
+
+@dataclass
+class StackCloudInfo:
+    """Information about a stack's cloud provider and classification."""
+    
+    stack: str
+    cloud_provider: str
+    is_dev: bool
+
+
+def get_stack_cloud_provider(stack: str, io_layer: IOLayerProtocol) -> str:
+    """Get cloud provider for any stack with strict validation.
+    
+    Args:
+        stack: Stack name to check
+        io_layer: IO layer instance for reading files
+        
+    Returns:
+        Cloud provider name (aws, azure, or gcp)
+        
+    Raises:
+        ValueError: If cloudProvider is missing, invalid, or inconsistent with dev mapping
+    """
+    # For dev stacks: check static mapping
+    dev_cloud = None
+    for cloud, dev_stack in DEV_STACK_MAPPING.items():
+        if stack == dev_stack:
+            dev_cloud = cloud
+            break
+    
+    # Read shared-values.yaml for all stacks (validation for dev, requirement for prod)
+    shared_values = io_layer.read_shared_values_yaml(stack)
+    if not shared_values or 'cloudProvider' not in shared_values:
+        raise ValueError(f"Missing cloudProvider in {stack}/shared-values.yaml")
+    
+    yaml_cloud = shared_values['cloudProvider']
+    if yaml_cloud not in SUPPORTED_CLOUD_PROVIDERS:
+        raise ValueError(f"Unsupported cloudProvider '{yaml_cloud}' in {stack}/shared-values.yaml")
+    
+    # For dev stacks: validate consistency between mapping and YAML
+    if dev_cloud and dev_cloud != yaml_cloud:
+        raise ValueError(f"Dev stack {stack} cloud mismatch: expected {dev_cloud}, found {yaml_cloud}")
+    
+    return yaml_cloud
+
+
+def classify_stacks_by_cloud(stacks: List[str], io_layer: IOLayerProtocol) -> Dict[str, List[StackCloudInfo]]:
+    """Group stacks by cloud provider with dev/prod classification.
+    
+    Args:
+        stacks: List of stack names to classify
+        io_layer: IO layer instance for reading files
+        
+    Returns:
+        Dictionary mapping cloud providers to lists of StackCloudInfo objects
+        
+    Raises:
+        ValueError: If any stack has invalid cloud provider configuration
+    """
+    result = {"aws": [], "azure": [], "gcp": []}
+    
+    for stack in stacks:
+        cloud = get_stack_cloud_provider(stack, io_layer)
+        is_dev = stack in DEV_STACK_MAPPING.values()
+        
+        result[cloud].append(StackCloudInfo(
+            stack=stack,
+            cloud_provider=cloud,
+            is_dev=is_dev
+        ))
+    
+    return result

--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -37,7 +37,7 @@ CANARY_STACKS = {
         "base_branch": "canary-orion",
     },
 }
-IGNORED_FOLDERS = {".venv", "aws", ".git", ".github"}
+IGNORED_FOLDERS = {".venv", "aws", ".git", ".github", "utils", "docs", "apps"}
 GITHUB_REPO = os.getenv("GITHUB_REPOSITORY", "keboola/kbc-stacks")
 GITHUB_BRANCH = "main"
 

--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -6,7 +6,8 @@ It defines constants and configuration classes that control
 the behavior of the image updating process.
 
 Constants:
-    DEV_STACKS: List of stack names considered as development stacks
+    DEV_STACK_MAPPING: Dictionary mapping cloud providers to development stack names
+    SUPPORTED_CLOUD_PROVIDERS: List of supported cloud provider names
     CANARY_STACKS: Dictionary of canary stack names and their corresponding tag prefixes
     IGNORED_FOLDERS: Set of folder names to ignore during processing
     GITHUB_REPO: Name of the GitHub repository (from environment)
@@ -23,7 +24,12 @@ from git import Repo
 from github.Repository import Repository
 
 # Constants
-DEV_STACKS = ["dev-keboola-gcp-us-central1"]
+DEV_STACK_MAPPING = {
+    "gcp": "dev-keboola-gcp-us-central1",
+    "azure": "kbc-testing-azure-east-us-2",
+    "aws": "dev-keboola-aws-eu-west-1"
+}
+SUPPORTED_CLOUD_PROVIDERS = ["aws", "azure", "gcp"]
 EXCLUDED_STACKS = ["dev-keboola-gcp-us-east1-e2e", "dev-keboola-azure-east-us-2-e2e", "dev-keboola-aws-us-east-1-e2e"]
 CANARY_STACKS = {
     "canary-orion": {

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -364,7 +364,12 @@ class IOLayer:
         Returns:
             PR URL if created, None if dry run
         """
+        # Always start from the base branch before creating new branch
+        print(f"🔀 Switching to base branch: {base_branch}")
+        self.checkout_branch(base_branch, create=False)
+        
         # Create and checkout branch
+        print(f"🌿 Creating new branch: {branch_name} from {base_branch}")
         self.checkout_branch(branch_name, create=True)
         
         # Add and commit files (files should already exist on disk)

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -119,6 +119,25 @@ class IOLayer:
         
         return True
     
+    def read_shared_values_yaml(self, stack: str) -> Optional[Dict[str, Any]]:
+        """Read and parse <stack>/shared-values.yaml.
+        
+        Args:
+            stack: Stack name to read shared values for
+            
+        Returns:
+            Dictionary with shared values contents or None if file doesn't exist
+        """
+        file_path = Path(stack) / "shared-values.yaml"
+        if not file_path.exists():
+            return None
+        
+        try:
+            with file_path.open() as f:
+                return yaml.safe_load(f)
+        except yaml.YAMLError:
+            return None
+    
     # -----------------------------------------------------------------------------
     # Git Operations
     # -----------------------------------------------------------------------------

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -259,6 +259,10 @@ class IOLayer:
         Returns:
             PR URL if created, None if dry run
         """
+        print(f"🚀 Creating PR: '{title}'")
+        print(f"   - Base: {base_branch}, Head: {branch_name}")
+        print(f"   - Auto-merge requested: {'YES' if auto_merge else 'NO'}")
+        
         if self.dry_run:
             merge_status = "and auto-merge" if auto_merge else "without auto-merge"
             print(f"[DRY RUN] Would create PR: '{title}' {merge_status}")
@@ -281,7 +285,10 @@ class IOLayer:
         
         # Auto-merge if requested
         if auto_merge:
+            print(f"🔄 Auto-merge requested - attempting to merge PR...")
             self._attempt_auto_merge(pr)
+        else:
+            print(f"⏸️ Auto-merge NOT requested - PR left for manual review")
         
         return pr.html_url
     

--- a/helm_image_updater/message_generation.py
+++ b/helm_image_updater/message_generation.py
@@ -59,7 +59,8 @@ def generate_pr_title_prefix(
     strategy: UpdateStrategy,
     is_multi_stage: bool,
     user_requested_automerge: bool,
-    target_stacks: List[str]
+    target_stacks: List[str],
+    cloud_provider: Optional[str] = None
 ) -> str:
     """
     Generate the PR title prefix based on the update context.
@@ -71,6 +72,7 @@ def generate_pr_title_prefix(
         is_multi_stage: Whether this is a multi-stage deployment
         user_requested_automerge: Original user automerge preference
         target_stacks: List of stacks being updated
+        cloud_provider: Cloud provider for multi-cloud deployment (aws, azure, gcp)
         
     Returns:
         PR title prefix string
@@ -87,16 +89,15 @@ def generate_pr_title_prefix(
     
     # Multi-stage mode has special prefixes
     if is_multi_stage:
+        # Build cloud suffix
+        cloud_suffix = f" {cloud_provider}" if cloud_provider else ""
+        
         if is_dev_update:
-            if user_requested_automerge:
-                return "[multi-stage] [test sync]"
-            else:
-                return "[multi-stage] [test sync manual]"
+            merge_suffix = "" if user_requested_automerge else " manual"
+            return f"[multi-stage] [test sync{cloud_suffix}{merge_suffix}]"
         else:
-            if user_requested_automerge:
-                return "[multi-stage] [prod sync]"
-            else:
-                return "[multi-stage] [prod sync manual]"
+            # Production PRs never auto-merge in multi-stage, so no "manual" needed for requested automerge
+            return f"[multi-stage] [prod sync{cloud_suffix}]"
     
     # Regular mode
     if is_dev_update:

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -8,7 +8,7 @@ from .models import UpdatePlan, FileChange, PRPlan, UpdateStrategy, TagChange
 from .environment import EnvironmentConfig
 from .io_layer import IOLayer
 from .tag_classification import detect_tag_type, TagType
-from .stack_classification import classify_stack, filter_stacks_by_type
+from .stack_classification import classify_stack, get_dev_stacks
 from .message_generation import (
     generate_commit_message,
     generate_pr_title,
@@ -132,7 +132,7 @@ def _select_target_stacks(
         return []
     
     if strategy == UpdateStrategy.DEV:
-        return filter_stacks_by_type(all_stacks, "dev")
+        return get_dev_stacks(all_stacks)
     
     if strategy == UpdateStrategy.PRODUCTION:
         # All non-canary stacks

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -67,8 +67,9 @@ def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
     stack_changes = _calculate_all_changes(plan, io_layer)
     
     if not stack_changes:
-        print("No changes needed.")
-        return plan
+        import sys
+        print(f"\nError: tag.yaml for chart {plan.helm_chart} does not exist in any stack or all tags are already up to date (noop change).")
+        sys.exit(1)
     
     # Create file changes
     for stack_change in stack_changes:

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -338,10 +338,11 @@ def _group_changes_for_prs(
             print(f"  - {stack} → {cloud} {category}")
         
         # Create PR plans for each non-empty (cloud, category) combination
+        # Production PRs first, then dev PRs to prevent race condition
         groups = []
-        print("\n🎯 Creating PR groups:")
-        for cloud in ["aws", "azure", "gcp"]:
-            for category in ["dev", "prod"]:
+        print("\n🎯 Creating PR groups (prod first, then dev):")
+        for category in ["prod", "dev"]:
+            for cloud in ["aws", "azure", "gcp"]:
                 changes = cloud_groups[cloud][category]
                 if changes:  # Only create PR if there are changes
                     stacks = [sc['stack'] for sc in changes]

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -67,9 +67,9 @@ def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
     stack_changes = _calculate_all_changes(plan, io_layer)
     
     if not stack_changes:
-        import sys
-        print(f"\nError: tag.yaml for chart {plan.helm_chart} does not exist in any stack or all tags are already up to date (noop change).")
-        sys.exit(1)
+        raise RuntimeError(
+            f"\nError: tag.yaml for chart {plan.helm_chart} does not exist in any stack or all tags are already up to date (noop change)."
+        )
     
     # Create file changes
     for stack_change in stack_changes:

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -1,5 +1,6 @@
 """Plan executor - executes a prepared plan."""
 
+import time
 from typing import Dict, List
 from .models import UpdatePlan, ExecutionResult
 from .io_layer import IOLayer
@@ -68,7 +69,13 @@ def _group_files_by_pr(plan: UpdatePlan) -> Dict[str, Dict[str, any]]:
 
 def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResult):
     """Create all pull requests."""
-    for pr_plan in plan.pr_plans:
+    print(f"📋 Creating {len(plan.pr_plans)} PRs with 2-second delays to prevent race conditions...")
+    
+    for i, pr_plan in enumerate(plan.pr_plans):
+        # Add delay between PRs to prevent GitHub API race conditions
+        if i > 0:
+            print(f"⏱️ Waiting 2 seconds before creating next PR to prevent race conditions...")
+            time.sleep(2)
         if plan.dry_run:
             print(f"[DRY RUN] Would create PR: {pr_plan.pr_title}")
             print(f"  Branch: {pr_plan.branch_name}")

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -82,6 +82,8 @@ def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResu
             io_layer.write_file_changes(relevant_file_changes)
             
             # Step 2: Create branch, commit, and PR (files already exist on disk)
+            print(f"🔍 DEBUG: About to call create_branch_commit_and_pr with auto_merge={pr_plan.auto_merge}")
+            print(f"🔍 DEBUG: PR title: {pr_plan.pr_title}")
             pr_url = io_layer.create_branch_commit_and_pr(
                 branch_name=pr_plan.branch_name,
                 files_to_commit=pr_plan.files_to_commit,  # List[str] - just paths

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -1,6 +1,5 @@
 """Plan executor - executes a prepared plan."""
 
-import time
 from typing import Dict, List
 from .models import UpdatePlan, ExecutionResult
 from .io_layer import IOLayer
@@ -69,13 +68,7 @@ def _group_files_by_pr(plan: UpdatePlan) -> Dict[str, Dict[str, any]]:
 
 def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResult):
     """Create all pull requests."""
-    print(f"📋 Creating {len(plan.pr_plans)} PRs with 2-second delays to prevent race conditions...")
-    
-    for i, pr_plan in enumerate(plan.pr_plans):
-        # Add delay between PRs to prevent GitHub API race conditions
-        if i > 0:
-            print(f"⏱️ Waiting 2 seconds before creating next PR to prevent race conditions...")
-            time.sleep(2)
+    for pr_plan in plan.pr_plans:
         if plan.dry_run:
             print(f"[DRY RUN] Would create PR: {pr_plan.pr_title}")
             print(f"  Branch: {pr_plan.branch_name}")

--- a/helm_image_updater/stack_classification.py
+++ b/helm_image_updater/stack_classification.py
@@ -55,31 +55,21 @@ def classify_stack(stack_name: str) -> StackClassification:
     )
 
 
-def filter_stacks_by_type(all_stacks: List[str], stack_type: str) -> List[str]:
+def get_dev_stacks(all_stacks: List[str]) -> List[str]:
     """
-    Filter stacks based on the desired type.
+    Get development stacks, excluding ignored/excluded ones.
     
     Args:
         all_stacks: List of all stack names
-        stack_type: Type of stacks to filter ('dev', 'production', 'canary', 'all')
         
     Returns:
-        Filtered list of stack names
+        Filtered list of development stack names
     """
     result = []
     for stack in all_stacks:
         classification = classify_stack(stack)
-        
-        if classification.is_ignored or classification.is_excluded:
-            continue
             
-        if stack_type == "dev" and classification.is_dev:
-            result.append(stack)
-        elif stack_type == "production" and classification.is_production:
-            result.append(stack)
-        elif stack_type == "canary" and classification.is_canary:
-            result.append(stack)
-        elif stack_type == "all" and (classification.is_dev or classification.is_production):
+        if classification.is_dev:
             result.append(stack)
     
     return result

--- a/helm_image_updater/stack_classification.py
+++ b/helm_image_updater/stack_classification.py
@@ -8,7 +8,7 @@ This module contains no side effects - only stack analysis logic.
 from dataclasses import dataclass
 from typing import List
 
-from .config import DEV_STACKS, CANARY_STACKS, IGNORED_FOLDERS, EXCLUDED_STACKS
+from .config import DEV_STACK_MAPPING, CANARY_STACKS, IGNORED_FOLDERS, EXCLUDED_STACKS
 
 
 @dataclass
@@ -37,13 +37,16 @@ def classify_stack(stack_name: str) -> StackClassification:
     # Get list of canary stack names
     canary_stack_names = [info["stack"] for info in CANARY_STACKS.values()]
     
+    # Get list of dev stack names from mapping
+    dev_stack_names = list(DEV_STACK_MAPPING.values())
+    
     return StackClassification(
         name=stack_name,
-        is_dev=stack_name in DEV_STACKS,
+        is_dev=stack_name in dev_stack_names,
         is_production=(
             stack_name not in IGNORED_FOLDERS
             and stack_name not in EXCLUDED_STACKS
-            and stack_name not in DEV_STACKS
+            and stack_name not in dev_stack_names
             and stack_name not in canary_stack_names
         ),
         is_canary=stack_name in canary_stack_names,

--- a/tests/test_cli_functional.py
+++ b/tests/test_cli_functional.py
@@ -123,7 +123,7 @@ def setup_test_stacks(base_path):
     """Create test stack structure with tag.yaml and shared-values.yaml files."""
     # Create dev stacks (3 clouds)
     create_stack_with_shared_values(base_path / "dev-keboola-gcp-us-central1", "gcp")
-    create_stack_with_shared_values(base_path / "kbc-testing-azure-east-us-2", "azure") 
+    create_stack_with_shared_values(base_path / "kbc-testing-azure-east-us-2", "azure")
     create_stack_with_shared_values(base_path / "dev-keboola-aws-eu-west-1", "aws")
 
     # Create production stacks (3 clouds) 

--- a/tests/test_cli_functional.py
+++ b/tests/test_cli_functional.py
@@ -120,30 +120,34 @@ def cli_test_env(mock_repo, mock_github_repo, tmp_path):
 
 
 def setup_test_stacks(base_path):
-    """Create test stack structure with tag.yaml files."""
-    # Create dev stack
-    dev_stack = base_path / "dev-keboola-gcp-us-central1"
-    dev_stack.mkdir()
-    (dev_stack / "test-chart").mkdir()
-    create_tag_yaml(dev_stack / "test-chart" / "tag.yaml", "old-tag")
+    """Create test stack structure with tag.yaml and shared-values.yaml files."""
+    # Create dev stacks (3 clouds)
+    create_stack_with_shared_values(base_path / "dev-keboola-gcp-us-central1", "gcp")
+    create_stack_with_shared_values(base_path / "kbc-testing-azure-east-us-2", "azure") 
+    create_stack_with_shared_values(base_path / "dev-keboola-aws-eu-west-1", "aws")
 
-    # Create production stack
-    prod_stack = base_path / "com-keboola-prod"
-    prod_stack.mkdir()
-    (prod_stack / "test-chart").mkdir()
-    create_tag_yaml(prod_stack / "test-chart" / "tag.yaml", "old-tag")
+    # Create production stacks (3 clouds) 
+    create_stack_with_shared_values(base_path / "com-keboola-gcp-prod", "gcp")
+    create_stack_with_shared_values(base_path / "com-keboola-azure-prod", "azure")
+    create_stack_with_shared_values(base_path / "com-keboola-aws-prod", "aws")
 
     # Create canary stack
-    canary_stack = base_path / "dev-keboola-canary-orion"
-    canary_stack.mkdir()
-    (canary_stack / "test-chart").mkdir()
-    create_tag_yaml(canary_stack / "test-chart" / "tag.yaml", "old-tag")
+    create_stack_with_shared_values(base_path / "dev-keboola-canary-orion", "gcp")
 
-    # Create e2e dev stack
-    e2e_dev_stack = base_path / "dev-keboola-gcp-us-east1-e2e"
-    e2e_dev_stack.mkdir()
-    (e2e_dev_stack / "test-chart").mkdir()
-    create_tag_yaml(e2e_dev_stack / "test-chart" / "tag.yaml", "old-tag")
+    # Create e2e dev stack (excluded)
+    create_stack_with_shared_values(base_path / "dev-keboola-gcp-us-east1-e2e", "gcp")
+
+
+def create_stack_with_shared_values(stack_path, cloud_provider):
+    """Helper to create stack with both tag.yaml and shared-values.yaml."""
+    stack_path.mkdir()
+    (stack_path / "test-chart").mkdir()
+    create_tag_yaml(stack_path / "test-chart" / "tag.yaml", "old-tag")
+    
+    # Create shared-values.yaml
+    shared_values = {"cloudProvider": cloud_provider}
+    with open(stack_path / "shared-values.yaml", "w") as f:
+        yaml.dump(shared_values, f)
 
 
 def create_tag_yaml(path, tag):
@@ -245,7 +249,7 @@ def test_dev_tag_update(cli_test_env, mock_git_operations, capsys):
 
     # Verify tag.yaml was NOT updated in prod stack
     prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
     )
     assert prod_tag_yaml["image"]["tag"] == "old-tag"
 
@@ -314,7 +318,7 @@ def test_production_tag_update(cli_test_env, mock_git_operations, capsys):
     assert dev_tag_yaml["image"]["tag"] == "production-1.2.3"
 
     prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
     )
     assert prod_tag_yaml["image"]["tag"] == "production-1.2.3"
 
@@ -394,7 +398,7 @@ def test_canary_tag_update(cli_test_env, capsys):
     assert dev_tag_yaml["image"]["tag"] == "old-tag"
 
     prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
     )
     assert prod_tag_yaml["image"]["tag"] == "old-tag"    
 
@@ -698,22 +702,20 @@ def test_nonexistent_stack_override(cli_test_env, capsys):
     assert len(created_prs) == 0
 
 
-def test_multi_stage_automerge_true(cli_test_env, capsys):
-    """Test multi-stage deployment with automerge=true.
+def test_multi_cloud_multi_stage_automerge_true(cli_test_env, capsys):
+    """Test multi-cloud multi-stage deployment with automerge=true.
 
     This test verifies that:
     1. With multi-stage=true and automerge=true
-    2. For production tags, it creates:
-       - Dev PR with [multi-stage] [test sync] that has automerge=true
-       - Prod PR with [multi-stage] [prod sync] that has automerge=false
-    3. The automerge setting for dev stacks is true (as requested)
-    4. The automerge setting for prod stacks is forced to false (regardless of input)
-    5. The prod PR title uses regular [prod sync] format when automerge=true is requested
-       (This allows workflow to find it even though the PR itself won't auto-merge)
+    2. For production tags, it creates 6 PRs:
+       - 3 Dev PRs with [multi-stage] [test sync {cloud}] that have automerge=true
+       - 3 Prod PRs with [multi-stage] [prod sync {cloud}] that have automerge=false
+    3. Each cloud (aws, azure, gcp) gets both dev and prod PRs
+    4. The automerge setting for dev stacks is true, prod stacks is false
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
 
-    # Set environment variables for multi-stage deployment
+    # Set environment variables for multi-cloud multi-stage deployment
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "production-1.2.3"
     os.environ["MULTI_STAGE"] = "true"
@@ -745,57 +747,67 @@ def test_multi_stage_automerge_true(cli_test_env, capsys):
     assert "Multi-stage deployment: True" in captured.out
     assert "Automerge: True" in captured.out
 
-    # Verify 2 PRs were created
-    assert len(created_prs) == 2, "Should create exactly 2 PRs"
+    # Verify 6 PRs were created (3 dev + 3 prod)
+    assert len(created_prs) == 6, f"Should create exactly 6 PRs, got {len(created_prs)}"
 
     # Debug: Print all PR titles for inspection
     print("DEBUG: All PR titles:")
     for pr in created_prs:
         print(f"  - '{pr['title']}' (automerge: {pr['automerge']})")
 
-    # Find dev and prod PRs
-    dev_pr = next(
-        (pr for pr in created_prs if "[multi-stage] [test sync]" in pr["title"]), None
-    )
-    prod_pr = next(
-        (pr for pr in created_prs if "[multi-stage] [prod sync]" in pr["title"]), None
-    )
+    # Find dev and prod PRs by cloud
+    dev_prs = {}
+    prod_prs = {}
+    
+    for pr in created_prs:
+        if "[multi-stage] [test sync" in pr["title"]:
+            # Extract cloud from title like "[multi-stage] [test sync aws]"
+            for cloud in ["aws", "azure", "gcp"]:
+                if f"[test sync {cloud}]" in pr["title"]:
+                    dev_prs[cloud] = pr
+                    break
+        elif "[multi-stage] [prod sync" in pr["title"]:
+            # Extract cloud from title like "[multi-stage] [prod sync aws]"
+            for cloud in ["aws", "azure", "gcp"]:
+                if f"[prod sync {cloud}]" in pr["title"]:
+                    prod_prs[cloud] = pr
+                    break
 
-    # Verify PRs exist with correct settings
-    assert dev_pr is not None, "Should create a dev PR with [multi-stage] [test sync]"
-    assert prod_pr is not None, "Should create a prod PR with [multi-stage] [prod sync]"
+    # Verify all cloud PRs exist
+    expected_clouds = ["aws", "azure", "gcp"]
+    for cloud in expected_clouds:
+        assert cloud in dev_prs, f"Should create dev PR for {cloud}"
+        assert cloud in prod_prs, f"Should create prod PR for {cloud}"
 
-    # Verify automerge settings
-    assert dev_pr["automerge"] is True, "Dev PR should have automerge=True"
-    assert prod_pr["automerge"] is False, (
-        "Prod PR should have automerge=False (forced by multi-stage)"
-    )
+    # Verify automerge settings for all clouds
+    for cloud in expected_clouds:
+        assert dev_prs[cloud]["automerge"] is True, f"Dev {cloud} PR should have automerge=True"
+        assert prod_prs[cloud]["automerge"] is False, f"Prod {cloud} PR should have automerge=False"
 
-    # Verify complete PR title prefixes
-    assert dev_pr["title"].startswith("[multi-stage] [test sync]"), (
-        "Dev PR should start with [multi-stage] [test sync]"
-    )
-    assert prod_pr["title"].startswith("[multi-stage] [prod sync]"), (
-        "Prod PR should start with [multi-stage] [prod sync]"
-    )
+    # Verify PR title patterns
+    for cloud in expected_clouds:
+        assert dev_prs[cloud]["title"].startswith(f"[multi-stage] [test sync {cloud}]"), (
+            f"Dev {cloud} PR should start with [multi-stage] [test sync {cloud}]"
+        )
+        assert prod_prs[cloud]["title"].startswith(f"[multi-stage] [prod sync {cloud}]"), (
+            f"Prod {cloud} PR should start with [multi-stage] [prod sync {cloud}]"
+        )
 
 
-def test_multi_stage_with_automerge_false(cli_test_env, capsys):
-    """Test multi-stage deployment with automerge=false.
+def test_multi_cloud_multi_stage_automerge_false(cli_test_env, capsys):
+    """Test multi-cloud multi-stage deployment with automerge=false.
 
     This test verifies that:
     1. With multi-stage=true and automerge=false
-    2. For production tags, it creates:
-       - Dev PR with [multi-stage] [test sync manual] that respects the automerge=false setting
-       - Prod PR with [multi-stage] [prod sync manual] that is NOT auto-merged
-    3. The automerge setting for dev stacks respects user's setting
-    4. The automerge setting for prod stacks is always forced to false
-    5. The PR titles use different formats that won't match automated workflows
-       (This prevents automated workflows from finding these PRs)
+    2. For production tags, it creates 6 PRs:
+       - 3 Dev PRs with [multi-stage] [test sync {cloud} manual] that respect automerge=false
+       - 3 Prod PRs with [multi-stage] [prod sync {cloud}] that are NOT auto-merged
+    3. Each cloud (aws, azure, gcp) gets both dev and prod PRs
+    4. All PRs have automerge=false due to user preference and multi-stage prod rule
     """
     base_dir, mock_repo, mock_github_repo = cli_test_env
 
-    # Set environment variables for multi-stage deployment with automerge=false
+    # Set environment variables for multi-cloud multi-stage deployment with automerge=false
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "production-1.2.3"
     os.environ["MULTI_STAGE"] = "true"
@@ -827,43 +839,52 @@ def test_multi_stage_with_automerge_false(cli_test_env, capsys):
     assert "Multi-stage deployment: True" in captured.out
     assert "Automerge: False" in captured.out
 
-    # Verify 2 PRs were created
-    assert len(created_prs) == 2, "Should create exactly 2 PRs"
+    # Verify 6 PRs were created (3 dev + 3 prod)
+    assert len(created_prs) == 6, f"Should create exactly 6 PRs, got {len(created_prs)}"
 
     # Debug: Print all PR titles for inspection
     print("DEBUG: All PR titles:")
     for pr in created_prs:
         print(f"  - '{pr['title']}' (automerge: {pr['automerge']})")
 
-    # Find dev and prod PRs
-    dev_pr = next(
-        (pr for pr in created_prs if "[multi-stage] [test sync manual]" in pr["title"]),
-        None,
-    )
-    prod_pr = next(
-        (pr for pr in created_prs if "[multi-stage] [prod sync manual]" in pr["title"]),
-        None,
-    )
+    # Find dev and prod PRs by cloud
+    dev_prs = {}
+    prod_prs = {}
+    
+    for pr in created_prs:
+        if "[multi-stage] [test sync" in pr["title"]:
+            # Extract cloud from title like "[multi-stage] [test sync aws manual]"
+            for cloud in ["aws", "azure", "gcp"]:
+                if f"[test sync {cloud} manual]" in pr["title"]:
+                    dev_prs[cloud] = pr
+                    break
+        elif "[multi-stage] [prod sync" in pr["title"]:
+            # Extract cloud from title like "[multi-stage] [prod sync aws]"
+            for cloud in ["aws", "azure", "gcp"]:
+                if f"[prod sync {cloud}]" in pr["title"]:
+                    prod_prs[cloud] = pr
+                    break
 
-    # Verify PRs exist with correct settings
-    assert dev_pr is not None, (
-        "Should create a dev PR with [multi-stage] [test sync manual]"
-    )
-    assert prod_pr is not None, (
-        "Should create a prod PR with [multi-stage] [prod sync manual]"
-    )
+    # Verify all cloud PRs exist
+    expected_clouds = ["aws", "azure", "gcp"]
+    for cloud in expected_clouds:
+        assert cloud in dev_prs, f"Should create dev PR for {cloud}"
+        assert cloud in prod_prs, f"Should create prod PR for {cloud}"
 
-    # Verify automerge settings
-    assert dev_pr["automerge"] is False, "Dev PR should have automerge=False"
-    assert prod_pr["automerge"] is False, "Prod PR should have automerge=False"
+    # Verify automerge settings for all clouds (all should be False)
+    for cloud in expected_clouds:
+        assert dev_prs[cloud]["automerge"] is False, f"Dev {cloud} PR should have automerge=False"
+        assert prod_prs[cloud]["automerge"] is False, f"Prod {cloud} PR should have automerge=False"
 
-    # Verify complete PR title prefixes
-    assert dev_pr["title"].startswith("[multi-stage] [test sync manual]"), (
-        "Dev PR should start with [multi-stage] [test sync manual]"
-    )
-    assert prod_pr["title"].startswith("[multi-stage] [prod sync manual]"), (
-        "Prod PR should start with [multi-stage] [prod sync manual]"
-    )
+    # Verify PR title patterns
+    for cloud in expected_clouds:
+        assert dev_prs[cloud]["title"].startswith(f"[multi-stage] [test sync {cloud} manual]"), (
+            f"Dev {cloud} PR should start with [multi-stage] [test sync {cloud} manual]"
+        )
+        assert prod_prs[cloud]["title"].startswith(f"[multi-stage] [prod sync {cloud}]"), (
+            f"Prod {cloud} PR should start with [multi-stage] [prod sync {cloud}]"
+        )
+
 
 
 def test_dry_run(cli_test_env, capsys):
@@ -950,7 +971,7 @@ def test_custom_tag_with_override_stack(cli_test_env, capsys):
 
     # Verify other stacks were NOT updated
     prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
     )
     assert prod_tag_yaml["image"]["tag"] == "old-tag"
 
@@ -974,7 +995,7 @@ def test_dev_tag_with_production_override_stack(cli_test_env, capsys):
     # Set environment variables with dev tag and production stack override
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-123-tag"  # Dev tag
-    os.environ["OVERRIDE_STACK"] = "com-keboola-prod"  # Production stack
+    os.environ["OVERRIDE_STACK"] = "com-keboola-gcp-prod"  # Production stack
 
     # Track PRs
     created_prs = []
@@ -998,7 +1019,7 @@ def test_dev_tag_with_production_override_stack(cli_test_env, capsys):
 
     # Verify tag.yaml was NOT updated in the production stack
     prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
     )
     assert prod_tag_yaml["image"]["tag"] == "old-tag"
 
@@ -1070,7 +1091,7 @@ def test_happy_path_production_update(cli_test_env, mock_git_operations, capsys)
 
     # Verify console output shows updates for both dev and prod stacks
     assert "Updated dev-keboola-gcp-us-central1/test-chart/tag.yaml: image.tag from old-tag to production-2.0.0" in captured.out
-    assert "Updated com-keboola-prod/test-chart/tag.yaml: image.tag from old-tag to production-2.0.0" in captured.out
+    assert "Updated com-keboola-gcp-prod/test-chart/tag.yaml: image.tag from old-tag to production-2.0.0" in captured.out
 
     # Verify Git operations were performed
     assert mock_git_operations['checkout_branch'].called, "git checkout should be called"
@@ -1124,7 +1145,7 @@ def test_semver_main_image_tag(cli_test_env, capsys):
     assert dev_tag_yaml["image"]["tag"] == "1.2.3"
 
     prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
     )
     assert prod_tag_yaml["image"]["tag"] == "1.2.3"
 
@@ -1158,7 +1179,7 @@ def test_semver_main_image_tag(cli_test_env, capsys):
     assert dev_tag_yaml["image"]["tag"] == "v2.3.4"
 
     prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-prod" / "test-chart" / "tag.yaml"
+        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
     )
     assert prod_tag_yaml["image"]["tag"] == "v2.3.4"
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,10 +5,12 @@ without any mocks or complex setup. Each test is fast and deterministic.
 """
 
 import pytest
+from unittest.mock import Mock
 from helm_image_updater.tag_classification import detect_tag_type, TagType
 from helm_image_updater.message_generation import generate_pr_title_prefix
 from helm_image_updater.models import UpdateStrategy
 from helm_image_updater.stack_classification import classify_stack, filter_stacks_by_type
+from helm_image_updater.cloud_detection import get_stack_cloud_provider, classify_stacks_by_cloud, StackCloudInfo
 
 
 class TestTagTypeDetection:
@@ -47,9 +49,23 @@ class TestTagTypeDetection:
 class TestStackClassification:
     """Test stack classification logic."""
     
-    def test_dev_stack(self):
-        """Test classification of dev stacks."""
+    def test_dev_stack_gcp(self):
+        """Test classification of GCP dev stack."""
         result = classify_stack("dev-keboola-gcp-us-central1")
+        assert result.is_dev
+        assert not result.is_production
+        assert not result.is_canary
+        
+    def test_dev_stack_azure(self):
+        """Test classification of Azure dev stack."""
+        result = classify_stack("kbc-testing-azure-east-us-2")
+        assert result.is_dev
+        assert not result.is_production
+        assert not result.is_canary
+        
+    def test_dev_stack_aws(self):
+        """Test classification of AWS dev stack."""
+        result = classify_stack("dev-keboola-aws-eu-west-1")
         assert result.is_dev
         assert not result.is_production
         assert not result.is_canary
@@ -82,14 +98,21 @@ class TestStackFiltering:
     def test_filter_dev_stacks(self):
         """Test filtering for dev stacks."""
         all_stacks = [
-            "dev-keboola-gcp-us-central1",
+            "dev-keboola-gcp-us-central1",  # GCP dev
+            "kbc-testing-azure-east-us-2",  # Azure dev  
+            "dev-keboola-aws-eu-west-1",    # AWS dev
             "com-keboola-prod",
             "dev-keboola-canary-orion",
             "dev-keboola-gcp-us-east1-e2e",  # excluded
         ]
         
         result = filter_stacks_by_type(all_stacks, "dev")
-        assert result == ["dev-keboola-gcp-us-central1"]
+        expected = [
+            "dev-keboola-gcp-us-central1", 
+            "kbc-testing-azure-east-us-2", 
+            "dev-keboola-aws-eu-west-1"
+        ]
+        assert sorted(result) == sorted(expected)
         
     def test_filter_production_stacks(self):
         """Test filtering for production stacks."""
@@ -147,7 +170,142 @@ class TestPRTitleGeneration:
             target_stacks=["dev-keboola-gcp-us-central1"]
         )
         assert prefix == "[multi-stage] [test sync manual]"
+        
+    def test_multi_cloud_dev_pr_title_with_cloud_provider(self):
+        """Test multi-cloud dev PR title generation with cloud provider."""
+        # With automerge and cloud provider
+        prefix = generate_pr_title_prefix(
+            strategy=UpdateStrategy.DEV,
+            is_multi_stage=True,
+            user_requested_automerge=True,
+            target_stacks=["dev-keboola-gcp-us-central1"],
+            cloud_provider="gcp"
+        )
+        assert prefix == "[multi-stage] [test sync gcp]"
+        
+        # Without automerge and cloud provider
+        prefix = generate_pr_title_prefix(
+            strategy=UpdateStrategy.DEV,
+            is_multi_stage=True,
+            user_requested_automerge=False,
+            target_stacks=["kbc-testing-azure-east-us-2"],
+            cloud_provider="azure"
+        )
+        assert prefix == "[multi-stage] [test sync azure manual]"
+        
+    def test_multi_cloud_prod_pr_title_with_cloud_provider(self):
+        """Test multi-cloud production PR title generation with cloud provider."""
+        prefix = generate_pr_title_prefix(
+            strategy=UpdateStrategy.PRODUCTION,
+            is_multi_stage=True,
+            user_requested_automerge=True,
+            target_stacks=["com-keboola-aws-prod"],
+            cloud_provider="aws"
+        )
+        assert prefix == "[multi-stage] [prod sync aws]"
 
 
+class TestCloudDetection:
+    """Test cloud provider detection logic."""
+    
+    def test_get_stack_cloud_provider_dev_stack(self):
+        """Test cloud provider detection for dev stacks."""
+        # Mock IO layer
+        mock_io_layer = Mock()
+        mock_io_layer.read_shared_values_yaml.return_value = {"cloudProvider": "gcp"}
+        
+        result = get_stack_cloud_provider("dev-keboola-gcp-us-central1", mock_io_layer)
+        assert result == "gcp"
+        
+        mock_io_layer.read_shared_values_yaml.assert_called_once_with("dev-keboola-gcp-us-central1")
+        
+    def test_get_stack_cloud_provider_prod_stack(self):
+        """Test cloud provider detection for production stacks."""
+        # Mock IO layer  
+        mock_io_layer = Mock()
+        mock_io_layer.read_shared_values_yaml.return_value = {"cloudProvider": "azure"}
+        
+        result = get_stack_cloud_provider("com-keboola-azure-prod", mock_io_layer)
+        assert result == "azure"
+        
+    def test_get_stack_cloud_provider_missing_yaml(self):
+        """Test error handling for missing shared-values.yaml."""
+        mock_io_layer = Mock()
+        mock_io_layer.read_shared_values_yaml.return_value = None
+        
+        with pytest.raises(ValueError, match="Missing cloudProvider in test-stack/shared-values.yaml"):
+            get_stack_cloud_provider("test-stack", mock_io_layer)
+            
+    def test_get_stack_cloud_provider_missing_field(self):
+        """Test error handling for missing cloudProvider field."""
+        mock_io_layer = Mock()
+        mock_io_layer.read_shared_values_yaml.return_value = {"someOtherField": "value"}
+        
+        with pytest.raises(ValueError, match="Missing cloudProvider in test-stack/shared-values.yaml"):
+            get_stack_cloud_provider("test-stack", mock_io_layer)
+            
+    def test_get_stack_cloud_provider_invalid_provider(self):
+        """Test error handling for invalid cloud provider."""
+        mock_io_layer = Mock()
+        mock_io_layer.read_shared_values_yaml.return_value = {"cloudProvider": "invalid"}
+        
+        with pytest.raises(ValueError, match="Unsupported cloudProvider 'invalid' in test-stack/shared-values.yaml"):
+            get_stack_cloud_provider("test-stack", mock_io_layer)
+            
+    def test_get_stack_cloud_provider_dev_mismatch(self):
+        """Test error handling for dev stack cloud provider mismatch."""
+        mock_io_layer = Mock()
+        mock_io_layer.read_shared_values_yaml.return_value = {"cloudProvider": "azure"}
+        
+        with pytest.raises(ValueError, match="Dev stack dev-keboola-gcp-us-central1 cloud mismatch: expected gcp, found azure"):
+            get_stack_cloud_provider("dev-keboola-gcp-us-central1", mock_io_layer)
+            
+    def test_classify_stacks_by_cloud(self):
+        """Test stack classification by cloud provider."""
+        mock_io_layer = Mock()
+        
+        def mock_shared_values(stack):
+            cloud_mapping = {
+                "dev-keboola-gcp-us-central1": {"cloudProvider": "gcp"},
+                "kbc-testing-azure-east-us-2": {"cloudProvider": "azure"},
+                "com-keboola-aws-prod": {"cloudProvider": "aws"},
+            }
+            return cloud_mapping.get(stack)
+            
+        mock_io_layer.read_shared_values_yaml.side_effect = mock_shared_values
+        
+        stacks = [
+            "dev-keboola-gcp-us-central1",
+            "kbc-testing-azure-east-us-2", 
+            "com-keboola-aws-prod"
+        ]
+        
+        result = classify_stacks_by_cloud(stacks, mock_io_layer)
+        
+        # Check structure
+        assert "aws" in result
+        assert "azure" in result
+        assert "gcp" in result
+        
+        # Check GCP classification
+        assert len(result["gcp"]) == 1
+        gcp_stack = result["gcp"][0]
+        assert gcp_stack.stack == "dev-keboola-gcp-us-central1"
+        assert gcp_stack.cloud_provider == "gcp"
+        assert gcp_stack.is_dev == True
+        
+        # Check Azure classification
+        assert len(result["azure"]) == 1
+        azure_stack = result["azure"][0]
+        assert azure_stack.stack == "kbc-testing-azure-east-us-2"
+        assert azure_stack.cloud_provider == "azure"
+        assert azure_stack.is_dev == True
+        
+        # Check AWS classification
+        assert len(result["aws"]) == 1
+        aws_stack = result["aws"][0]
+        assert aws_stack.stack == "com-keboola-aws-prod"
+        assert aws_stack.cloud_provider == "aws"
+        assert aws_stack.is_dev == False
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -99,7 +99,7 @@ class TestStackFiltering:
         """Test getting dev stacks."""
         all_stacks = [
             "dev-keboola-gcp-us-central1",  # GCP dev
-            "kbc-testing-azure-east-us-2",  # Azure dev  
+            "kbc-testing-azure-east-us-2",  # Azure dev
             "dev-keboola-aws-eu-west-1",    # AWS dev
             "com-keboola-prod",             # production
             "dev-keboola-canary-orion",     # canary

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 from helm_image_updater.tag_classification import detect_tag_type, TagType
 from helm_image_updater.message_generation import generate_pr_title_prefix
 from helm_image_updater.models import UpdateStrategy
-from helm_image_updater.stack_classification import classify_stack, filter_stacks_by_type
+from helm_image_updater.stack_classification import classify_stack, get_dev_stacks
 from helm_image_updater.cloud_detection import get_stack_cloud_provider
 
 
@@ -95,37 +95,24 @@ class TestStackClassification:
 class TestStackFiltering:
     """Test stack filtering logic."""
     
-    def test_filter_dev_stacks(self):
-        """Test filtering for dev stacks."""
+    def test_get_dev_stacks(self):
+        """Test getting dev stacks."""
         all_stacks = [
             "dev-keboola-gcp-us-central1",  # GCP dev
             "kbc-testing-azure-east-us-2",  # Azure dev  
             "dev-keboola-aws-eu-west-1",    # AWS dev
-            "com-keboola-prod",
-            "dev-keboola-canary-orion",
-            "dev-keboola-gcp-us-east1-e2e",  # excluded
+            "com-keboola-prod",             # production
+            "dev-keboola-canary-orion",     # canary
+            "dev-keboola-gcp-us-east1-e2e", # excluded
         ]
         
-        result = filter_stacks_by_type(all_stacks, "dev")
+        result = get_dev_stacks(all_stacks)
         expected = [
             "dev-keboola-gcp-us-central1", 
             "kbc-testing-azure-east-us-2", 
             "dev-keboola-aws-eu-west-1"
         ]
         assert sorted(result) == sorted(expected)
-        
-    def test_filter_production_stacks(self):
-        """Test filtering for production stacks."""
-        all_stacks = [
-            "dev-keboola-gcp-us-central1",
-            "com-keboola-prod",
-            "cloud-keboola-prod",
-        ]
-        
-        result = filter_stacks_by_type(all_stacks, "production")
-        assert "com-keboola-prod" in result
-        assert "cloud-keboola-prod" in result
-        assert "dev-keboola-gcp-us-central1" not in result
 
 
 class TestPRTitleGeneration:

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -9,32 +9,50 @@ This file contains a few remaining integration tests for backward compatibility.
 
 import os
 import pytest
+import yaml
 from helm_image_updater.io_layer import IOLayer
 from helm_image_updater.environment import EnvironmentConfig
-from helm_image_updater.plan_builder import prepare_plan
+from helm_image_updater.plan_builder import prepare_plan, _group_changes_for_prs
+from helm_image_updater.models import UpdatePlan, UpdateStrategy
 from unittest.mock import Mock
 
 
 @pytest.fixture
 def test_stacks(tmp_path):
-    """Creates test stack structure with tag.yaml files."""
-    # Create dev stack
-    dev_stack = tmp_path / "dev-keboola-gcp-us-central1"
-    dev_stack.mkdir()
-    (dev_stack / "test-chart").mkdir()
-    create_tag_yaml(dev_stack / "test-chart" / "tag.yaml", "old-tag")
+    """Creates test stack structure with tag.yaml and shared-values.yaml files."""
+    # Create dev stacks (3 clouds)
+    dev_gcp = create_stack_with_shared_values(tmp_path / "dev-keboola-gcp-us-central1", "gcp")
+    dev_azure = create_stack_with_shared_values(tmp_path / "kbc-testing-azure-east-us-2", "azure") 
+    dev_aws = create_stack_with_shared_values(tmp_path / "dev-keboola-aws-eu-west-1", "aws")
 
-    # Create production stacks
-    com_stack = tmp_path / "com-keboola-prod"
-    com_stack.mkdir()
-    (com_stack / "test-chart").mkdir()
-    create_tag_yaml(com_stack / "test-chart" / "tag.yaml", "old-tag")
+    # Create production stacks (3 clouds)
+    prod_gcp = create_stack_with_shared_values(tmp_path / "com-keboola-gcp-prod", "gcp")
+    prod_azure = create_stack_with_shared_values(tmp_path / "com-keboola-azure-prod", "azure")
+    prod_aws = create_stack_with_shared_values(tmp_path / "com-keboola-aws-prod", "aws")
 
     return {
         "base_dir": tmp_path,
-        "dev_stack": dev_stack,
-        "com_stack": com_stack,
+        "dev_gcp": dev_gcp,
+        "dev_azure": dev_azure,
+        "dev_aws": dev_aws,
+        "prod_gcp": prod_gcp,
+        "prod_azure": prod_azure,
+        "prod_aws": prod_aws,
     }
+
+
+def create_stack_with_shared_values(stack_path, cloud_provider):
+    """Helper to create stack with both tag.yaml and shared-values.yaml."""
+    stack_path.mkdir()
+    (stack_path / "test-chart").mkdir()
+    create_tag_yaml(stack_path / "test-chart" / "tag.yaml", "old-tag")
+    
+    # Create shared-values.yaml
+    shared_values = {"cloudProvider": cloud_provider}
+    with open(stack_path / "shared-values.yaml", "w") as f:
+        yaml.dump(shared_values, f)
+        
+    return stack_path
 
 
 def create_tag_yaml(path, tag):
@@ -75,7 +93,7 @@ def test_plan_with_dry_run(test_stacks):
     assert plan is not None
     
     # Verify the tag.yaml file exists and has expected content
-    tag_file = test_stacks["dev_stack"] / "test-chart" / "tag.yaml"
+    tag_file = test_stacks["dev_gcp"] / "test-chart" / "tag.yaml"
     assert tag_file.exists()
     
     with open(tag_file) as f:
@@ -86,10 +104,9 @@ def test_plan_with_dry_run(test_stacks):
 def test_tag_yaml_file_operations(test_stacks):
     """Test basic tag.yaml file operations that are now handled by plan_builder module."""
     from helm_image_updater.plan_builder import calculate_tag_changes
-    import yaml
     
     # Read current data
-    tag_file = test_stacks["dev_stack"] / "test-chart" / "tag.yaml"
+    tag_file = test_stacks["dev_gcp"] / "test-chart" / "tag.yaml"
     with open(tag_file) as f:
         current_data = yaml.safe_load(f)
     
@@ -109,10 +126,9 @@ def test_tag_yaml_file_operations(test_stacks):
 def test_extra_tags_calculation(test_stacks):
     """Test extra tags calculation."""
     from helm_image_updater.plan_builder import calculate_tag_changes
-    import yaml
     
     # Read current data and add some nested structure
-    tag_file = test_stacks["dev_stack"] / "test-chart" / "tag.yaml"
+    tag_file = test_stacks["dev_gcp"] / "test-chart" / "tag.yaml"
     with open(tag_file, "w") as f:
         yaml.dump({
             "image": {"tag": "old-tag"},
@@ -140,3 +156,158 @@ def test_extra_tags_calculation(test_stacks):
     assert main_change.new_value == "dev-1.2.3"
     assert extra_change.old_value == "old-agent-tag"
     assert extra_change.new_value == "dev-2.0.0"
+
+
+# Multi-cloud grouping tests
+def test_multi_cloud_multi_stage_grouping_production_tag(test_stacks):
+    """Test multi-cloud multi-stage grouping logic for production tags."""
+    from helm_image_updater.plan_builder import _group_changes_for_prs
+    
+    os.chdir(test_stacks["base_dir"])
+    
+    # Create mock I/O layer that can read shared-values.yaml
+    mock_io_layer = Mock()
+    def mock_shared_values(stack):
+        cloud_mapping = {
+            "dev-keboola-gcp-us-central1": {"cloudProvider": "gcp"},
+            "kbc-testing-azure-east-us-2": {"cloudProvider": "azure"},
+            "dev-keboola-aws-eu-west-1": {"cloudProvider": "aws"},
+            "com-keboola-gcp-prod": {"cloudProvider": "gcp"},
+            "com-keboola-azure-prod": {"cloudProvider": "azure"},
+            "com-keboola-aws-prod": {"cloudProvider": "aws"},
+        }
+        return cloud_mapping.get(stack)
+    mock_io_layer.read_shared_values_yaml.side_effect = mock_shared_values
+
+    # Create mock environment config
+    mock_config = Mock()
+    mock_config.automerge = True
+    
+    # Create mock plan
+    mock_plan = Mock()
+    mock_plan.multi_stage = True
+    mock_plan.strategy = UpdateStrategy.PRODUCTION
+    
+    # Create mock stack changes for all 6 stacks
+    stack_changes = []
+    all_stacks = [
+        "dev-keboola-gcp-us-central1", "kbc-testing-azure-east-us-2", "dev-keboola-aws-eu-west-1",
+        "com-keboola-gcp-prod", "com-keboola-azure-prod", "com-keboola-aws-prod"
+    ]
+    
+    for stack in all_stacks:
+        stack_changes.append({
+            'stack': stack,
+            'file_change': Mock(),
+            'changes': []
+        })
+    
+    # Test the grouping
+    groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
+    
+    # Verify 6 groups were created (3 dev + 3 prod)
+    assert len(groups) == 6, f"Expected 6 groups, got {len(groups)}"
+    
+    # Verify each group has correct properties
+    dev_groups = [g for g in groups if g['pr_type'] == 'multi_stage_dev']
+    prod_groups = [g for g in groups if g['pr_type'] == 'multi_stage_prod']
+    
+    assert len(dev_groups) == 3, f"Expected 3 dev groups, got {len(dev_groups)}"
+    assert len(prod_groups) == 3, f"Expected 3 prod groups, got {len(prod_groups)}"
+    
+    # Verify cloud providers are correctly assigned
+    dev_clouds = {g['cloud_provider'] for g in dev_groups}
+    prod_clouds = {g['cloud_provider'] for g in prod_groups}
+    
+    expected_clouds = {"aws", "azure", "gcp"}
+    assert dev_clouds == expected_clouds, f"Dev clouds {dev_clouds} != expected {expected_clouds}"
+    assert prod_clouds == expected_clouds, f"Prod clouds {prod_clouds} != expected {expected_clouds}"
+    
+    # Verify each group has exactly one stack (one per cloud)
+    for group in groups:
+        assert len(group['stacks']) == 1, f"Each group should have exactly 1 stack, got {len(group['stacks'])}"
+        assert len(group['changes']) == 1, f"Each group should have exactly 1 change, got {len(group['changes'])}"
+        assert group['base_branch'] == 'main', f"All groups should target main branch"
+
+
+def test_multi_cloud_grouping_non_multi_stage(test_stacks):
+    """Test that non-multi-stage deployments still work correctly."""
+    from helm_image_updater.plan_builder import _group_changes_for_prs
+    
+    os.chdir(test_stacks["base_dir"])
+    
+    # Create mock I/O layer
+    mock_io_layer = Mock()
+    
+    # Create mock environment config
+    mock_config = Mock()
+    mock_config.automerge = True
+    
+    # Create mock plan (non-multi-stage)
+    mock_plan = Mock()
+    mock_plan.multi_stage = False  # Non-multi-stage
+    mock_plan.strategy = UpdateStrategy.PRODUCTION
+    
+    # Create mock stack changes for all 6 stacks
+    stack_changes = []
+    all_stacks = [
+        "dev-keboola-gcp-us-central1", "kbc-testing-azure-east-us-2", "dev-keboola-aws-eu-west-1",
+        "com-keboola-gcp-prod", "com-keboola-azure-prod", "com-keboola-aws-prod"
+    ]
+    
+    for stack in all_stacks:
+        stack_changes.append({
+            'stack': stack,
+            'file_change': Mock(),
+            'changes': []
+        })
+    
+    # Test the grouping
+    groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
+    
+    # Verify only 1 group was created (normal behavior for non-multi-stage)
+    assert len(groups) == 1, f"Non-multi-stage should create 1 group, got {len(groups)}"
+    
+    # Verify the group contains all stacks
+    assert len(groups[0]['stacks']) == 6, f"Group should contain all 6 stacks"
+    assert groups[0]['pr_type'] == 'standard', f"PR type should be 'standard'"
+
+
+def test_multi_cloud_grouping_dev_strategy(test_stacks):
+    """Test multi-cloud grouping with dev strategy (should not use multi-stage logic)."""
+    from helm_image_updater.plan_builder import _group_changes_for_prs
+    
+    os.chdir(test_stacks["base_dir"])
+    
+    # Create mock I/O layer
+    mock_io_layer = Mock()
+    
+    # Create mock environment config
+    mock_config = Mock()
+    mock_config.automerge = True
+    
+    # Create mock plan (dev strategy, even with multi_stage=True)
+    mock_plan = Mock()
+    mock_plan.multi_stage = True
+    mock_plan.strategy = UpdateStrategy.DEV  # Dev strategy
+    
+    # Create mock stack changes for dev stacks only
+    stack_changes = []
+    dev_stacks = ["dev-keboola-gcp-us-central1", "kbc-testing-azure-east-us-2", "dev-keboola-aws-eu-west-1"]
+    
+    for stack in dev_stacks:
+        stack_changes.append({
+            'stack': stack,
+            'file_change': Mock(),
+            'changes': []
+        })
+    
+    # Test the grouping
+    groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
+    
+    # Verify only 1 group was created (dev strategy doesn't use multi-cloud logic)
+    assert len(groups) == 1, f"Dev strategy should create 1 group regardless of multi-stage, got {len(groups)}"
+    
+    # Verify the group contains all dev stacks
+    assert len(groups[0]['stacks']) == 3, f"Group should contain all 3 dev stacks"
+    assert groups[0]['pr_type'] == 'standard', f"PR type should be 'standard'"

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -22,7 +22,7 @@ def test_stacks(tmp_path):
     """Creates test stack structure with tag.yaml and shared-values.yaml files."""
     # Create dev stacks (3 clouds)
     dev_gcp = create_stack_with_shared_values(tmp_path / "dev-keboola-gcp-us-central1", "gcp")
-    dev_azure = create_stack_with_shared_values(tmp_path / "kbc-testing-azure-east-us-2", "azure") 
+    dev_azure = create_stack_with_shared_values(tmp_path / "kbc-testing-azure-east-us-2", "azure")
     dev_aws = create_stack_with_shared_values(tmp_path / "dev-keboola-aws-eu-west-1", "aws")
 
     # Create production stacks (3 clouds)


### PR DESCRIPTION
## Release Notes 
https://keboola.atlassian.net/browse/PAT-738

This will will add multi-cloud support to in multi-stage deployment.
This means that if a service has multi-stage deploy, then it will:
- create one PR pre dev stack (aws, gcp, azure) and merge them
- create one PR per prod stacks and cloud (one aws prod stacks PR, one azure prod stacks PR, one gcp prod stacks PR)

Example of PR titles created:
```
  Dev PRs (auto-merge enabled):
  - [multi-stage] [test sync aws] job-queue-public-api@production-1234567890123456789 in dev-keboola-aws-eu-west-1
  - [multi-stage] [test sync azure] job-queue-public-api@production-1234567890123456789 in dev-keboola-azure-east-us-2
  - [multi-stage] [test sync gcp] job-queue-public-api@production-1234567890123456789 in dev-keboola-gcp-us-central1

  Prod PRs (manual merge only):
  - [multi-stage] [prod sync aws] job-queue-public-api@production-1234567890123456789
  - [multi-stage] [prod sync azure] job-queue-public-api@production-1234567890123456789
  - [multi-stage] [prod sync gcp] job-queue-public-api@production-1234567890123456789
```

The pro PRs are then correctly merged via implementation in https://github.com/keboola/kbc-stacks/pull/6000

Code Distribution:                      
  - 🧪 Test Code: 586 lines (69.7%)
  - 🏗️ Application Code: 255 lines (30.3%)

### Tests

#### Multi-stage=true (GCP stacks only)
deploy when there are only gcp stacks having configured the app
- https://github.com/keboola/sre-playground/pull/444
- https://github.com/keboola/sre-playground/pull/443

Po tomto teste som pridal AWS stacky (dev a 2 prody)

#### Multi-stage=true (GCP and AWS)
Spravne to vytvorilo:
- prod PRs a nemergol
  - https://github.com/keboola/sre-playground/pull/483
  - https://github.com/keboola/sre-playground/pull/482
-  dev PRs ktore mergol
    - https://github.com/keboola/sre-playground/pull/485
    - https://github.com/keboola/sre-playground/pull/484

#### Multi-stage=true with extra tags
Spravne to vytvorilo:
- prod PRs a nemergol
  - https://github.com/keboola/sre-playground/pull/487
  - https://github.com/keboola/sre-playground/pull/486
-  dev PRs ktore mergol
    - https://github.com/keboola/sre-playground/pull/489
    - https://github.com/keboola/sre-playground/pull/488

#### Happy path (multi-stage=false)
- https://github.com/keboola/sre-playground/pull/490

#### Auto-merge = false
Spravne to vytvorilo 6 PRs ktore nemergol:
- https://github.com/keboola/sre-playground/pulls?q=is%3Apr+is%3Aopen+production-dont-merge
Nemergol ziadne PR - https://github.com/keboola/sre-playground/pulls?q=is%3Apr+is%3Aclosed+

#### Stack overide

- https://github.com/keboola/sre-playground/pull/497

#### Invalid service (should fail)
- https://github.com/keboola/sre-playground/actions/runs/17672323342

## Plans for customer communication
None.

## Impact analysis
Continuous deployments in all gitopsed services.

## Change type
Update continuous deployment workflow.

## Justification
This is prerequisite for GitOps migration of job queue services.

## Deployment
- Merge & create release.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
