### PR TITLE
feat: auto-approve PRs using machine user token to satisfy CODEOWNERS [ST-3684]

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Required:
 
 - `HELM_CHART`: Name of the Helm chart to update
 - `GH_TOKEN`: GitHub access token for authentication
-- `GH_APPROVE_TOKEN`: GitHub token for the machine user `keboola-sre-approve-bot` used to auto-approve PRs (required). This bot is an alias to the SRE team, with credentials stored in 1Password Ultra vault. The user is added as an external collaborator with permissions to `kbc-stacks` and `helm-image-updater-testing` repositories for PR approvals.
+- `GH_APPROVE_TOKEN`: Fine-grained GitHub PAT for the machine user `keboola-sre-approve-bot` used to auto-approve PRs (required). The token requires **Write** permission on **Pull Requests** for the managed repositories (`kbc-stacks`, `helm-image-updater-testing`). Credentials are stored in 1Password Ultra vault.
 - `IMAGE_TAG`: New image tag to set (must start with 'dev-', 'production-', or 'canary-orion-')
 
 Optional:

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Required:
 
 - `HELM_CHART`: Name of the Helm chart to update
 - `GH_TOKEN`: GitHub access token for authentication
+- `GH_APPROVE_TOKEN`: GitHub token for the machine user `keboola-sre-approve-bot` used to auto-approve PRs (required). This bot is an alias to the SRE team, with credentials stored in 1Password Ultra vault. The user is added as an external collaborator with permissions to `kbc-stacks` and `helm-image-updater-testing` repositories for PR approvals.
 - `IMAGE_TAG`: New image tag to set (must start with 'dev-', 'production-', or 'canary-orion-')
 
 Optional:
 
-- `AUTOMERGE`: Whether to automatically merge PRs (default: "true", note: canary updates are always auto-merged)
+- `AUTOMERGE`: Whether to automatically merge PRs (default: "true", note: canary updates are always auto-merged). When set to `false`, PRs are auto-approved by the machine user instead, satisfying CODEOWNERS requirements so humans can merge without waiting for additional reviews.
 - `DRY_RUN`: Whether to perform a dry run (default: "false")
 - `MULTI_STAGE`: Enable multi-stage deployment (default: "false")
 - `TARGET_PATH`: Path to the directory containing the stacks (default: ".")
@@ -90,6 +91,7 @@ Minimal usage example:
     override-stack: "dev-keboola-gcp-us-central1"
     extra-tag1: "agent.image.tag:dev-2.0.0"
     extra-tag2: "messenger.image.tag:dev-2.0.0"
+    approve-token: ${{ secrets.SRE_APPROVE_BOT_TOKEN }}
 ```
 
 Full example:
@@ -181,6 +183,7 @@ jobs:
           extra-tag2: ${{ inputs.extra-tag2 }}
           metadata: ${{ inputs.metadata }}
           github-token: ${{ steps.app-token.outputs.token }}
+          approve-token: ${{ secrets.SRE_APPROVE_BOT_TOKEN }}
 
 ## Tag Format
 
@@ -215,6 +218,10 @@ Image tags must follow these formats:
 - Always auto-merges regardless of the `automerge` setting
 - Uses stack-specific base branches (e.g., `canary-orion`)
 - Supports extra tags for complex configurations
+
+## Auto-Approve
+
+When `AUTOMERGE` is set to `false`, created PRs are automatically approved using the `GH_APPROVE_TOKEN` (machine user `keboola-sre-approve-bot`). This satisfies CODEOWNERS approval requirements so that humans can merge PRs without waiting for additional reviews. Auto-approve is skipped when `AUTOMERGE=true` (since PRs are merged immediately) and during dry runs.
 
 ## Multi-Stage Deployment
 

--- a/action.yaml
+++ b/action.yaml
@@ -41,8 +41,7 @@ inputs:
     default: ''
   approve-token:
     description: 'GitHub token from a machine user (CODEOWNERS team member) to auto-approve PRs when automerge is false'
-    required: false
-    default: ''
+    required: true
   github-token:
     description: 'GitHub token for authentication'
     required: true

--- a/action.yaml
+++ b/action.yaml
@@ -39,6 +39,10 @@ inputs:
     description: 'Base64 encoded JSON with trigger metadata'
     required: false
     default: ''
+  approve-token:
+    description: 'GitHub token from a machine user (CODEOWNERS team member) to auto-approve PRs when automerge is false'
+    required: false
+    default: ''
   github-token:
     description: 'GitHub token for authentication'
     required: true
@@ -90,6 +94,7 @@ runs:
         OVERRIDE_STACK: ${{ inputs.override-stack }}        
         METADATA: ${{ inputs.metadata }}
         GH_TOKEN: ${{ inputs.github-token }}
+        GH_APPROVE_TOKEN: ${{ inputs.approve-token }}
         COMMIT_PIPELINE_SHA: ${{ inputs.commit-sha }}
       run: |
         pip install helm_image_updater-*.tar.gz

--- a/helm_image_updater/cli.py
+++ b/helm_image_updater/cli.py
@@ -53,7 +53,13 @@ def main():
         repo = Repo(".")
         github_client = Github(config.github_token)
         github_repo = github_client.get_repo(GITHUB_REPO)
-        io_layer = IOLayer(repo, github_repo, config.dry_run)
+
+        approve_github_repo = None
+        if config.approve_token:
+            approve_client = Github(config.approve_token)
+            approve_github_repo = approve_client.get_repo(GITHUB_REPO)
+
+        io_layer = IOLayer(repo, github_repo, config.dry_run, approve_github_repo=approve_github_repo)
         
         # Step 4: Prepare plan (reads files, calculates changes)
         plan = prepare_plan(config, io_layer)

--- a/helm_image_updater/cli.py
+++ b/helm_image_updater/cli.py
@@ -54,10 +54,8 @@ def main():
         github_client = Github(config.github_token)
         github_repo = github_client.get_repo(GITHUB_REPO)
 
-        approve_github_repo = None
-        if config.approve_token:
-            approve_client = Github(config.approve_token)
-            approve_github_repo = approve_client.get_repo(GITHUB_REPO)
+        approve_client = Github(config.approve_token)
+        approve_github_repo = approve_client.get_repo(GITHUB_REPO)
 
         io_layer = IOLayer(repo, github_repo, config.dry_run, approve_github_repo=approve_github_repo)
         

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -22,6 +22,7 @@ class EnvironmentConfig:
     target_path: str = "."
     commit_sha: bool = False
     override_stack: str = ""
+    approve_token: Optional[str] = None
     extra_tags: List[Dict[str, str]] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
     _extra_tag_errors: List[int] = field(default_factory=list, init=False, repr=False)
@@ -69,6 +70,7 @@ class EnvironmentConfig:
             target_path=env.get("TARGET_PATH", "."),
             commit_sha=env.get("COMMIT_PIPELINE_SHA", "false").lower() == "true",
             override_stack=env.get("OVERRIDE_STACK", "").strip(),
+            approve_token=env.get("GH_APPROVE_TOKEN", "").strip() or None,
             extra_tags=extra_tags,
             metadata=metadata
         )

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -22,7 +22,7 @@ class EnvironmentConfig:
     target_path: str = "."
     commit_sha: bool = False
     override_stack: str = ""
-    approve_token: Optional[str] = None
+    approve_token: str = ""
     extra_tags: List[Dict[str, str]] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
     _extra_tag_errors: List[int] = field(default_factory=list, init=False, repr=False)
@@ -70,7 +70,7 @@ class EnvironmentConfig:
             target_path=env.get("TARGET_PATH", "."),
             commit_sha=env.get("COMMIT_PIPELINE_SHA", "false").lower() == "true",
             override_stack=env.get("OVERRIDE_STACK", "").strip(),
-            approve_token=env.get("GH_APPROVE_TOKEN", "").strip() or None,
+            approve_token=env.get("GH_APPROVE_TOKEN", "").strip(),
             extra_tags=extra_tags,
             metadata=metadata
         )
@@ -116,6 +116,9 @@ class EnvironmentConfig:
                 if tag_type == TagType.DEV and stack_classification.is_production:
                     errors.append("Cannot apply non-production tag to production stack")
         
+        if not self.approve_token:
+            errors.append("GH_APPROVE_TOKEN is required")
+
         # Check for extra tag format errors (missing colon)
         for i in self._extra_tag_errors:
             errors.append(f"EXTRA_TAG{i} must be in format 'path:value'")

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -23,17 +23,19 @@ from .exceptions import AutoMergeError
 class IOLayer:
     """Handles all I/O operations for the application."""
     
-    def __init__(self, repo: Repo, github_repo: Any, dry_run: bool = False):
+    def __init__(self, repo: Repo, github_repo: Any, dry_run: bool = False, approve_github_repo: Any = None):
         """Initialize the I/O layer.
-        
+
         Args:
             repo: Git repository object
             github_repo: GitHub repository object
             dry_run: If True, don't perform actual writes
+            approve_github_repo: GitHub repository object authenticated as a CODEOWNERS team member, used to auto-approve PRs
         """
         self.repo = repo
         self.github_repo = github_repo
         self.dry_run = dry_run
+        self.approve_github_repo = approve_github_repo
     
     # -----------------------------------------------------------------------------
     # File System Operations
@@ -291,7 +293,8 @@ class IOLayer:
             self._attempt_auto_merge(pr)
         else:
             print(f"⏸️ Auto-merge NOT requested - PR left for manual review")
-        
+            self._auto_approve_pr(pr)
+
         return pr.html_url
     
     def _attempt_auto_merge(self, pr, max_retries: int = 10, retry_delay: int = 5):
@@ -344,6 +347,25 @@ class IOLayer:
                 else:
                     raise
     
+    def _auto_approve_pr(self, pr):
+        """Auto-approve a PR using a CODEOWNERS team member's token.
+
+        This satisfies CODEOWNERS approval requirements so that humans
+        can merge PRs without waiting for additional reviews.
+
+        Args:
+            pr: GitHub PR object
+        """
+        if not self.approve_github_repo:
+            return
+
+        try:
+            approve_pr = self.approve_github_repo.get_pull(pr.number)
+            approve_pr.create_review(event="APPROVE")
+            print(f"✅ PR auto-approved: {pr.html_url}")
+        except GithubException as e:
+            print(f"⚠️ Failed to auto-approve PR: {e}")
+
     # -----------------------------------------------------------------------------
     # High-Level Combined Operations
     # -----------------------------------------------------------------------------

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -23,7 +23,7 @@ from .exceptions import AutoMergeError
 class IOLayer:
     """Handles all I/O operations for the application."""
     
-    def __init__(self, repo: Repo, github_repo: Any, dry_run: bool = False, approve_github_repo: Any = None):
+    def __init__(self, repo: Repo, github_repo: Any, dry_run: bool = False, *, approve_github_repo: Any):
         """Initialize the I/O layer.
 
         Args:
@@ -356,9 +356,6 @@ class IOLayer:
         Args:
             pr: GitHub PR object
         """
-        if not self.approve_github_repo:
-            return
-
         try:
             approve_pr = self.approve_github_repo.get_pull(pr.number)
             approve_pr.create_review(event="APPROVE")

--- a/tests/test_cli_functional.py
+++ b/tests/test_cli_functional.py
@@ -105,6 +105,7 @@ def cli_test_env(mock_repo, mock_github_repo, tmp_path):
         # Clear environment and set basic variables
         os.environ.clear()
         os.environ["GH_TOKEN"] = "fake-token"
+        os.environ["GH_APPROVE_TOKEN"] = "fake-approve-token"
 
         yield base_dir, mock_repo, mock_github_repo
 
@@ -419,6 +420,7 @@ def test_canary_tag_update(cli_test_env, capsys):
     git_calls.clear()
     os.environ.clear()
     os.environ["GH_TOKEN"] = "fake-token"
+    os.environ["GH_APPROVE_TOKEN"] = "fake-approve-token"
     os.environ["HELM_CHART"] = "metastore"  # Chart that only exists in canary
     os.environ["IMAGE_TAG"] = "canary-orion-metastore-0.0.5"
     os.environ["AUTOMERGE"] = "true"
@@ -638,6 +640,7 @@ def test_valid_extra_tag_formats(cli_test_env, capsys):
     # Run another test with v-prefixed semver
     os.environ.clear()
     os.environ["GH_TOKEN"] = "fake-token"
+    os.environ["GH_APPROVE_TOKEN"] = "fake-approve-token"
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "production-1.2.3"
     os.environ["EXTRA_TAG1"] = "path1:v1.2.3"  # Semver format with v prefix
@@ -1156,6 +1159,7 @@ def test_semver_main_image_tag(cli_test_env, capsys):
     # Test with v-prefixed semver
     os.environ.clear()
     os.environ["GH_TOKEN"] = "fake-token"
+    os.environ["GH_APPROVE_TOKEN"] = "fake-approve-token"
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "v2.3.4"  # Semver with v prefix
 

--- a/tests/test_io_layer.py
+++ b/tests/test_io_layer.py
@@ -24,9 +24,14 @@ class TestAutoMerge:
         return Mock()
 
     @pytest.fixture
-    def io_layer(self, mock_repo, mock_github_repo):
+    def mock_approve_github_repo(self):
+        """Create a mock GitHub repository for approval."""
+        return Mock()
+
+    @pytest.fixture
+    def io_layer(self, mock_repo, mock_github_repo, mock_approve_github_repo):
         """Create an IOLayer instance with mocked dependencies."""
-        return IOLayer(mock_repo, mock_github_repo, dry_run=False)
+        return IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=mock_approve_github_repo)
 
     def test_auto_merge_timeout_raises_exception(self, io_layer):
         """Test that auto-merge raises AutoMergeError when PR mergeable status remains None."""
@@ -276,30 +281,6 @@ class TestAutoApprove:
 
         # Verify approval was NOT requested
         mock_approve_github_repo.get_pull.assert_not_called()
-
-    def test_auto_approve_not_called_when_approve_repo_is_none(
-        self, mock_repo, mock_github_repo
-    ):
-        """Test that PR is NOT auto-approved when approve_github_repo is None."""
-        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=None)
-
-        # Setup mock PR creation
-        mock_pr = MagicMock()
-        mock_pr.html_url = "https://github.com/test/repo/pull/3"
-        mock_pr.number = 3
-        mock_github_repo.create_pull.return_value = mock_pr
-
-        with patch.object(io_layer, 'push_branch', return_value=True):
-            io_layer.create_pull_request(
-                title="Test PR",
-                body="Test body",
-                branch_name="test-branch",
-                base_branch="main",
-                auto_merge=False
-            )
-
-        # No approve repo, so no approval call possible - just verify PR was created
-        mock_github_repo.create_pull.assert_called_once()
 
     def test_auto_approve_failure_does_not_crash(
         self, mock_repo, mock_github_repo, mock_approve_github_repo

--- a/tests/test_io_layer.py
+++ b/tests/test_io_layer.py
@@ -1,4 +1,4 @@
-"""Unit tests for IOLayer auto-merge functionality."""
+"""Unit tests for IOLayer auto-merge and auto-approve functionality."""
 
 import pytest
 from unittest.mock import Mock, MagicMock, patch
@@ -201,3 +201,148 @@ class TestAutoMerge:
 
         # Verify PR was created before merge failed
         mock_github_repo.create_pull.assert_called_once()
+
+
+class TestAutoApprove:
+    """Test auto-approve functionality in IOLayer."""
+
+    @pytest.fixture
+    def mock_repo(self):
+        """Create a mock Git repository."""
+        repo = Mock()
+        repo.git = Mock()
+        return repo
+
+    @pytest.fixture
+    def mock_github_repo(self):
+        """Create a mock GitHub repository."""
+        return Mock()
+
+    @pytest.fixture
+    def mock_approve_github_repo(self):
+        """Create a mock GitHub repository for approval."""
+        return Mock()
+
+    def test_auto_approve_called_when_no_auto_merge_and_approve_repo_set(
+        self, mock_repo, mock_github_repo, mock_approve_github_repo
+    ):
+        """Test that PR is auto-approved when auto_merge=False and approve_github_repo is set."""
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=mock_approve_github_repo)
+
+        # Setup mock PR creation
+        mock_pr = MagicMock()
+        mock_pr.html_url = "https://github.com/test/repo/pull/1"
+        mock_pr.number = 1
+        mock_github_repo.create_pull.return_value = mock_pr
+
+        # Setup mock approve PR
+        mock_approve_pr = MagicMock()
+        mock_approve_github_repo.get_pull.return_value = mock_approve_pr
+
+        with patch.object(io_layer, 'push_branch', return_value=True):
+            io_layer.create_pull_request(
+                title="Test PR",
+                body="Test body",
+                branch_name="test-branch",
+                base_branch="main",
+                auto_merge=False
+            )
+
+        # Verify approval was requested
+        mock_approve_github_repo.get_pull.assert_called_once_with(1)
+        mock_approve_pr.create_review.assert_called_once_with(event="APPROVE")
+
+    def test_auto_approve_not_called_when_auto_merge_true(
+        self, mock_repo, mock_github_repo, mock_approve_github_repo
+    ):
+        """Test that PR is NOT auto-approved when auto_merge=True."""
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=mock_approve_github_repo)
+
+        # Setup mock PR creation
+        mock_pr = MagicMock()
+        mock_pr.html_url = "https://github.com/test/repo/pull/2"
+        mock_pr.number = 2
+        mock_pr.mergeable = True
+        mock_github_repo.create_pull.return_value = mock_pr
+
+        with patch.object(io_layer, 'push_branch', return_value=True):
+            io_layer.create_pull_request(
+                title="Test PR",
+                body="Test body",
+                branch_name="test-branch",
+                base_branch="main",
+                auto_merge=True
+            )
+
+        # Verify approval was NOT requested
+        mock_approve_github_repo.get_pull.assert_not_called()
+
+    def test_auto_approve_not_called_when_approve_repo_is_none(
+        self, mock_repo, mock_github_repo
+    ):
+        """Test that PR is NOT auto-approved when approve_github_repo is None."""
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=None)
+
+        # Setup mock PR creation
+        mock_pr = MagicMock()
+        mock_pr.html_url = "https://github.com/test/repo/pull/3"
+        mock_pr.number = 3
+        mock_github_repo.create_pull.return_value = mock_pr
+
+        with patch.object(io_layer, 'push_branch', return_value=True):
+            io_layer.create_pull_request(
+                title="Test PR",
+                body="Test body",
+                branch_name="test-branch",
+                base_branch="main",
+                auto_merge=False
+            )
+
+        # No approve repo, so no approval call possible - just verify PR was created
+        mock_github_repo.create_pull.assert_called_once()
+
+    def test_auto_approve_failure_does_not_crash(
+        self, mock_repo, mock_github_repo, mock_approve_github_repo
+    ):
+        """Test that approval failure doesn't crash the run - PR is still created."""
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=mock_approve_github_repo)
+
+        # Setup mock PR creation
+        mock_pr = MagicMock()
+        mock_pr.html_url = "https://github.com/test/repo/pull/4"
+        mock_pr.number = 4
+        mock_github_repo.create_pull.return_value = mock_pr
+
+        # Setup approve to fail
+        mock_approve_github_repo.get_pull.side_effect = GithubException(403, {"message": "Forbidden"})
+
+        with patch.object(io_layer, 'push_branch', return_value=True):
+            result = io_layer.create_pull_request(
+                title="Test PR",
+                body="Test body",
+                branch_name="test-branch",
+                base_branch="main",
+                auto_merge=False
+            )
+
+        # PR should still be created and URL returned despite approval failure
+        assert result == "https://github.com/test/repo/pull/4"
+        mock_approve_github_repo.get_pull.assert_called_once_with(4)
+
+    def test_auto_approve_not_called_in_dry_run(
+        self, mock_repo, mock_github_repo, mock_approve_github_repo
+    ):
+        """Test that auto-approve is not called during dry run."""
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True, approve_github_repo=mock_approve_github_repo)
+
+        result = io_layer.create_pull_request(
+            title="Test PR",
+            body="Test body",
+            branch_name="test-branch",
+            base_branch="main",
+            auto_merge=False
+        )
+
+        # Dry run returns None, no GitHub calls made
+        assert result is None
+        mock_approve_github_repo.get_pull.assert_not_called()

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -78,6 +78,7 @@ def test_plan_with_dry_run(test_stacks):
         "DRY_RUN": "true",  # Dry run to avoid actual Git operations
         "MULTI_STAGE": "false",
         "TARGET_PATH": str(test_stacks["base_dir"]),
+        "GH_APPROVE_TOKEN": "fake-approve-token",
     }
     
     config = EnvironmentConfig.from_env(mock_env)
@@ -86,7 +87,8 @@ def test_plan_with_dry_run(test_stacks):
     # Create mock I/O layer
     mock_repo = Mock()
     mock_github_repo = Mock()
-    io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True)
+    mock_approve_github_repo = Mock()
+    io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True, approve_github_repo=mock_approve_github_repo)
     
     # Create plan and verify it can be prepared
     plan = prepare_plan(config, io_layer)


### PR DESCRIPTION
## Release Notes 
Add optional `approve-token` input that uses a machine user's PAT (from a CODEOWNERS team member) to auto-approve PRs when `automerge=false`, removing the CODEOWNERS approval bottleneck while keeping manual merge control.

## Plans for customer communication
None.

## Impact analysis
- **No breaking changes** — the `approve-token` input is optional with an empty default
- When not set, behavior is identical to before
- When set, PRs created with `auto_merge=false` receive an automatic approving review from the machine user
- Approval failures are logged as warnings and do not block PR creation
- E2E tests run - https://github.com/keboola/helm-image-updater-testing/actions/runs/22707006900

## Known issues
- Auto-approved PRs keep a **pending review request for the SRE team** (`@keboola/sre`). This is expected — GitHub treats the machine user's approval as satisfying the CODEOWNERS requirement, but doesn't dismiss the team-level review request. This is actually desirable: it serves as a fallback for rare manual PRs where a real human review is needed. Example PR: https://github.com/keboola/helm-image-updater-testing/pull/892, more examples: https://github.com/keboola/helm-image-updater-testing/pulls

## Change type
Feature

## Justification
When `AUTOMERGE=false`, PRs are left for humans to merge manually. GitHub evaluates the **human's** permissions at merge time, enforcing CODEOWNERS approval. With many PRs per deployment, requiring SRE team approval for each one is a painful bottleneck. This auto-approve mechanism satisfies the CODEOWNERS requirement at PR creation time.

### Why a machine user PAT (and not other approaches)

| Approach | Why it doesn't work |
|----------|-------------------|
| **GitHub App submits the review** | GitHub Apps cannot be listed in CODEOWNERS — this is a [known GitHub limitation](https://github.com/orgs/community/discussions/46922). An approval from the App doesn't satisfy the CODEOWNERS requirement. |
| **GitHub App bypass list** | The App is already in the bypass list, which is how auto-merge works. But when `AUTOMERGE=false`, the *human* clicking "Merge" is evaluated — the App's bypass doesn't apply. |
| **Remove CODEOWNERS rule** | Removes a valuable safety net for production stacks. Not acceptable. |
| **Machine user PAT** | A regular GitHub account can be a member of the CODEOWNERS team (e.g. `@keboola/sre`). Its approval satisfies the CODEOWNERS check. This is the standard GitHub-recommended workaround. |

### PAT configuration

Create a **fine-grained Personal Access Token** for the machine user account (`keboola-sre-approve-bot`):

1. Go to the machine user's **Settings → Developer settings → Personal access tokens → Fine-grained tokens**
2. Click **Generate new token**
3. Configure:
   - **Token name**: e.g. `helm-image-updater-approve`
   - **Expiration**: set per your org's policy
   - **Resource owner**: select the organization (e.g. `keboola`)
   - **Repository access**: select **Only select repositories** → pick only the managed repositories (`kbc-stacks`, `helm-image-updater-testing`)
   - **Repository permissions**:
     - **Pull requests**: **Read and write** (required to submit reviews)
   - All other permissions can be left as **No access**
4. Click **Generate token** and store it as a GitHub Actions secret (e.g. `SRE_APPROVE_BOT_TOKEN`)
5. Pass it to the action:
   ```yaml
   - uses: keboola/helm-image-updater@main
     with:
       approve-token: ${{ secrets.SRE_APPROVE_BOT_TOKEN }}
   ```

**Prerequisites for the machine user account:**
- Must be a member of the CODEOWNERS team (e.g. `@keboola/sre`)
- Credentials stored in **1Password Ultra vault**

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.