### PR TITLE
fix: retry all 405 errors during auto-merge

### DIFF
--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -332,10 +332,10 @@ class IOLayer:
                 # Re-raise AutoMergeError without modification
                 raise
             except GithubException as e:
-                error_message = str(e.data.get("message", "")).lower()
-                if e.status == 405 and "not mergeable" in error_message:
+                if e.status == 405:
                     if attempt < max_retries - 1:
-                        print(f"PR not ready to merge, waiting... (attempt {attempt + 1}/{max_retries})")
+                        error_message = str(e.data.get("message", ""))
+                        print(f"PR not ready to merge ({error_message}), waiting... (attempt {attempt + 1}/{max_retries})")
                         sleep(retry_delay)
                     else:
                         error_msg = f"Failed to merge PR after {max_retries} attempts: {pr.html_url}"


### PR DESCRIPTION
Part of: https://linear.app/keboola/issue/PAT-1014/investigate-intermittent-e2e-aws-deploy-failures

## Release Notes 
Fixed auto-merge retry logic to handle "Base branch was modified" errors. Previously, these 405 errors would fail immediately without retry, causing spurious failures in the auto-merge process.

- E2E tests - https://github.com/keboola/helm-image-updater-testing/actions/runs/19460240213

## Plans for customer communication
None.

## Impact analysis
**Positive impact:**
- Auto-merge process is now more resilient to temporary merge conflicts
- "Base branch was modified" errors will be retried up to 10 times
- Better error visibility with specific error messages in console output

**Risk:**
- Low risk - simplifies and broadens existing retry logic
- All 53 tests pass including new test coverage

## Change type
Bug fix - improves reliability of existing auto-merge feature

## Justification
The previous implementation only retried 405 errors when the message contained "not mergeable". This caused immediate failures for "Base branch was modified" errors, which are also temporary conditions that benefit from retry.

By checking only the 405 status code (regardless of message), we handle all temporary merge conflicts consistently.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.