### PR TITLE
fix: update GitHub Actions and fix release-downloader breaking change

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,10 +25,10 @@ jobs:
       checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -41,14 +41,14 @@ jobs:
         run: pytest tests -sv --doctest-modules --junitxml=junit/test-results.xml
 
       - name: Upload pytest results
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results
           path: junit/test-results.xml
         if: ${{ always() }}
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.18.0
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           comment_mode: off
@@ -60,11 +60,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,6 +54,28 @@ jobs:
           comment_mode: off
           files: junit/test-results.xml
 
+  test-action-yaml:
+    name: Test action.yaml release download
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - uses: robinraju/release-downloader@v1.12
+        with:
+          repository: "keboola/helm-image-updater"
+          latest: true
+          fileName: "*.tar.gz"
+
+      - name: Verify download and install
+        run: |
+          echo "Downloaded files:"
+          ls -la helm_image_updater-*.tar.gz
+          pip install helm_image_updater-*.tar.gz
+          which helm-image-updater
+          echo "action.yaml release download verified successfully"
+
   build-and-publish-package:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,28 +54,6 @@ jobs:
           comment_mode: off
           files: junit/test-results.xml
 
-  test-action-yaml:
-    name: Test action.yaml release download
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-
-      - uses: robinraju/release-downloader@v1.12
-        with:
-          repository: "keboola/helm-image-updater"
-          latest: true
-          fileName: "*.tar.gz"
-
-      - name: Verify download and install
-        run: |
-          echo "Downloaded files:"
-          ls -la helm_image_updater-*.tar.gz
-          pip install helm_image_updater-*.tar.gz
-          which helm-image-updater
-          echo "action.yaml release download verified successfully"
-
   build-and-publish-package:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')

--- a/action.yaml
+++ b/action.yaml
@@ -55,14 +55,15 @@ runs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT" > github_context.json
 
-    - uses: actions/setup-python@v5.2.0
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 
-    - uses: robinraju/release-downloader@v1.9
+    - uses: robinraju/release-downloader@v1.12
       with:
         repository: "keboola/helm-image-updater"
         latest: true
+        fileName: "*.tar.gz"
 
     - name: Configure git and fetch branches
       shell: bash


### PR DESCRIPTION
## Why

The previous attempt to update GitHub Actions dependencies (#25) broke the composite action because `robinraju/release-downloader` changed its default `fileName` from `"*"` to `""` between v1.9 and v1.12, causing no assets to be downloaded. This resulted in pipeline failures with `OSError: [Errno 2] No such file or directory: 'helm_image_updater-*.tar.gz'`. The change was fully reverted in #26.

## Context

The `v1` major version tag for `release-downloader` now points to v1.12, which introduced a silent breaking change in the default `fileName` input. Without an explicit `fileName`, the action downloads nothing instead of all assets.

## Approach

- Re-applied all GitHub Actions version updates from #25 (workflow and composite action)
- Pinned `release-downloader` to `@v1.12` (instead of floating `@v1`) and added an explicit `fileName: "*.tar.gz"` to avoid relying on default behavior
- This makes the action resilient to future default changes in the downloader

## Impact

- All GitHub Actions dependencies are updated to latest major versions
- The `release-downloader` breaking change is addressed with an explicit `fileName`
- No functional changes to CI or the composite action behavior

## Testing

- CI pipeline passes on this branch
- Verified the release-downloader fix with a [temporary CI job](https://github.com/keboola/helm-image-updater/actions/runs/23140625510) that replicated the exact `action.yaml` flow (download via `release-downloader@v1.12` + `pip install helm_image_updater-*.tar.gz`) — passed successfully

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)