### PR TITLE
fix: only remove argocdApplication override on production releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,3 +118,49 @@ The test suite covers:
 - Configuration validation and error handling
 
 Tests use pytest with fixtures defined in `conftest.py` for common setup like mock repositories and GitHub clients.
+
+## Development Workflow
+
+When making changes, follow this workflow:
+
+### 1. Run unit tests locally
+```bash
+pytest -sv tests/
+```
+All 74 tests must pass before proceeding.
+
+### 2. Create a draft PR
+```bash
+gh pr create --draft --title "..." --body "..."
+```
+- Always use the PR template from `.github/pull_request_template.md`
+- Always create as draft
+- Include the Linear task ID (e.g. `[ST-XXXX]`) in the PR body
+
+### 3. Trigger E2E tests
+The E2E test suite lives in a separate repo (`keboola/helm-image-updater-testing`). Trigger it against your branch:
+```bash
+gh workflow run test-suite.yaml \
+  --repo keboola/helm-image-updater-testing \
+  --field helm-image-updater-branch=<your-branch-name>
+```
+Get the run URL:
+```bash
+gh run list --repo keboola/helm-image-updater-testing --workflow=test-suite.yaml --limit 1 --json url --jq '.[0].url'
+```
+Monitor until completion:
+```bash
+gh run view <run-id> --repo keboola/helm-image-updater-testing --json status,conclusion,jobs \
+  --jq '{status: .status, conclusion: .conclusion, jobs: [.jobs[] | {name: .name, conclusion: .conclusion}]}'
+```
+
+### 4. Update PR with E2E results
+Once the E2E suite passes, add the run link to the PR description under an `## E2E tests` section:
+```bash
+gh pr edit <pr-number> --body "...(updated body with E2E test link)..."
+```
+
+### 5. If E2E tests fail
+- Check which test cases failed and read the logs
+- Fix the code, push, and re-trigger the E2E suite
+- Repeat until all 9 test scenarios pass

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -235,8 +235,8 @@ def _calculate_all_changes(plan: UpdatePlan, io_layer: IOLayer) -> List[Dict[str
             'changes': changes
         }
 
-        # Check for argocdApplication override in values.yaml (only for production releases)
-        if plan.strategy == UpdateStrategy.PRODUCTION:
+        # Check for argocdApplication override in values.yaml (only for production releases, not dev)
+        if plan.strategy != UpdateStrategy.DEV:
             override_change = _check_and_remove_override(stack, plan.helm_chart, io_layer)
             if override_change:
                 stack_change['override_change'] = override_change

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -235,10 +235,11 @@ def _calculate_all_changes(plan: UpdatePlan, io_layer: IOLayer) -> List[Dict[str
             'changes': changes
         }
 
-        # Check for argocdApplication override in values.yaml
-        override_change = _check_and_remove_override(stack, plan.helm_chart, io_layer)
-        if override_change:
-            stack_change['override_change'] = override_change
+        # Check for argocdApplication override in values.yaml (only for production releases)
+        if plan.strategy == UpdateStrategy.PRODUCTION:
+            override_change = _check_and_remove_override(stack, plan.helm_chart, io_layer)
+            if override_change:
+                stack_change['override_change'] = override_change
 
         stack_changes.append(stack_change)
 

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -235,8 +235,8 @@ def _calculate_all_changes(plan: UpdatePlan, io_layer: IOLayer) -> List[Dict[str
             'changes': changes
         }
 
-        # Check for argocdApplication override in values.yaml (only for production releases, not dev)
-        if plan.strategy != UpdateStrategy.DEV:
+        # Check for argocdApplication override in values.yaml (only for production releases)
+        if plan.strategy == UpdateStrategy.PRODUCTION:
             override_change = _check_and_remove_override(stack, plan.helm_chart, io_layer)
             if override_change:
                 stack_change['override_change'] = override_change

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -440,8 +440,56 @@ class TestCheckAndRemoveOverride:
 class TestOverrideIntegration:
     """Integration tests for override removal in the full plan flow."""
 
-    def test_plan_includes_override_removal(self, tmp_path, monkeypatch):
-        """prepare_plan includes override FileChange when values.yaml has an override."""
+    def test_plan_includes_override_removal_for_production(self, tmp_path, monkeypatch):
+        """prepare_plan includes override FileChange when values.yaml has an override and tag is production."""
+        # Set up a production stack with tag.yaml and values.yaml with override
+        stack_name = "com-keboola-gcp-prod"
+        stack_dir = tmp_path / stack_name
+        chart_dir = stack_dir / "test-chart"
+        chart_dir.mkdir(parents=True)
+
+        # Create tag.yaml
+        create_tag_yaml(chart_dir / "tag.yaml", "old-tag")
+
+        # Create values.yaml with override
+        with open(chart_dir / "values.yaml", "w") as f:
+            yaml.dump({"argocdApplication": {"appManifestsRevision": "feature-branch"}}, f)
+
+        # Create shared-values.yaml
+        with open(stack_dir / "shared-values.yaml", "w") as f:
+            yaml.dump({"cloudProvider": "gcp"}, f)
+
+        monkeypatch.chdir(tmp_path)
+
+        mock_env = {
+            "HELM_CHART": "test-chart",
+            "IMAGE_TAG": "production-new-tag",
+            "GH_TOKEN": "fake-token",
+            "AUTOMERGE": "true",
+            "DRY_RUN": "true",
+            "MULTI_STAGE": "false",
+            "TARGET_PATH": str(tmp_path),
+        }
+
+        config = EnvironmentConfig.from_env(mock_env)
+        mock_repo = Mock()
+        mock_github_repo = Mock()
+        io_layer = IOLayer(mock_repo, mock_github_repo, dry_run=True, approve_github_repo=Mock())
+
+        plan = prepare_plan(config, io_layer)
+
+        # Should have 2 file changes: tag.yaml + values.yaml
+        assert len(plan.file_changes) == 2
+        file_paths = [fc.file_path for fc in plan.file_changes]
+        assert f"{stack_name}/test-chart/tag.yaml" in file_paths
+        assert f"{stack_name}/test-chart/values.yaml" in file_paths
+
+        # PR should include both files
+        assert len(plan.pr_plans) == 1
+        assert f"{stack_name}/test-chart/values.yaml" in plan.pr_plans[0].files_to_commit
+
+    def test_plan_skips_override_removal_for_dev(self, tmp_path, monkeypatch):
+        """prepare_plan does NOT remove override when tag is dev."""
         # Set up a dev stack with tag.yaml and values.yaml with override
         stack_name = "dev-keboola-gcp-us-central1"
         stack_dir = tmp_path / stack_name
@@ -478,15 +526,9 @@ class TestOverrideIntegration:
 
         plan = prepare_plan(config, io_layer)
 
-        # Should have 2 file changes: tag.yaml + values.yaml
-        assert len(plan.file_changes) == 2
-        file_paths = [fc.file_path for fc in plan.file_changes]
-        assert f"{stack_name}/test-chart/tag.yaml" in file_paths
-        assert f"{stack_name}/test-chart/values.yaml" in file_paths
-
-        # PR should include both files
-        assert len(plan.pr_plans) == 1
-        assert f"{stack_name}/test-chart/values.yaml" in plan.pr_plans[0].files_to_commit
+        # Should have only 1 file change: tag.yaml (no override removal)
+        assert len(plan.file_changes) == 1
+        assert plan.file_changes[0].file_path == f"{stack_name}/test-chart/tag.yaml"
 
     def test_plan_without_override_has_only_tag_change(self, tmp_path, monkeypatch):
         """prepare_plan only has tag.yaml change when no override exists."""


### PR DESCRIPTION
Part of: https://linear.app/keboola/issue/ST-3803/zachovat-poradi-a-format-yaml-v-release-pr

## Release Notes 
Fix: `argocdApplication.appManifestsRevision` override removal now only triggers on production releases (`production-*` and semver tags), not on dev releases.

## Plans for customer communication
None.

## Impact analysis
Previously, dev deploys (`dev-*` tags) would strip `argocdApplication.appManifestsRevision` overrides from `values.yaml`, defeating the purpose of branch overrides used for testing. This fix restricts override removal to production strategy only.

## Change type
Bug fix

## Justification
Developers intentionally set branch overrides in dev stacks for testing. The override removal feature (PR #23) was too aggressive — it ran for all strategies instead of only production.

Linked task: [ST-3803]

## E2E tests
[Test Suite run (all green)](https://github.com/keboola/helm-image-updater-testing/actions/runs/24512650802)

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.