### PR TITLE
fix: auto-approve retry on 404 and raise error on failure

### DIFF
--- a/helm_image_updater/exceptions.py
+++ b/helm_image_updater/exceptions.py
@@ -7,3 +7,11 @@ class AutoMergeError(Exception):
     def __init__(self, message: str, pr_url: str = None):
         self.pr_url = pr_url
         super().__init__(message)
+
+
+class AutoApproveError(Exception):
+    """Raised when automatic PR approval fails."""
+
+    def __init__(self, message: str, pr_url: str = None):
+        self.pr_url = pr_url
+        super().__init__(message)

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -357,6 +357,9 @@ class IOLayer:
             pr: GitHub PR object
             max_retries: Maximum number of retry attempts for transient errors
             retry_delay: Base delay in seconds between retries (exponential backoff)
+
+        Raises:
+            AutoApproveError: If the PR cannot be auto-approved after retries or due to GitHub API errors.
         """
         for attempt in range(max_retries):
             try:

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -17,7 +17,7 @@ from github import Github
 from github.GithubException import GithubException
 from time import sleep
 
-from .exceptions import AutoMergeError
+from .exceptions import AutoMergeError, AutoApproveError
 
 
 class IOLayer:
@@ -347,7 +347,7 @@ class IOLayer:
                 else:
                     raise
     
-    def _auto_approve_pr(self, pr):
+    def _auto_approve_pr(self, pr, max_retries: int = 5, retry_delay: int = 2):
         """Auto-approve a PR using a CODEOWNERS team member's token.
 
         This satisfies CODEOWNERS approval requirements so that humans
@@ -355,13 +355,24 @@ class IOLayer:
 
         Args:
             pr: GitHub PR object
+            max_retries: Maximum number of retry attempts for transient errors
+            retry_delay: Base delay in seconds between retries (exponential backoff)
         """
-        try:
-            approve_pr = self.approve_github_repo.get_pull(pr.number)
-            approve_pr.create_review(event="APPROVE")
-            print(f"✅ PR auto-approved: {pr.html_url}")
-        except GithubException as e:
-            print(f"⚠️ Failed to auto-approve PR: {e}")
+        for attempt in range(max_retries):
+            try:
+                approve_pr = self.approve_github_repo.get_pull(pr.number)
+                approve_pr.create_review(event="APPROVE")
+                print(f"✅ PR auto-approved: {pr.html_url}")
+                return
+            except GithubException as e:
+                if e.status == 404 and attempt < max_retries - 1:
+                    print(f"PR not yet available for approval (404), retrying... (attempt {attempt + 1}/{max_retries})")
+                    sleep(retry_delay * (2 ** attempt))
+                else:
+                    raise AutoApproveError(
+                        f"Failed to auto-approve PR after {attempt + 1} attempt(s): {e}",
+                        pr_url=pr.html_url
+                    )
 
     # -----------------------------------------------------------------------------
     # High-Level Combined Operations

--- a/tests/test_io_layer.py
+++ b/tests/test_io_layer.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, MagicMock, patch
 from github.GithubException import GithubException
 
 from helm_image_updater.io_layer import IOLayer
-from helm_image_updater.exceptions import AutoMergeError
+from helm_image_updater.exceptions import AutoMergeError, AutoApproveError
 
 
 class TestAutoMerge:
@@ -282,10 +282,10 @@ class TestAutoApprove:
         # Verify approval was NOT requested
         mock_approve_github_repo.get_pull.assert_not_called()
 
-    def test_auto_approve_failure_does_not_crash(
+    def test_auto_approve_failure_raises_error(
         self, mock_repo, mock_github_repo, mock_approve_github_repo
     ):
-        """Test that approval failure doesn't crash the run - PR is still created."""
+        """Test that approval failure raises AutoApproveError."""
         io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=mock_approve_github_repo)
 
         # Setup mock PR creation
@@ -294,21 +294,78 @@ class TestAutoApprove:
         mock_pr.number = 4
         mock_github_repo.create_pull.return_value = mock_pr
 
-        # Setup approve to fail
+        # Setup approve to fail with non-404 error
         mock_approve_github_repo.get_pull.side_effect = GithubException(403, {"message": "Forbidden"})
 
         with patch.object(io_layer, 'push_branch', return_value=True):
-            result = io_layer.create_pull_request(
-                title="Test PR",
-                body="Test body",
-                branch_name="test-branch",
-                base_branch="main",
-                auto_merge=False
-            )
+            with pytest.raises(AutoApproveError):
+                io_layer.create_pull_request(
+                    title="Test PR",
+                    body="Test body",
+                    branch_name="test-branch",
+                    base_branch="main",
+                    auto_merge=False
+                )
 
-        # PR should still be created and URL returned despite approval failure
-        assert result == "https://github.com/test/repo/pull/4"
         mock_approve_github_repo.get_pull.assert_called_once_with(4)
+
+    def test_auto_approve_retries_on_404_then_succeeds(
+        self, mock_repo, mock_github_repo, mock_approve_github_repo
+    ):
+        """Test that 404 on first attempt is retried and succeeds on second."""
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=mock_approve_github_repo)
+
+        mock_pr = MagicMock()
+        mock_pr.html_url = "https://github.com/test/repo/pull/5"
+        mock_pr.number = 5
+
+        mock_approve_pr = MagicMock()
+        # First call raises 404, second call succeeds
+        mock_approve_github_repo.get_pull.side_effect = [
+            GithubException(404, {"message": "Not Found"}),
+            mock_approve_pr,
+        ]
+
+        with patch('helm_image_updater.io_layer.sleep'):
+            io_layer._auto_approve_pr(mock_pr)
+
+        assert mock_approve_github_repo.get_pull.call_count == 2
+        mock_approve_pr.create_review.assert_called_once_with(event="APPROVE")
+
+    def test_auto_approve_retries_on_404_exhausted(
+        self, mock_repo, mock_github_repo, mock_approve_github_repo
+    ):
+        """Test that repeated 404s exhaust retries and raise AutoApproveError."""
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=mock_approve_github_repo)
+
+        mock_pr = MagicMock()
+        mock_pr.html_url = "https://github.com/test/repo/pull/6"
+        mock_pr.number = 6
+
+        mock_approve_github_repo.get_pull.side_effect = GithubException(404, {"message": "Not Found"})
+
+        with patch('helm_image_updater.io_layer.sleep'):
+            with pytest.raises(AutoApproveError, match="Failed to auto-approve PR after 5 attempt"):
+                io_layer._auto_approve_pr(mock_pr)
+
+        assert mock_approve_github_repo.get_pull.call_count == 5
+
+    def test_auto_approve_non_404_fails_immediately(
+        self, mock_repo, mock_github_repo, mock_approve_github_repo
+    ):
+        """Test that non-404 error (e.g. 403) raises AutoApproveError on first attempt without retry."""
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=False, approve_github_repo=mock_approve_github_repo)
+
+        mock_pr = MagicMock()
+        mock_pr.html_url = "https://github.com/test/repo/pull/7"
+        mock_pr.number = 7
+
+        mock_approve_github_repo.get_pull.side_effect = GithubException(403, {"message": "Forbidden"})
+
+        with pytest.raises(AutoApproveError, match="Failed to auto-approve PR after 1 attempt"):
+            io_layer._auto_approve_pr(mock_pr)
+
+        mock_approve_github_repo.get_pull.assert_called_once_with(7)
 
     def test_auto_approve_not_called_in_dry_run(
         self, mock_repo, mock_github_repo, mock_approve_github_repo


### PR DESCRIPTION
Part of: https://linear.app/keboola/issue/ST-3684/critical-release-auto-approval

## Release Notes 
- Fix auto-approve race condition (404 on newly created PR) by adding retry with exponential backoff, and raise `AutoApproveError` on failure instead of silently swallowing errors.
- E2E tests - https://github.com/keboola/helm-image-updater-testing/actions/runs/22760843518

## Plans for customer communication
None.

## Impact analysis
- `_auto_approve_pr` now retries up to 5 times with exponential backoff when getting 404 (GitHub propagation delay)
- `_auto_approve_pr` now raises `AutoApproveError` on failure instead of printing a warning and continuing
- New `AutoApproveError` exception class added

## Change type
Bug fix

## Justification
Two bugs in auto-approve (ST-3684):
1. 404 race condition immediately after PR creation — GitHub hasn't propagated the PR yet
2. Errors silently swallowed — process reports success when approval actually failed

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.