### PR TITLE
fix: include ruamel.yaml in sdist packaging (production hotfix)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,13 @@ if requirements_file.exists():
     with open(requirements_file, encoding="utf-8") as f:
         requirements = f.read().splitlines()
 else:
-    # Default requirements if file is not found
+    # Default requirements if file is not found.
+    # IMPORTANT: Keep this list in sync with requirements.txt — when pip
+    # installs from an sdist, requirements.txt may not be present, so pip
+    # falls back to this list when building metadata.
     requirements = [
         "PyYAML>=6.0",
+        "ruamel.yaml>=0.18.0",
         "GitPython>=3.1.0",
         "PyGithub>=2.1.1",
         "dpath>=2.1.0",


### PR DESCRIPTION
## Release Notes 
Fixes production failure in v0.11.2 where `helm-image-updater` crashed with `ModuleNotFoundError: No module named 'ruamel'`.

## Plans for customer communication
None.

## Impact analysis
Root cause: the sdist (`helm_image_updater-*.tar.gz`) didn't include `requirements.txt`, so when pip rebuilt the wheel from the tarball, `setup.py` fell back to a hardcoded requirements list that was missing `ruamel.yaml`.

Two complementary fixes:
1. **`MANIFEST.in`** — ensures `requirements.txt` is shipped in the sdist (primary fix)
2. **`setup.py` fallback** — adds `ruamel.yaml>=0.18.0` to the hardcoded fallback list (safety net)

Verified by building the sdist locally, installing in a clean venv, and confirming pip resolves `ruamel.yaml>=0.18.0` as a dependency.

## Change type
Bug fix (production hotfix)

## Justification
Production failure in https://github.com/keboola/kbc-stacks/actions/runs/24553336920:
```
ModuleNotFoundError: No module named 'ruamel'
```
This blocks all releases using the latest `helm-image-updater` action.

[ST-3803](https://linear.app/keboola/issue/ST-3803)

## Deployment
Merge & release a new patch version. Releases are triggered by the existing release workflow.

## Rollback plan
Revert of this PR + revert of #29 (the ruamel.yaml introduction).

## Post release support plan
Monitor next production deployment to confirm fix.