### PR TITLE
fix: preserve YAML key order, blank lines, and quote styles in release PRs

### DIFF
--- a/docs/superpowers/specs/2026-04-16-preserve-yaml-formatting-design.md
+++ b/docs/superpowers/specs/2026-04-16-preserve-yaml-formatting-design.md
@@ -1,0 +1,120 @@
+# Preserve YAML Order and Format in Release PRs
+
+**Linear:** ST-3803
+**Date:** 2026-04-16
+
+## Context
+
+When helm-image-updater creates release PRs that modify `tag.yaml` and `values.yaml` files, the resulting diffs show unwanted formatting changes alongside the actual value updates. This is caused by PyYAML's `dump()` which re-serializes YAML from scratch, destroying:
+
+- **Key ordering** — keys get alphabetically sorted
+- **Blank lines** — separators between logical sections are stripped
+- **Quote styles** — `"10m"` becomes `10m`, `"https://..."` becomes unquoted
+- **Comments** — any `#` comments are lost
+
+Example: [kbc-stacks commit f3efe45](https://github.com/keboola/kbc-stacks/commit/f3efe458f1e798c49051b5b7078ef374c1566804) — a simple tag update + override removal produced a massive diff reordering every key in `values.yaml`.
+
+## Approach
+
+Replace PyYAML with **ruamel.yaml** (round-trip mode) in all code paths that write YAML back to disk. ruamel.yaml preserves comments, key order, blank lines, and quote styles by default.
+
+Read-only YAML operations (`read_yaml()`, `read_shared_values_yaml()`) remain on PyYAML since they return plain dicts for consumption and never write back.
+
+## Changes
+
+### 1. `plan_builder.py` — `_calculate_all_changes()` (lines 193-217)
+
+**Before:** Reads file content as string, parses with `yaml.safe_load()`, applies changes to plain dict, re-serializes with `yaml.dump()`.
+
+**After:** Parse with `ruamel.yaml` round-trip loader, apply changes to the `CommentedMap` (which supports the same dict operations), serialize with `ruamel.yaml` dump to a `StringIO` to produce `new_content`.
+
+```python
+from ruamel.yaml import YAML
+from io import StringIO
+
+ryaml = YAML()
+ryaml.preserve_quotes = True
+
+# In _calculate_all_changes():
+current_data = ryaml.load(current_content)
+# ... calculate_tag_changes() and _apply_changes_to_data() work unchanged
+# ... (CommentedMap is a dict subclass)
+new_data = _apply_changes_to_data(current_data, changes)
+stream = StringIO()
+ryaml.dump(new_data, stream)
+new_content = stream.getvalue()
+```
+
+### 2. `plan_builder.py` — `_check_and_remove_override()` (lines 264-289)
+
+**Before:** Parses `values.yaml` with `yaml.safe_load()`, deletes the override key, re-serializes with `yaml.dump()`.
+
+**After:** Same pattern — parse with ruamel.yaml, delete the key, serialize preserving formatting.
+
+```python
+# In _check_and_remove_override():
+values_data = ryaml.load(values_content)
+# ... existing dict operations (get, del, isinstance) work unchanged
+stream = StringIO()
+ryaml.dump(new_data, stream)
+new_content = stream.getvalue()
+```
+
+### 3. `io_layer.py` — `write_file_changes()` (lines 112-122)
+
+**Before:** Re-parses `new_content` with `yaml.safe_load()` and re-dumps via `write_yaml()` — causing a second round of formatting destruction.
+
+**After:** Write `new_content` directly as text for all files (remove the YAML-specific branch). The `new_content` from `plan_builder.py` is already correctly formatted by ruamel.yaml.
+
+```python
+def write_file_changes(self, file_changes) -> bool:
+    if self.dry_run:
+        for file_change in file_changes:
+            print(f"[DRY RUN] Would write to {file_change.file_path}")
+        return False
+
+    for file_change in file_changes:
+        file_path = Path(file_change.file_path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open('w') as f:
+            f.write(file_change.new_content)
+
+    return True
+```
+
+### 4. `io_layer.py` — `write_yaml()` (line 94)
+
+Add `sort_keys=False` and `default_flow_style=False` as a safety net for any remaining callers:
+
+```python
+yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+```
+
+### 5. `requirements.txt`
+
+Add `ruamel.yaml>=0.18.0`. (`setup.py` reads from `requirements.txt` so no separate change needed.)
+
+## What stays unchanged
+
+- `calculate_tag_changes()` — pure function operating on dict interface, works with `CommentedMap`
+- `_apply_changes_to_data()` — uses `copy.deepcopy()` and dict operations, works with `CommentedMap`
+- `read_yaml()`, `read_shared_values_yaml()` — read-only, keep PyYAML
+- All model classes (`FileChange`, `UpdatePlan`, etc.) — unchanged
+- `plan_executor.py` — unchanged (calls `write_file_changes` which now just writes text)
+
+## Testing
+
+- Existing 74 unit tests must continue to pass
+- Test fixtures in `test_plan_builder.py` already create tag.yaml files with specific formatting (using `f.write()` with literal YAML) — these will verify round-trip preservation
+- Test fixtures in `test_cli_functional.py` use `yaml.dump()` to create files — these test that the tool handles PyYAML-formatted input correctly too
+- Add new tests verifying:
+  - Key order is preserved after tag update
+  - Blank lines are preserved after tag update
+  - Quoted values remain quoted after tag update
+  - Override removal preserves formatting of remaining keys in values.yaml
+
+## Verification
+
+1. Run `pytest -sv tests/` — all existing tests pass
+2. Run the tool with `DRY_RUN=true` against a real kbc-stacks checkout to verify formatting preservation
+3. Trigger E2E tests via `gh workflow run test-suite.yaml --repo keboola/helm-image-updater-testing --field helm-image-updater-branch=<branch>`

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -91,8 +91,8 @@ class IOLayer:
         file_path.parent.mkdir(parents=True, exist_ok=True)
         
         with file_path.open('w') as f:
-            yaml.dump(data, f)
-        
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
         return True
     
     def write_file_changes(self, file_changes) -> bool:
@@ -110,16 +110,10 @@ class IOLayer:
             return False
         
         for file_change in file_changes:
-            if file_change.file_path.endswith(('.yaml', '.yml')) and file_change.new_content.strip():
-                # For YAML files, parse and write properly
-                data = yaml.safe_load(file_change.new_content)
-                self.write_yaml(file_change.file_path, data)
-            else:
-                # For other files, write as text
-                file_path = Path(file_change.file_path)
-                file_path.parent.mkdir(parents=True, exist_ok=True)
-                with file_path.open('w') as f:
-                    f.write(file_change.new_content)
+            file_path = Path(file_change.file_path)
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            with file_path.open('w') as f:
+                f.write(file_change.new_content)
         
         return True
     

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -1,8 +1,14 @@
 """Plan builder - creates an execution plan from configuration."""
 
 import os
-import yaml
+from io import StringIO
 from typing import List, Dict, Any, Optional
+
+from ruamel.yaml import YAML, YAMLError
+
+# Module-level ruamel.yaml instance for round-trip (format-preserving) operations
+_ryaml = YAML()
+_ryaml.preserve_quotes = True
 
 from .models import UpdatePlan, FileChange, PRPlan, UpdateStrategy, TagChange
 from .environment import EnvironmentConfig
@@ -195,12 +201,12 @@ def _calculate_all_changes(plan: UpdatePlan, io_layer: IOLayer) -> List[Dict[str
             if current_content is None:
                 print(f"Warning: {tag_file_path} not found, skipping")
                 continue
-                
-            current_data = yaml.safe_load(current_content)
+
+            current_data = _ryaml.load(current_content)
         except Exception as e:
             print(f"Warning: Failed to read {tag_file_path}: {e}")
             continue
-        
+
         # Calculate changes
         changes = calculate_tag_changes(
             current_data=current_data,
@@ -208,13 +214,15 @@ def _calculate_all_changes(plan: UpdatePlan, io_layer: IOLayer) -> List[Dict[str
             extra_tags=plan.extra_tags,
             commit_sha=plan.metadata.get("commit_sha")
         )
-        
+
         if not changes:
             continue
-        
-        # Apply changes to create new content
+
+        # Apply changes to create new content (preserving formatting)
         new_data = _apply_changes_to_data(current_data, changes)
-        new_content = yaml.dump(new_data, default_flow_style=False, sort_keys=False)
+        stream = StringIO()
+        _ryaml.dump(new_data, stream)
+        new_content = stream.getvalue()
         
         # Create change description
         change_descriptions = []
@@ -262,8 +270,8 @@ def _check_and_remove_override(
         return None
 
     try:
-        values_data = yaml.safe_load(values_content)
-    except yaml.YAMLError as e:
+        values_data = _ryaml.load(values_content)
+    except YAMLError as e:
         print(f"Warning: could not parse {values_file_path}, skipping override check: {e}")
         return None
 
@@ -278,15 +286,18 @@ def _check_and_remove_override(
     if not revision or revision == "main":
         return None
 
-    import copy
-    new_data = copy.deepcopy(values_data)
-    del new_data["argocdApplication"]["appManifestsRevision"]
+    del values_data["argocdApplication"]["appManifestsRevision"]
 
     # If argocdApplication is now empty, remove the entire block
-    if not new_data["argocdApplication"]:
-        del new_data["argocdApplication"]
+    if not values_data["argocdApplication"]:
+        del values_data["argocdApplication"]
 
-    new_content = yaml.dump(new_data, default_flow_style=False, sort_keys=False) if new_data else ""
+    if values_data:
+        stream = StringIO()
+        _ryaml.dump(values_data, stream)
+        new_content = stream.getvalue()
+    else:
+        new_content = ""
 
     print(f"Detected appManifestsRevision override ({revision}) in {values_file_path}, will remove it")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML>=6.0
+ruamel.yaml>=0.18.0
 GitPython>=3.1.0
 PyGithub>=2.1.1
 dpath>=2.1.0

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -565,3 +565,160 @@ class TestOverrideIntegration:
         # Should have only 1 file change: tag.yaml
         assert len(plan.file_changes) == 1
         assert plan.file_changes[0].file_path == f"{stack_name}/test-chart/tag.yaml"
+
+
+class TestYamlFormattingPreservation:
+    """Tests that YAML formatting (key order, blank lines, quotes) is preserved."""
+
+    def test_tag_update_preserves_key_order(self):
+        """Tag update should not reorder keys in tag.yaml."""
+        mock_io = Mock()
+        # Deliberately non-alphabetical key order
+        original_content = (
+            "image:\n"
+            "  tag: old-tag\n"
+            "zebra: value\n"
+            "apple: value\n"
+        )
+        mock_io.read_file.return_value = original_content
+
+        from helm_image_updater.plan_builder import _calculate_all_changes
+        from helm_image_updater.models import UpdatePlan, UpdateStrategy
+
+        plan = UpdatePlan(
+            strategy=UpdateStrategy.DEV,
+            helm_chart="test-chart",
+            image_tag="dev-new-tag",
+        )
+        plan.target_stacks = ["dev-stack"]
+
+        changes = _calculate_all_changes(plan, mock_io)
+
+        assert len(changes) == 1
+        new_content = changes[0]['file_change'].new_content
+        lines = new_content.strip().split('\n')
+        # Keys should remain in original order: image, zebra, apple
+        top_level_keys = [l.split(':')[0] for l in lines if not l.startswith(' ')]
+        assert top_level_keys == ['image', 'zebra', 'apple']
+
+    def test_tag_update_preserves_blank_lines(self):
+        """Tag update should preserve blank lines between sections."""
+        mock_io = Mock()
+        original_content = (
+            "image:\n"
+            "  tag: old-tag\n"
+            "\n"
+            "resources:\n"
+            "  cpu: 100m\n"
+        )
+        mock_io.read_file.return_value = original_content
+
+        from helm_image_updater.plan_builder import _calculate_all_changes
+        from helm_image_updater.models import UpdatePlan, UpdateStrategy
+
+        plan = UpdatePlan(
+            strategy=UpdateStrategy.DEV,
+            helm_chart="test-chart",
+            image_tag="dev-new-tag",
+        )
+        plan.target_stacks = ["dev-stack"]
+
+        changes = _calculate_all_changes(plan, mock_io)
+
+        assert len(changes) == 1
+        new_content = changes[0]['file_change'].new_content
+        # Blank line between sections should be preserved
+        assert "\n\nresources:" in new_content
+
+    def test_tag_update_preserves_quoted_values(self):
+        """Tag update should not strip quotes from other values."""
+        mock_io = Mock()
+        original_content = (
+            'image:\n'
+            '  tag: old-tag\n'
+            '  repository: "keboola/my-service"\n'
+            'resources:\n'
+            '  cpu: "100m"\n'
+            '  memory: "256Mi"\n'
+        )
+        mock_io.read_file.return_value = original_content
+
+        from helm_image_updater.plan_builder import _calculate_all_changes
+        from helm_image_updater.models import UpdatePlan, UpdateStrategy
+
+        plan = UpdatePlan(
+            strategy=UpdateStrategy.DEV,
+            helm_chart="test-chart",
+            image_tag="dev-new-tag",
+        )
+        plan.target_stacks = ["dev-stack"]
+
+        changes = _calculate_all_changes(plan, mock_io)
+
+        assert len(changes) == 1
+        new_content = changes[0]['file_change'].new_content
+        # Quoted values should remain quoted
+        assert '"keboola/my-service"' in new_content
+        assert '"100m"' in new_content
+        assert '"256Mi"' in new_content
+
+    def test_override_removal_preserves_formatting(self):
+        """Override removal should preserve key order, blank lines, and quotes."""
+        mock_io = Mock()
+        original_content = (
+            'image:\n'
+            '  repository: "keboola/oauth-service"\n'
+            '\n'
+            'apiReplicaCount: 0\n'
+            'messengerConsumerReplicaCount: 0\n'
+            '\n'
+            'apiResources:\n'
+            '  requests:\n'
+            '    cpu: "10m"\n'
+            '    memory: "50Mi"\n'
+            '\n'
+            'argocdApplication:\n'
+            '  appManifestsRevision: feature-branch-123\n'
+        )
+        mock_io.read_file.return_value = original_content
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+
+        assert result is not None
+        new_content = result.new_content
+
+        # Key order preserved
+        lines = [l for l in new_content.split('\n') if l and not l.startswith(' ')]
+        top_keys = [l.split(':')[0] for l in lines]
+        assert top_keys == ['image', 'apiReplicaCount', 'messengerConsumerReplicaCount', 'apiResources']
+
+        # Quoted values preserved
+        assert '"10m"' in new_content
+        assert '"50Mi"' in new_content
+        assert '"keboola/oauth-service"' in new_content
+
+        # argocdApplication block removed
+        assert 'argocdApplication' not in new_content
+
+    def test_override_removal_preserves_other_argocd_fields_formatting(self):
+        """When argocdApplication has other fields, their formatting is preserved."""
+        mock_io = Mock()
+        original_content = (
+            'image:\n'
+            '  repository: "keboola/my-service"\n'
+            '\n'
+            'argocdApplication:\n'
+            '  appManifestsRevision: feature-branch\n'
+            '  syncPolicy: "automated"\n'
+        )
+        mock_io.read_file.return_value = original_content
+
+        result = _check_and_remove_override("dev-stack", "my-chart", mock_io)
+
+        assert result is not None
+        new_content = result.new_content
+
+        # syncPolicy should remain with its quoted value
+        assert '"automated"' in new_content
+        assert 'appManifestsRevision' not in new_content
+        assert 'argocdApplication' in new_content


### PR DESCRIPTION
## Release Notes 
Fixes YAML formatting preservation in release PRs. Previously, updating a tag or removing an override would reorder all keys alphabetically, strip blank lines between sections, and remove quote styles (e.g., `"10m"` → `10m`). Now only the actual value change appears in the diff.

## Plans for customer communication
None.

## Impact analysis
- Replaces PyYAML with `ruamel.yaml` (round-trip mode) for all YAML write paths in `plan_builder.py`
- Simplifies `io_layer.py` `write_file_changes()` to write pre-formatted content directly instead of re-parsing YAML
- Read-only YAML operations remain on PyYAML (no change)
- All 79 tests pass (74 existing + 5 new formatting preservation tests)

## Change type
Bug fix

## Justification
Release PRs were producing massive diffs due to PyYAML's `dump()` destroying formatting. Example: [kbc-stacks commit f3efe45](https://github.com/keboola/kbc-stacks/commit/f3efe458f1e798c49051b5b7078ef374c1566804) — a simple tag update + override removal reordered every key in `values.yaml`.

[ST-3803](https://linear.app/keboola/issue/ST-3803)

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.

## E2E tests
https://github.com/keboola/helm-image-updater-testing/actions/runs/24530400309 — all 9 tests passed, including `override-removal-with-values` with the enriched fixture (comments, blank lines, quoted values).