### PR TITLE
feat: remove argocdApplication override on tag update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Python tool for automating image tag updates across Helm charts in different K
 - Multi-stage deployment support
 - Extra tag updates for complex configurations
 - Detailed logging and error handling
+- Automatically removes ArgoCD branch overrides (`appManifestsRevision`) from `values.yaml` in the same PR
 
 ## Installation
 
@@ -222,6 +223,39 @@ Image tags must follow these formats:
 ## Auto-Approve
 
 When `AUTOMERGE` is set to `false`, created PRs are automatically approved using the `GH_APPROVE_TOKEN` (machine user `keboola-sre-approve-bot`). This satisfies CODEOWNERS approval requirements so that humans can merge PRs without waiting for additional reviews. Auto-approve is skipped when `AUTOMERGE=true` (since PRs are merged immediately) and during dry runs.
+
+## Override Removal
+
+When updating image tags, the tool automatically checks each target stack's `{helm-chart}/values.yaml` for ArgoCD branch overrides and removes them in the same PR.
+
+**What gets removed:** The `argocdApplication.appManifestsRevision` field, when set to anything other than `"main"`. Developers sometimes set this to a feature branch for testing, but leaving it in place causes ArgoCD to keep deploying from that branch, silently ignoring any new image tag updates.
+
+**What is preserved:** All other fields in `values.yaml` remain untouched. If removing `appManifestsRevision` leaves the `argocdApplication` block empty, the entire block is removed. If the file becomes empty as a result, an empty file is written.
+
+**No configuration required** — this behavior is always active and runs automatically for every stack update.
+
+**Visibility:** When overrides are removed, the PR body includes a "⚠️ Removed Branch Overrides" section listing exactly which files were modified.
+
+Example `values.yaml` before update:
+
+```yaml
+argocdApplication:
+  appManifestsRevision: my-feature-branch
+  someOtherField: value
+```
+
+After update (override removed, other fields preserved):
+
+```yaml
+argocdApplication:
+  someOtherField: value
+```
+
+If `argocdApplication` only contained `appManifestsRevision`, the entire block is removed:
+
+```yaml
+# (empty file)
+```
 
 ## Multi-Stage Deployment
 

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -110,7 +110,7 @@ class IOLayer:
             return False
         
         for file_change in file_changes:
-            if file_change.file_path.endswith(('.yaml', '.yml')):
+            if file_change.file_path.endswith(('.yaml', '.yml')) and file_change.new_content.strip():
                 # For YAML files, parse and write properly
                 data = yaml.safe_load(file_change.new_content)
                 self.write_yaml(file_change.file_path, data)

--- a/helm_image_updater/message_generation.py
+++ b/helm_image_updater/message_generation.py
@@ -152,18 +152,20 @@ def generate_pr_title(
 def format_pr_body_with_metadata(
     helm_chart: str,
     image_tag: str,
-    metadata: Dict[str, Any]
+    metadata: Dict[str, Any],
+    removed_overrides: Optional[List[Dict[str, str]]] = None,
 ) -> str:
     """
     Generate PR body when pipeline metadata is available.
-    
+
     Pure function that formats PR body with metadata.
-    
+
     Args:
         helm_chart: Name of the Helm chart
         image_tag: The image tag
         metadata: Pipeline trigger metadata
-        
+        removed_overrides: Optional list of dicts with 'stack' and 'description' keys
+
     Returns:
         Formatted PR body string
     """
@@ -201,10 +203,23 @@ def format_pr_body_with_metadata(
         f"- [🐕 Datadog](https://app.datadoghq.eu/ci/deployments?search=%40deployment.service%3A{helm_chart})"
     )
     
+    override_section = ""
+    if removed_overrides:
+        override_lines = "\n".join(
+            f"- **{o['stack']}**: {o['description']}" for o in removed_overrides
+        )
+        override_section = (
+            f"\n\n### ⚠️ Removed Branch Overrides\n"
+            f"The following stacks had `argocdApplication.appManifestsRevision` overrides that were removed "
+            f"so ArgoCD will deploy from `main` with the latest tag:\n"
+            f"{override_lines}"
+        )
+
     return (
         f"## 🤖 Automated Image Tag Update\n\n"
         f"{trigger_info}\n\n"
-        f"{change_summary}\n\n"
+        f"{change_summary}"
+        f"{override_section}\n\n"
         f"{monitoring_links}"
     )
 

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -285,7 +285,7 @@ def _check_and_remove_override(
     if not new_data["argocdApplication"]:
         del new_data["argocdApplication"]
 
-    new_content = yaml.dump(new_data, default_flow_style=False, sort_keys=False)
+    new_content = yaml.dump(new_data, default_flow_style=False, sort_keys=False) if new_data else ""
 
     print(f"Detected appManifestsRevision override ({revision}) in {values_file_path}, will remove it")
 

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -256,13 +256,14 @@ def _check_and_remove_override(
         values_content = io_layer.read_file(values_file_path)
         if values_content is None:
             return None
-    except Exception:
-        print(f"Warning: could not read {values_file_path}, skipping override check")
+    except Exception as e:
+        print(f"Warning: could not read {values_file_path}, skipping override check: {e}")
         return None
 
     try:
         values_data = yaml.safe_load(values_content)
-    except Exception:
+    except yaml.YAMLError as e:
+        print(f"Warning: could not parse {values_file_path}, skipping override check: {e}")
         return None
 
     if not isinstance(values_data, dict):

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -252,8 +252,12 @@ def _check_and_remove_override(
     Returns a FileChange if an override was found and should be removed, None otherwise.
     """
     values_file_path = f"{stack}/{helm_chart}/values.yaml"
-    values_content = io_layer.read_file(values_file_path)
-    if values_content is None:
+    try:
+        values_content = io_layer.read_file(values_file_path)
+        if values_content is None:
+            return None
+    except Exception:
+        print(f"Warning: could not read {values_file_path}, skipping override check")
         return None
 
     try:

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -282,10 +282,6 @@ def _check_and_remove_override(
 
     new_content = yaml.dump(new_data, default_flow_style=False, sort_keys=False)
 
-    # Handle case where removing argocdApplication leaves an empty dict
-    if not new_data:
-        new_content = ""
-
     print(f"Detected appManifestsRevision override ({revision}) in {values_file_path}, will remove it")
 
     return FileChange(

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -75,6 +75,8 @@ def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
     # Create file changes
     for stack_change in stack_changes:
         plan.file_changes.append(stack_change['file_change'])
+        if 'override_change' in stack_change:
+            plan.file_changes.append(stack_change['override_change'])
     
     # Group changes into PRs
     pr_groups = _group_changes_for_prs(stack_changes, plan, config, io_layer)
@@ -221,19 +223,78 @@ def _calculate_all_changes(plan: UpdatePlan, io_layer: IOLayer) -> List[Dict[str
                 f"{change.path} from {change.old_value} to {change.new_value}"
             )
         
-        stack_changes.append({
+        stack_change = {
             'stack': stack,
             'file_change': FileChange(
                 file_path=tag_file_path,
                 old_content=current_content,
                 new_content=new_content,
-                change_description=f"Updated {stack}/{plan.helm_chart}/tag.yaml: " + 
+                change_description=f"Updated {stack}/{plan.helm_chart}/tag.yaml: " +
                                  ", ".join(change_descriptions)
             ),
             'changes': changes
-        })
-    
+        }
+
+        # Check for argocdApplication override in values.yaml
+        override_change = _check_and_remove_override(stack, plan.helm_chart, io_layer)
+        if override_change:
+            stack_change['override_change'] = override_change
+
+        stack_changes.append(stack_change)
+
     return stack_changes
+
+def _check_and_remove_override(
+    stack: str, helm_chart: str, io_layer: IOLayer
+) -> Optional[FileChange]:
+    """Check values.yaml for argocdApplication.appManifestsRevision and remove it if present.
+
+    Returns a FileChange if an override was found and should be removed, None otherwise.
+    """
+    values_file_path = f"{stack}/{helm_chart}/values.yaml"
+    values_content = io_layer.read_file(values_file_path)
+    if values_content is None:
+        return None
+
+    try:
+        values_data = yaml.safe_load(values_content)
+    except Exception:
+        return None
+
+    if not isinstance(values_data, dict):
+        return None
+
+    argo_app = values_data.get("argocdApplication")
+    if not isinstance(argo_app, dict):
+        return None
+
+    revision = argo_app.get("appManifestsRevision")
+    if not revision or revision == "main":
+        return None
+
+    import copy
+    new_data = copy.deepcopy(values_data)
+    del new_data["argocdApplication"]["appManifestsRevision"]
+
+    # If argocdApplication is now empty, remove the entire block
+    if not new_data["argocdApplication"]:
+        del new_data["argocdApplication"]
+
+    new_content = yaml.dump(new_data, default_flow_style=False, sort_keys=False)
+
+    # Handle case where removing argocdApplication leaves an empty dict
+    if not new_data:
+        new_content = ""
+
+    print(f"Detected appManifestsRevision override ({revision}) in {values_file_path}, will remove it")
+
+    return FileChange(
+        file_path=values_file_path,
+        old_content=values_content,
+        new_content=new_content,
+        change_description=f"Removed appManifestsRevision override ({revision}) from {values_file_path}",
+    )
+
 
 def calculate_tag_changes(
     current_data: Dict[str, Any],
@@ -469,11 +530,21 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         target_stacks=pr_group['stacks']
     )
     
+    # Collect removed overrides for PR body
+    removed_overrides = []
+    for change in pr_group['changes']:
+        if 'override_change' in change:
+            removed_overrides.append({
+                'stack': change['stack'],
+                'description': change['override_change'].change_description,
+            })
+
     # Generate PR body
     pr_body = format_pr_body_with_metadata(
         helm_chart=plan.helm_chart,
         image_tag=plan.image_tag,
-        metadata=plan.metadata
+        metadata=plan.metadata,
+        removed_overrides=removed_overrides,
     )
     
     # Determine auto-merge
@@ -485,9 +556,12 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
     print(f"   - strategy: {plan.strategy}")
     print(f"   - decision: {'AUTO-MERGE' if auto_merge else 'MANUAL ONLY'}")
     
-    # Get files to commit
+    # Get files to commit (tag.yaml + any override values.yaml changes)
     files_to_commit = [change['file_change'].file_path for change in pr_group['changes']]
-    
+    for change in pr_group['changes']:
+        if 'override_change' in change:
+            files_to_commit.append(change['override_change'].file_path)
+
     return PRPlan(
         branch_name=branch_name,
         pr_title=pr_title,

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -12,7 +12,7 @@ import pytest
 import yaml
 from helm_image_updater.io_layer import IOLayer
 from helm_image_updater.environment import EnvironmentConfig
-from helm_image_updater.plan_builder import prepare_plan, _group_changes_for_prs
+from helm_image_updater.plan_builder import prepare_plan, _group_changes_for_prs, _check_and_remove_override
 from helm_image_updater.models import UpdatePlan, UpdateStrategy
 from unittest.mock import Mock
 
@@ -313,3 +313,203 @@ def test_multi_cloud_grouping_dev_strategy(test_stacks):
     # Verify the group contains all dev stacks
     assert len(groups[0]['stacks']) == 3, f"Group should contain all 3 dev stacks"
     assert groups[0]['pr_type'] == 'standard', f"PR type should be 'standard'"
+
+
+# Override removal tests
+
+class TestCheckAndRemoveOverride:
+    """Tests for _check_and_remove_override function."""
+
+    def test_removes_override_with_branch(self):
+        """Override with a feature branch name is removed."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = yaml.dump({
+            "argocdApplication": {"appManifestsRevision": "feature-branch-123"}
+        })
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+
+        assert result is not None
+        assert result.file_path == "dev-stack/my-chart/values.yaml"
+        assert "feature-branch-123" in result.change_description
+
+        new_data = yaml.safe_load(result.new_content)
+        # argocdApplication block should be completely removed (it was the only key)
+        assert new_data is None or "argocdApplication" not in (new_data or {})
+
+    def test_no_values_yaml(self):
+        """Returns None when values.yaml doesn't exist."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = None
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+        assert result is None
+
+    def test_no_override_key(self):
+        """Returns None when argocdApplication is not present."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = yaml.dump({
+            "image": {"repository": "keboola/my-service"}
+        })
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+        assert result is None
+
+    def test_override_set_to_main(self):
+        """Returns None when override is set to 'main' (already correct)."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = yaml.dump({
+            "argocdApplication": {"appManifestsRevision": "main"}
+        })
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+        assert result is None
+
+    def test_preserves_other_argocd_fields(self):
+        """Only removes appManifestsRevision, keeps other argocdApplication fields."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = yaml.dump({
+            "argocdApplication": {
+                "appManifestsRevision": "feature-branch",
+                "syncPolicy": "automated",
+            }
+        })
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+
+        assert result is not None
+        new_data = yaml.safe_load(result.new_content)
+        assert "argocdApplication" in new_data
+        assert "appManifestsRevision" not in new_data["argocdApplication"]
+        assert new_data["argocdApplication"]["syncPolicy"] == "automated"
+
+    def test_preserves_other_top_level_keys(self):
+        """Other top-level keys in values.yaml are preserved."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = yaml.dump({
+            "image": {"repository": "keboola/my-service"},
+            "argocdApplication": {"appManifestsRevision": "feature-branch"},
+            "resources": {"limits": {"cpu": "100m"}},
+        })
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+
+        assert result is not None
+        new_data = yaml.safe_load(result.new_content)
+        assert new_data["image"]["repository"] == "keboola/my-service"
+        assert new_data["resources"]["limits"]["cpu"] == "100m"
+        assert "argocdApplication" not in new_data
+
+    def test_empty_argocd_block_no_revision(self):
+        """Returns None when argocdApplication exists but has no appManifestsRevision."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = yaml.dump({
+            "argocdApplication": {"syncPolicy": "automated"}
+        })
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+        assert result is None
+
+    def test_invalid_yaml(self):
+        """Returns None when values.yaml contains invalid YAML."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = "{{invalid yaml: ["
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+        assert result is None
+
+    def test_values_yaml_is_just_a_string(self):
+        """Returns None when values.yaml parses to a non-dict (e.g. a plain string)."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = "just a string"
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+        assert result is None
+
+
+class TestOverrideIntegration:
+    """Integration tests for override removal in the full plan flow."""
+
+    def test_plan_includes_override_removal(self, tmp_path):
+        """prepare_plan includes override FileChange when values.yaml has an override."""
+        # Set up a dev stack with tag.yaml and values.yaml with override
+        stack_name = "dev-keboola-gcp-us-central1"
+        stack_dir = tmp_path / stack_name
+        chart_dir = stack_dir / "test-chart"
+        chart_dir.mkdir(parents=True)
+
+        # Create tag.yaml
+        create_tag_yaml(chart_dir / "tag.yaml", "old-tag")
+
+        # Create values.yaml with override
+        with open(chart_dir / "values.yaml", "w") as f:
+            yaml.dump({"argocdApplication": {"appManifestsRevision": "feature-branch"}}, f)
+
+        # Create shared-values.yaml
+        with open(stack_dir / "shared-values.yaml", "w") as f:
+            yaml.dump({"cloudProvider": "gcp"}, f)
+
+        os.chdir(tmp_path)
+
+        mock_env = {
+            "HELM_CHART": "test-chart",
+            "IMAGE_TAG": "dev-new-tag",
+            "GH_TOKEN": "fake-token",
+            "AUTOMERGE": "true",
+            "DRY_RUN": "true",
+            "MULTI_STAGE": "false",
+            "TARGET_PATH": str(tmp_path),
+        }
+
+        config = EnvironmentConfig.from_env(mock_env)
+        mock_repo = Mock()
+        mock_github_repo = Mock()
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True)
+
+        plan = prepare_plan(config, io_layer)
+
+        # Should have 2 file changes: tag.yaml + values.yaml
+        assert len(plan.file_changes) == 2
+        file_paths = [fc.file_path for fc in plan.file_changes]
+        assert f"{stack_name}/test-chart/tag.yaml" in file_paths
+        assert f"{stack_name}/test-chart/values.yaml" in file_paths
+
+        # PR should include both files
+        assert len(plan.pr_plans) == 1
+        assert f"{stack_name}/test-chart/values.yaml" in plan.pr_plans[0].files_to_commit
+
+    def test_plan_without_override_has_only_tag_change(self, tmp_path):
+        """prepare_plan only has tag.yaml change when no override exists."""
+        stack_name = "dev-keboola-gcp-us-central1"
+        stack_dir = tmp_path / stack_name
+        chart_dir = stack_dir / "test-chart"
+        chart_dir.mkdir(parents=True)
+
+        create_tag_yaml(chart_dir / "tag.yaml", "old-tag")
+
+        # Create shared-values.yaml
+        with open(stack_dir / "shared-values.yaml", "w") as f:
+            yaml.dump({"cloudProvider": "gcp"}, f)
+
+        os.chdir(tmp_path)
+
+        mock_env = {
+            "HELM_CHART": "test-chart",
+            "IMAGE_TAG": "dev-new-tag",
+            "GH_TOKEN": "fake-token",
+            "AUTOMERGE": "true",
+            "DRY_RUN": "true",
+            "MULTI_STAGE": "false",
+            "TARGET_PATH": str(tmp_path),
+        }
+
+        config = EnvironmentConfig.from_env(mock_env)
+        mock_repo = Mock()
+        mock_github_repo = Mock()
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True)
+
+        plan = prepare_plan(config, io_layer)
+
+        # Should have only 1 file change: tag.yaml
+        assert len(plan.file_changes) == 1
+        assert plan.file_changes[0].file_path == f"{stack_name}/test-chart/tag.yaml"

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -337,6 +337,18 @@ class TestCheckAndRemoveOverride:
         # argocdApplication block should be completely removed (it was the only key)
         assert new_data is None or "argocdApplication" not in (new_data or {})
 
+    def test_removes_override_leaves_empty_file_when_only_override_present(self):
+        """When values.yaml contains only the argocdApplication block, result is an empty file."""
+        mock_io = Mock()
+        mock_io.read_file.return_value = yaml.dump({
+            "argocdApplication": {"appManifestsRevision": "feature-branch-123"}
+        })
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+
+        assert result is not None
+        assert result.new_content == ""
+
     def test_no_values_yaml(self):
         """Returns None when values.yaml doesn't exist."""
         mock_io = Mock()

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -333,9 +333,7 @@ class TestCheckAndRemoveOverride:
         assert result.file_path == "dev-stack/my-chart/values.yaml"
         assert "feature-branch-123" in result.change_description
 
-        new_data = yaml.safe_load(result.new_content)
-        # argocdApplication block should be completely removed (it was the only key)
-        assert new_data is None or "argocdApplication" not in (new_data or {})
+        assert result.new_content == ""
 
     def test_removes_override_leaves_empty_file_when_only_override_present(self):
         """When values.yaml contains only the argocdApplication block, result is an empty file."""

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -430,7 +430,7 @@ class TestCheckAndRemoveOverride:
 class TestOverrideIntegration:
     """Integration tests for override removal in the full plan flow."""
 
-    def test_plan_includes_override_removal(self, tmp_path):
+    def test_plan_includes_override_removal(self, tmp_path, monkeypatch):
         """prepare_plan includes override FileChange when values.yaml has an override."""
         # Set up a dev stack with tag.yaml and values.yaml with override
         stack_name = "dev-keboola-gcp-us-central1"
@@ -449,7 +449,7 @@ class TestOverrideIntegration:
         with open(stack_dir / "shared-values.yaml", "w") as f:
             yaml.dump({"cloudProvider": "gcp"}, f)
 
-        os.chdir(tmp_path)
+        monkeypatch.chdir(tmp_path)
 
         mock_env = {
             "HELM_CHART": "test-chart",
@@ -478,7 +478,7 @@ class TestOverrideIntegration:
         assert len(plan.pr_plans) == 1
         assert f"{stack_name}/test-chart/values.yaml" in plan.pr_plans[0].files_to_commit
 
-    def test_plan_without_override_has_only_tag_change(self, tmp_path):
+    def test_plan_without_override_has_only_tag_change(self, tmp_path, monkeypatch):
         """prepare_plan only has tag.yaml change when no override exists."""
         stack_name = "dev-keboola-gcp-us-central1"
         stack_dir = tmp_path / stack_name
@@ -491,7 +491,7 @@ class TestOverrideIntegration:
         with open(stack_dir / "shared-values.yaml", "w") as f:
             yaml.dump({"cloudProvider": "gcp"}, f)
 
-        os.chdir(tmp_path)
+        monkeypatch.chdir(tmp_path)
 
         mock_env = {
             "HELM_CHART": "test-chart",

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -464,7 +464,7 @@ class TestOverrideIntegration:
         config = EnvironmentConfig.from_env(mock_env)
         mock_repo = Mock()
         mock_github_repo = Mock()
-        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True)
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True, approve_github_repo=Mock())
 
         plan = prepare_plan(config, io_layer)
 
@@ -506,7 +506,7 @@ class TestOverrideIntegration:
         config = EnvironmentConfig.from_env(mock_env)
         mock_repo = Mock()
         mock_github_repo = Mock()
-        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True)
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True, approve_github_repo=Mock())
 
         plan = prepare_plan(config, io_layer)
 


### PR DESCRIPTION
Part of: https://linear.app/keboola/issue/ST-3736/helm-image-updater-force-override-branch-on-release

## Summary
- When `helm-image-updater` updates `tag.yaml`, it now checks `values.yaml` for `argocdApplication.appManifestsRevision` overrides
- If an override is found (and not set to `main`), it is removed in the same PR — atomically updating the tag and forcing ArgoCD back to deploying from `main`
- Prevents production tag updates from being silently ignored when a developer has set a branch override for testing
- E2E Tests - https://github.com/keboola/helm-image-updater-testing/pull/635

## Changes
- **`plan_builder.py`**: Added `_check_and_remove_override()` function that detects and creates a `FileChange` to remove the override. Integrated into `_calculate_all_changes()`, `prepare_plan()`, and `_create_pr_plan()`
- **`message_generation.py`**: PR body now includes a "Removed Branch Overrides" section listing which stacks had overrides removed
- **`tests/test_plan_builder.py`**: 11 new tests — 9 unit tests for edge cases (`TestCheckAndRemoveOverride`) and 2 integration tests (`TestOverrideIntegration`)

## Edge cases handled
- `values.yaml` doesn't exist → skip
- No `argocdApplication` key → skip
- Override set to `main` → skip
- `argocdApplication` has other fields besides `appManifestsRevision` → only remove the key, keep the rest
- Invalid YAML → skip
- Empty file after removal → handled

## Test plan
- [x] All 65 existing + new tests pass
- [x] Dry-run test against a stack with an active override
- [x] Integration test: create override on dev stack, trigger tag update, verify PR contains both `tag.yaml` and `values.yaml` changes