### PR TITLE
feat: DEPLOY_STRATEGY + wave PRs for release-promoter (ST-4034)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Optional:
 
 - `AUTOMERGE`: Whether to automatically merge PRs (default: "true", note: canary updates are always auto-merged). When set to `false`, PRs are auto-approved by the machine user instead, satisfying CODEOWNERS requirements so humans can merge without waiting for additional reviews.
 - `DRY_RUN`: Whether to perform a dry run (default: "false")
-- `MULTI_STAGE`: Enable multi-stage deployment (default: "false")
+- `MULTI_STAGE`: Enable multi-stage deployment (default: "false"). **Deprecated** — alias for `DEPLOY_STRATEGY=cloud_multi_stage`; prefer `DEPLOY_STRATEGY`.
+- `DEPLOY_STRATEGY`: Rollout strategy (default: "standard"): `standard`, `cloud_multi_stage`, `gradual`, `critical`, or `critical-manual-gate`. See [Deploy Strategies](#deploy-strategies).
 - `TARGET_PATH`: Path to the directory containing the stacks (default: ".")
 - `OVERRIDE_STACK`: Stack ID to explicitly target for the update, bypassing automatic stack selection (default: None)
 - `EXTRA_TAG1`, `EXTRA_TAG2`: Additional tags to update (format: "path:value")
@@ -89,6 +90,7 @@ Minimal usage example:
     automerge: "true"
     dry-run: "false"
     multi-stage: "false"
+    deploy-strategy: ""  # standard | cloud_multi_stage | gradual | critical | critical-manual-gate
     override-stack: "dev-keboola-gcp-us-central1"
     extra-tag1: "agent.image.tag:dev-2.0.0"
     extra-tag2: "messenger.image.tag:dev-2.0.0"
@@ -123,10 +125,15 @@ on:
         type: boolean
         default: false
       multi-stage:
-        description: "Enable multi-stage deployment (auto-merge dev, manual prod)"
+        description: "Enable multi-stage deployment (auto-merge dev, manual prod). Deprecated alias for deploy-strategy=cloud_multi_stage."
         required: false
         type: boolean
         default: false
+      deploy-strategy:
+        description: "Rollout strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate"
+        required: false
+        type: string
+        default: ''
       override-stack:
         description: "Stack ID to explicitly target for the update, bypassing automatic stack selection."
         required: false
@@ -179,6 +186,7 @@ jobs:
           automerge: ${{ inputs.automerge }}
           dry-run: ${{ inputs.dry-run }}
           multi-stage: ${{ inputs.multi-stage }}
+          deploy-strategy: ${{ inputs.deploy-strategy }}
           override-stack: ${{ inputs.override-stack }}
           extra-tag1: ${{ inputs.extra-tag1 }}
           extra-tag2: ${{ inputs.extra-tag2 }}
@@ -257,12 +265,27 @@ If `argocdApplication` only contained `appManifestsRevision`, the entire block i
 # (empty file)
 ```
 
-## Multi-Stage Deployment
+## Deploy Strategies
 
-When `MULTI_STAGE=true`:
+`DEPLOY_STRATEGY` (action input `deploy-strategy`, default `standard`) selects how a production update is fanned out into PRs and who merges them. It supersedes the older boolean `MULTI_STAGE` flag.
 
-1. Creates and auto-merges PR for dev stacks (if automerge is also true, otherwise won't merge the dev PR)
-2. Creates a separate PR (without auto-merge) for production stacks
+| `DEPLOY_STRATEGY` | grouping | `AUTOMERGE=true` | `AUTOMERGE=false` |
+|---|---|---|---|
+| `standard` (default) | one PR (per-stack for a production tag) | merge the PR(s) | leave unmerged (per-stack) |
+| `cloud_multi_stage` | dev + prod PRs per cloud | merge dev, leave prod | leave all unmerged |
+| `gradual` · `critical` · `critical-manual-gate` | 4 unmerged **wave** PRs (waves 0–3) | *(ignored — release-promoter merges)* | *(release-promoter merges)* |
+
+### New vs. old parameters
+
+- **`DEPLOY_STRATEGY` is the single knob.** Unset (= `standard`) keeps today's behavior — existing deploys are unaffected.
+- **`MULTI_STAGE=true` is a deprecated alias for `DEPLOY_STRATEGY=cloud_multi_stage`** — identical behavior, kept for backward compatibility. If both are set, the explicit `DEPLOY_STRATEGY` wins.
+- **`AUTOMERGE`** still controls merging for `standard` and `cloud_multi_stage`. For the wave strategies (`gradual` / `critical` / `critical-manual-gate`) it is **ignored** — those PRs are always created unmerged and merged later by release-promoter.
+
+### Wave strategies (release-promoter)
+
+`gradual`, `critical`, and `critical-manual-gate` emit 4 unmerged PRs labeled `release:id:<id>`, `release:wave:<0-3>`, and `deploy:<strategy>`. [release-promoter](https://github.com/keboola/release-promoter) merges them wave-by-wave (0 → 3) as each wave syncs, passes UAT, and soaks; `critical-manual-gate` additionally waits for a human gate before the later waves. helm-image-updater itself never merges wave PRs (it still auto-approves them).
+
+> **Prerequisite (wave strategies):** the deploy token needs `Issues: write` (PR labels go through the Issues API), and release-promoter's merge identity needs `Contents: write` + `Pull requests: write` and must be a bypass actor on the target branch's ruleset.
 
 ## Development
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,7 +22,7 @@ inputs:
   deploy-strategy:
     description: 'Promoter deploy strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate'
     required: false
-    default: 'standard'
+    default: ''
   commit-sha:
     description: 'Store commit SHA in tag.yaml'
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: 'Enable multi-stage deployment'
     required: false
     default: 'false'
+  deploy-strategy:
+    description: 'Promoter deploy strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate'
+    required: false
+    default: 'standard'
   commit-sha:
     description: 'Store commit SHA in tag.yaml'
     required: false
@@ -89,9 +93,10 @@ runs:
         AUTOMERGE: ${{ inputs.automerge }}
         DRY_RUN: ${{ inputs.dry-run }}
         MULTI_STAGE: ${{ inputs.multi-stage }}
+        DEPLOY_STRATEGY: ${{ inputs.deploy-strategy }}
         EXTRA_TAG1: ${{ inputs.extra-tag1 }}
         EXTRA_TAG2: ${{ inputs.extra-tag2 }}
-        OVERRIDE_STACK: ${{ inputs.override-stack }}        
+        OVERRIDE_STACK: ${{ inputs.override-stack }}
         METADATA: ${{ inputs.metadata }}
         GH_TOKEN: ${{ inputs.github-token }}
         GH_APPROVE_TOKEN: ${{ inputs.approve-token }}

--- a/deploy-strategy-promoter-integration.md
+++ b/deploy-strategy-promoter-integration.md
@@ -73,7 +73,7 @@ DEPLOY_STRATEGY = standard (default) | cloud_multi_stage | gradual | critical | 
 
 | `DEPLOY_STRATEGY` | grouping | `AUTOMERGE=true` | `AUTOMERGE=false` / unset | promoter labels |
 |---|---|---|---|---|
-| **standard** (default) | **single PR**, all target stacks | merge the 1 PR | **1 PR, unmerged** (auto-approved) | none |
+| **standard** (default) | single PR — except prod + `AUTOMERGE=false` → **per-stack** | merge the 1 PR | **per-stack** unmerged PRs, auto-approved (dev / single-stack / override → 1 PR) | none |
 | **cloud_multi_stage** | cloud×stage PRs (≤6) | dev PRs merge, prod PRs never | all unmerged | none |
 | **gradual / critical / critical-manual-gate** | per-wave PRs (0–3) | *(ignored)* — promoter merges all | promoter merges all | `release:id` · `release:wave:N` · `deploy:<strategy>` |
 
@@ -84,7 +84,7 @@ There are **no nonsensical combinations**: `AUTOMERGE` is simply ignored where t
 - Wave mode **ignores `AUTOMERGE`** — promoter merges all waves incl. wave 0. (Auto-merging wave 0 in
   HIU would bypass promoter's per-app FIFO gate, so two concurrent same-app releases could hit dev out
   of order. Deferred as a possible explicit opt-in later.)
-- `standard` + `AUTOMERGE=false` → **one unmerged PR** (not per-stack). See §6 (behavior change).
+- `standard` keeps today's HIU grouping (no change): `AUTOMERGE=true` / dev / single-stack / override → one PR; prod + `AUTOMERGE=false` → one PR **per stack**.
 - `MULTI_STAGE=true` becomes a **deprecated alias** for `DEPLOY_STRATEGY=cloud_multi_stage`
   (behavior identical). If both are set and disagree, `DEPLOY_STRATEGY` wins + a warning is logged.
 
@@ -151,8 +151,8 @@ PR #19 (`kacurez-grouping-strategy`) is **superseded** — we salvage only its c
   wave-mode-requires-prod-tag validation.
 - **`plan_builder.py`**: replace the strategy-tangled `_group_changes_for_prs()` (lines 401–490) with a
   small dispatch keyed on `config.deploy_strategy`:
-  - `STANDARD` → single PR (all target stacks), `pr_type='standard'`. *(automerge=false now → still one
-    PR, just unmerged.)*
+  - `STANDARD` → today's HIU grouping, unchanged (`pr_type='standard'`): one PR for `automerge=true` /
+    dev / single-stack / override; one PR **per stack** for prod + `automerge=false`.
   - `CLOUD_MULTI_STAGE` → today's cloud×stage grouping (moved verbatim), `pr_type='multi_stage_{dev|prod}'`.
   - `GRADUAL|CRITICAL|CRITICAL_MANUAL_GATE` → one group per wave `w` with ≥1 change, `pr_type='wave'`,
     plus `wave_number=w`, `release_id`, and `labels=[release:id:…, release:wave:w, deploy:…]`.
@@ -175,7 +175,7 @@ PR #19 (`kacurez-grouping-strategy`) is **superseded** — we salvage only its c
 | Path | Today | After |
 |---|---|---|
 | `standard` + `AUTOMERGE=true` (prod) | single PR, merged | **unchanged** |
-| `standard` + `AUTOMERGE=false` (prod) | **per-stack** PRs (≈20) | **one unmerged PR** ⚠️ |
+| `standard` + `AUTOMERGE=false` (prod) | **per-stack** PRs | **unchanged** |
 | dev tag | single PR, merged | **unchanged** |
 | canary | single PR, merged | **unchanged** |
 | `MULTI_STAGE=true` | cloud×stage | **unchanged** (now via `cloud_multi_stage` alias) |

--- a/deploy-strategy-promoter-integration.md
+++ b/deploy-strategy-promoter-integration.md
@@ -93,7 +93,15 @@ There are **no nonsensical combinations**: `AUTOMERGE` is simply ignored where t
   (a typo like `gradul` with `AUTOMERGE=true` must not quietly merge everywhere).
 - `DEPLOY_STRATEGY ∈ {gradual, critical, critical-manual-gate}` requires a production/semver tag
   (`UpdateStrategy.PRODUCTION`). With a dev/canary tag or `OVERRIDE_STACK`, it is a config error
-  (`validate()` returns a message). `cloud_multi_stage` keeps today's production-only rule.
+  (`validate()` returns a message). Wave mode also requires `IMAGE_TAG` (not just an `EXTRA_TAG`).
+- `cloud_multi_stage` is production-only by the **same mechanism as today's `MULTI_STAGE`**: the
+  cloud×stage grouping only fires for a production strategy (the existing `strategy==PRODUCTION` guard
+  in grouping). There is **no new validation error** for `cloud_multi_stage` on a non-prod tag — that
+  would be stricter than today, which silently no-ops multi-stage for non-prod.
+- **Action input default is empty** (`deploy-strategy: ''`), not `standard`: the GitHub Action always
+  passes the input through, and a non-empty `DEPLOY_STRATEGY` is treated as *explicit* (overriding
+  `MULTI_STAGE`). An empty default lets legacy `multi-stage: true` callers keep aliasing to
+  `cloud_multi_stage`; `from_env` maps empty → unset → `standard`.
 
 ## 4. Wave→stack mapping: `rollout_wave`
 
@@ -159,7 +167,8 @@ PR #19 (`kacurez-grouping-strategy`) is **superseded** — we salvage only its c
   (`io_layer.py:240`). Both intermediate signatures currently take **no** `labels` arg — add it. In
   `create_pull_request()`: **provision** the labels (create-if-missing, §2) then **apply** them
   (`pr.add_to_labels`/`set_labels`) regardless of auto-merge; keep the existing auto-approve path. The
-  **dry-run** output (and `ExecutionResult`) must surface the labels that *would* be applied.
+  **dry-run** output prints the labels that *would* be applied (per PR). (No `ExecutionResult.labels`
+  field — nothing consumes it; the dry-run print is the observable output.)
 
 ## 6. Behavior changes vs today (explicit)
 

--- a/deploy-strategy-promoter-integration.md
+++ b/deploy-strategy-promoter-integration.md
@@ -1,0 +1,288 @@
+# Deploy strategies & release-promoter integration
+
+**Status:** design (spec) · **Issue:** [ST-4034](https://linear.app/keboola/issue/ST-4034) · **Date:** 2026-06-05
+
+## 1. Goal
+
+Teach `helm-image-updater` (HIU) to emit the PRs that `release-promoter` consumes, so promoter
+can stage a rollout across waves — **without breaking any current deploy**. Today HIU creates and
+auto-merges PRs itself; promoter never sees a contract it understands. After this change, a deploy
+launched with a *promoter strategy* produces a set of **wave PRs, created up front and left
+unmerged**, carrying the labels promoter reads; promoter then merges them wave-by-wave as each soaks
+and verifies.
+
+The promoter label contract is the source of truth — see
+`release-promoter/DESIGN.md` §2 (labels), §2 (strategy parameters), §2 (waves→stacks). This spec
+only describes the **HIU** side (plus the `rollout_wave` metadata and the integration test).
+
+## 2. The promoter contract HIU must satisfy
+
+A **release** = the set of wave PRs in the stacks repo sharing one `release:id:<releaseId>` label,
+all created up front by HIU (one chart, one new image tag, fanned out per wave). One release rolls
+out **one app**. Per the contract:
+
+- **Waves are fixed `0..3`.** Wave 3 is the canonical `PRlast` promoter anchors discovery on. Wave 0
+  is the dev wave (no UAT, soak 0).
+- Each wave PR edits **only** the `tag.yaml` files for that wave's stacks (`{stack}/{app}/tag.yaml`).
+  Promoter derives a wave's membership from the PR diff; the `release:wave:N` label gives ordering.
+- Labels HIU sets on **every** wave PR:
+  - `release:id:<releaseId>` — opaque grouping key (see below).
+  - `release:wave:N` — `N ∈ {0,1,2,3}`.
+  - `deploy:<strategy>` — `gradual | critical | critical-manual-gate`.
+
+  **`releaseId` construction & the label-length limit.** GitHub caps label names at **50 characters**,
+  and the `release:id:` prefix already eats 11. A naive `<chart>-<image_tag>` (e.g.
+  `connection-production-<40-hex-sha>` ≈ 58 chars) **overflows**. Since promoter treats `release:id`
+  as **opaque** — it gets the app for per-app FIFO from the PR diff, not by parsing the label
+  (DESIGN §2) — `releaseId` only has to be (a) **identical across all wave PRs of one release** and
+  (b) **unique per release**. So HIU builds a **compact** id that fits: `<chart>-<short>` where
+  `<short>` is a stable, collision-resistant slug of the image tag (e.g. a truncated content hash, or
+  the tag's trailing short-sha), with the whole label kept under the limit (unit-tested). The exact
+  slug scheme is an implementation detail; the invariants (fits, stable, unique, same across waves) are
+  the contract.
+- **Label provisioning (create-if-missing).** Applying a label name that does not yet exist in the repo
+  is not guaranteed to auto-create it via the GitHub API. HIU must **ensure each label exists before
+  applying it**: the fixed `release:wave:0..3` and `deploy:*` labels can be pre-created (idempotent
+  "create if absent, tolerate already-exists"); the **dynamic `release:id:<releaseId>`** label must be
+  created on demand the same way. (Confirm the exact GitHub `add-labels` behavior during
+  implementation; provision defensively regardless.)
+- **Idempotency (re-running HIU must not corrupt a release).** A retried workflow must **not** create a
+  *second* set of four wave PRs with the same `release:id` — duplicate `release:wave:N` makes the
+  release `¬wellFormed` and promoter holds it **`Conflicted`** (verified in
+  `release-promoter/src/core/interpret/shape.ts`). Before creating wave PRs, HIU **searches existing
+  (open) PRs by `release:id:<releaseId>`**; if a release with that id already exists it **no-ops/reuses**
+  (or fails loudly with a recoverable message) — never silently fans out duplicates.
+- **HIU never merges a wave PR — including wave 0.** Promoter owns every merge (gated by per-app
+  FIFO). HIU still **auto-approves** the PRs (confirmed: `io_layer.py:344 _auto_approve_pr`, called for
+  unmerged PRs today). **Note:** auto-approve ≠ authorization to merge under branch-protection rulesets
+  — promoter's merge identity must itself be permitted to merge the auto-approved wave PR (see §7).
+- HIU sets **none** of the `promoter:*` labels (those are promoter's, written from observed reality).
+
+The three strategies are **identical from HIU's point of view** — same wave PRs, same labels; only the
+`deploy:*` value differs. All soak timing, UAT gating, and the manual gate live entirely in promoter.
+
+## 3. Public interface: `DEPLOY_STRATEGY`
+
+One new knob. Action input `deploy-strategy` → env `DEPLOY_STRATEGY`:
+
+```
+DEPLOY_STRATEGY = standard (default) | cloud_multi_stage | gradual | critical | critical-manual-gate
+```
+
+`AUTOMERGE` stays a secondary modifier whose meaning depends on the mode:
+
+| `DEPLOY_STRATEGY` | grouping | `AUTOMERGE=true` | `AUTOMERGE=false` / unset | promoter labels |
+|---|---|---|---|---|
+| **standard** (default) | **single PR**, all target stacks | merge the 1 PR | **1 PR, unmerged** (auto-approved) | none |
+| **cloud_multi_stage** | cloud×stage PRs (≤6) | dev PRs merge, prod PRs never | all unmerged | none |
+| **gradual / critical / critical-manual-gate** | per-wave PRs (0–3) | *(ignored)* — promoter merges all | promoter merges all | `release:id` · `release:wave:N` · `deploy:<strategy>` |
+
+There are **no nonsensical combinations**: `AUTOMERGE` is simply ignored where the mode owns merging
+(wave strategies; multi-stage prod).
+
+**Decisions baked in (from brainstorming):**
+- Wave mode **ignores `AUTOMERGE`** — promoter merges all waves incl. wave 0. (Auto-merging wave 0 in
+  HIU would bypass promoter's per-app FIFO gate, so two concurrent same-app releases could hit dev out
+  of order. Deferred as a possible explicit opt-in later.)
+- `standard` + `AUTOMERGE=false` → **one unmerged PR** (not per-stack). See §6 (behavior change).
+- `MULTI_STAGE=true` becomes a **deprecated alias** for `DEPLOY_STRATEGY=cloud_multi_stage`
+  (behavior identical). If both are set and disagree, `DEPLOY_STRATEGY` wins + a warning is logged.
+
+**Validation:**
+- An **unknown** `DEPLOY_STRATEGY` is a **hard config error** — never a silent fall-back to `standard`
+  (a typo like `gradul` with `AUTOMERGE=true` must not quietly merge everywhere).
+- `DEPLOY_STRATEGY ∈ {gradual, critical, critical-manual-gate}` requires a production/semver tag
+  (`UpdateStrategy.PRODUCTION`). With a dev/canary tag or `OVERRIDE_STACK`, it is a config error
+  (`validate()` returns a message). `cloud_multi_stage` keeps today's production-only rule.
+
+## 4. Wave→stack mapping: `rollout_wave`
+
+Per-stack, in each stack's `stack-metadata.yaml`. A flat key:
+
+```yaml
+# <stack>/stack-metadata.yaml
+rollout_wave: 1        # integer 0..3
+```
+
+**Where it lives today:** kbc-stacks already has `stack-metadata.yaml` in (almost) every stack dir, so
+production stacks gain the `rollout_wave` key in their existing file (user-authored). The
+**helm-image-updater-testing repo has *no* `stack-metadata.yaml` files at all** (verified: 0 present,
+only `shared-values.yaml`) — so **PR-B creates them** for the mock stacks. HIU's reader must therefore
+**tolerate an absent file/field** and fall back to the default below.
+
+**The single wave-assignment rule** (resolves the dev-vs-default ambiguity):
+
+> `wave(stack)` = explicit `rollout_wave` from `stack-metadata.yaml` if present; otherwise a
+> **classification-aware default**: dev stacks (`classify_stack().is_dev`) → **0**, all other stacks →
+> **3**. An explicit `rollout_wave` always wins.
+
+So a dev stack with no metadata still lands in wave 0, and an unclassified production stack rolls out
+last (wave 3) — no per-dev-stack metadata is *required*, but an explicit value is honored.
+
+- **Wave-mode target universe** = all discovered stacks that have the app's `{stack}/{app}/tag.yaml`,
+  **excluding** canary, excluded, and `*-e2e` stacks (today's production exclusions) — but **including**
+  the dev stacks (they become wave 0). Each target stack is assigned `wave(stack)` per the rule above.
+
+**Edge cases:**
+- Promoter requires waves **contiguous from 0** (verified: `interpret/shape.ts` rejects gaps), and wave
+  3 must exist (`PRlast`). So HIU **requires all of waves 0..3 to be non-empty** for a valid wave deploy
+  and **fails loud** otherwise (rather than emitting a gapped `{0,1,3}` that promoter would hold
+  `Conflicted`).
+- A target stack has no `{stack}/{app}/tag.yaml` (app not deployed there) — skip that stack.
+
+## 5. Internal architecture (refactor, inspired by PR #19)
+
+PR #19 (`kacurez-grouping-strategy`) is **superseded** — we salvage only its core idea (separate
+*how many PRs* from *do we merge*) and rebuild it around `DEPLOY_STRATEGY`. Close #19. Changes:
+
+- **`models.py`**: add `class DeployStrategy(Enum)` = `STANDARD | CLOUD_MULTI_STAGE | GRADUAL |
+  CRITICAL | CRITICAL_MANUAL_GATE`. Add `PRPlan.labels: List[str] = field(default_factory=list)`.
+  Optionally add `wave_number`/`release_id` to the PR-group dicts.
+- **`environment.py`**: parse `DEPLOY_STRATEGY` (default `standard`; **unknown → hard validation
+  error**, never a silent `standard` fall-back); fold the `MULTI_STAGE` alias; add the
+  wave-mode-requires-prod-tag validation.
+- **`plan_builder.py`**: replace the strategy-tangled `_group_changes_for_prs()` (lines 401–490) with a
+  small dispatch keyed on `config.deploy_strategy`:
+  - `STANDARD` → single PR (all target stacks), `pr_type='standard'`. *(automerge=false now → still one
+    PR, just unmerged.)*
+  - `CLOUD_MULTI_STAGE` → today's cloud×stage grouping (moved verbatim), `pr_type='multi_stage_{dev|prod}'`.
+  - `GRADUAL|CRITICAL|CRITICAL_MANUAL_GATE` → one group per wave `w` with ≥1 change, `pr_type='wave'`,
+    plus `wave_number=w`, `release_id`, and `labels=[release:id:…, release:wave:w, deploy:…]`.
+  - Canary tag → canary grouping as today (independent of `DEPLOY_STRATEGY`).
+- **`_should_auto_merge(deploy_strategy, pr_type, user_requested)`** (lines 600–616): canary → `True`;
+  `pr_type='wave'` → `False`; `pr_type='multi_stage_prod'` → `False`; else → `user_requested`.
+- **`_create_pr_plan()`** (lines 493–586): wave branch/title carry the wave + release id (e.g.
+  `…-wave1-…`, title `[gradual wave 1] <chart>@<tag> …`); set `PRPlan.labels` from the group.
+- **Label plumbing — the full path, not just `create_pull_request`.** Labels must be threaded through
+  every layer: `PRPlan.labels` → `plan_executor._execute_pr_plans()` (≈`plan_executor.py:69`) →
+  `io_layer.create_branch_commit_and_pr()` (`io_layer.py:378`) → `create_pull_request()`
+  (`io_layer.py:240`). Both intermediate signatures currently take **no** `labels` arg — add it. In
+  `create_pull_request()`: **provision** the labels (create-if-missing, §2) then **apply** them
+  (`pr.add_to_labels`/`set_labels`) regardless of auto-merge; keep the existing auto-approve path. The
+  **dry-run** output (and `ExecutionResult`) must surface the labels that *would* be applied.
+
+## 6. Behavior changes vs today (explicit)
+
+| Path | Today | After |
+|---|---|---|
+| `standard` + `AUTOMERGE=true` (prod) | single PR, merged | **unchanged** |
+| `standard` + `AUTOMERGE=false` (prod) | **per-stack** PRs (≈20) | **one unmerged PR** ⚠️ |
+| dev tag | single PR, merged | **unchanged** |
+| canary | single PR, merged | **unchanged** |
+| `MULTI_STAGE=true` | cloud×stage | **unchanged** (now via `cloud_multi_stage` alias) |
+| wave strategies | — | **new**: wave PRs + labels, promoter-merged |
+
+⚠️ The only change to an existing deploy path. It is desired (kills the 20-PR explosion) but it
+**changes production `automerge=false` behavior**. Concrete blast radius (verified):
+- **HIU-testing** `dont-merge` scenario currently asserts `expected_count: 9` (per-stack)
+  (`test-suite.yaml:149`) → must become **1 PR** (+ the same 9 modified `tag.yaml` files). Updated in PR-B.
+- **HIU unit tests** don't currently assert prod `automerge=false` grouping at all
+  (`test_plan_builder.py:245` only covers `automerge=True`), so a new test is *added*, none rewritten.
+
+## 7. Non-goals (out of scope)
+
+- No `release-promoter` code changes — only a DESIGN.md note dropping the "HIU is not modified" MVP
+  caveat (§2).
+- No HIU-side soak/UAT/merge logic — promoter owns all of that.
+- No `SINGLE`/`STACK` grouping strategies from PR #19 (not needed).
+- HIU does not write `rollout_wave` data for production; the mapping is authored in kbc-stacks (the
+  test mocks' `stack-metadata.yaml` files **are** created here, in PR-B).
+- Auto-merge-wave-0 fast path: deferred.
+
+**External prerequisite (not built here, but must hold):** promoter's merge identity must be authorized
+to merge an auto-approved wave PR under branch-protection/CODEOWNERS rulesets — in production (the
+promoter GitHub App) and in HIU-testing (the workflow `GITHUB_TOKEN`). The integration test surfaces
+this as an explicit precondition (§8b.5).
+
+## 8. Testing
+
+### 8a. HIU unit tests (strict TDD — failing test first)
+
+- `DEPLOY_STRATEGY` parsing + `MULTI_STAGE` alias; **unknown value → validation error** (not `standard`);
+  wave-mode-requires-prod-tag validation.
+- Grouping: wave splits target stacks by `wave(stack)` (explicit `rollout_wave`, else dev→0 / other→3);
+  all-waves-0..3-non-empty rule (gapped → error); `standard` always one PR **including
+  `automerge=false`** (new test — was uncovered); `cloud_multi_stage` parity with old multi-stage;
+  canary unchanged.
+- `_should_auto_merge`: `wave→False`, `multi_stage_prod→False`, `canary→True`, else passthrough.
+- Labels (**invariants, not a literal string** — `releaseId` is compacted, §2): each wave PR carries a
+  `release:id:*`, a `release:wave:N`, and a `deploy:<strategy>` label; the `release:id` label is
+  **≤ GitHub's 50-char limit**, **identical across all 4 wave PRs** of a run, and **distinct** for
+  different `<chart>/<tag>` inputs; non-wave PRs get no promoter labels.
+- **Idempotency**: re-running the same wave deploy does not produce a second set of wave PRs (search by
+  `release:id` → reuse/no-op or loud recoverable error).
+- `rollout_wave` reader: default rule (dev→0, other→3), explicit value wins, missing-file tolerated,
+  integer coercion/validation.
+- Label plumbing reaches the executor + `create_branch_commit_and_pr` + dry-run output (not only
+  `_create_pr_plan`).
+
+### 8b. HIU-testing integration test (PR-B): **full gradual soak progression**
+
+**Mocks (created in PR-B):** add a `stack-metadata.yaml` with `rollout_wave: 0..3` to the 11 testing
+stacks so `dummy-service` spans all four waves (≥1 `dummy-service` stack per wave; dev stacks → wave 0;
+all of 0..3 non-empty).
+
+**Why a multi-tick state machine (not one tick per wave).** Verified against the promoter core: a
+single tick sets `promoter:synced` and triggers UAT, but the **latch *timestamp* is read from the
+label on a *subsequent* tick** (`interpret/shape.ts` reads `labelTimestamps[SYNCED]`; `verify.ts`
+sets the label this tick), and promotion's soak check compares `now − latchAt` (`promote.ts:106-109`).
+So synced→uat→verified→promote spans **several ticks**, and the **fake `world.clock` must be
+re-anchored to ≥ the real label time** before soak can elapse (even soak-0: `now < latchAt` ⇒ blocked).
+
+Scenario, added to `test-suite.yaml` (gated like the existing promoter smoke step):
+
+1. **Trigger HIU** `deploy-strategy=gradual` on `dummy-service` with a `production-<random>` tag →
+   assert exactly **4 wave PRs** (waves 0–3), each unmerged, with the correct `release:id` /
+   `release:wave:N` / `deploy:gradual` labels and correct per-wave stack membership.
+2. **Drive promoter** (Docker image, `--source live-only-github` — real GitHub + faked
+   argo/clock/slack via `world.json`, **real** commit-ancestry) in a harness loop (node script,
+   matching the existing `test-suite/*.js` pattern). The loop is a **state machine** with these moves
+   between ticks (each "tick" = one `reconcile` run; `saveWorld()` persists clock/world mutations):
+   - **Init**: `world.json` `clock = <real now>`, empty `appStatuses`/`uatRuns`. Tick → merges **wave 0**
+     (FIFO-active, no predecessor gate).
+   - **After any merge** of wave `w`: `git fetch`; set each `<app>-<stack>` of wave `w` to
+     `{ status:'Synced', health:'Healthy', syncedRevision: <origin/main HEAD> }` (a real commit ≥ the
+     merge commit, so real ancestry resolves *ahead*). Tick → promoter latches `promoter:synced@w`
+     (and, for `w>0`, emits `RunUAT`).
+   - **For `w>0`**: set `uat-<stack>` runs to `{ phase:'Succeeded', revision: <≥ merge commit> }`
+     — **note the UAT shape has no `health` field** (`UatRun = {stack, revision, phase}`). Tick →
+     promoter latches `promoter:uat-passed@w`. (Wave `w` is now *Verified* as of this label.)
+   - **Soak/promote**: re-anchor the clock to capture the real latch time, then jump past the soak —
+     `promoter dev set-clock now` **then** `promoter dev advance-clock <soakAfter[gradual][w] + ε>`
+     (gradual: 1h after w1, 1h after w2; w0 & w3 soak 0). Tick → promoter merges wave `w+1`.
+   - Repeat for waves 1→2→3. After wave 3 is Verified (soak 0), the next tick sets
+     **`promoter:complete`** on the wave-3 PR.
+3. **Assertions**: each wave merges only after its predecessor is Done; waves merge **in order**; the
+   release reaches `promoter:complete`; **bounded** tick budget (fail if it stalls — guards against the
+   clock-not-re-anchored trap above).
+4. **Regression**: the must-not-merge guard (PR #1487) still holds for the `standard` scenarios; update
+   the `dont-merge` scenario's `expected_count` 9 → 1 for the new single-PR behavior.
+5. **Merge-authorization precondition**: confirm the promoter merge identity used in HIU-testing (the
+   workflow `GITHUB_TOKEN`) can actually **merge** an auto-approved wave PR under the testing repo's
+   branch protection. If a ruleset blocks it, the test can't progress — document/relax as needed (§7).
+6. **Cleanup**: close any still-open wave PRs + delete their branches; merged PRs are done (main
+   advances by the wave merges — acceptable for a fixture repo).
+
+## 9. Deliverables / PR plan
+
+- **PR-A — helm-image-updater** (new branch, supersedes & closes #19): §3 interface, §5 refactor, §6
+  behavior change, §8a unit tests. Aim for one PR; split off a pure refactor commit/PR only if it
+  balloons.
+- **rollout_wave metadata**: authored in kbc-stacks `stack-metadata.yaml` (user-owned) and in the
+  HIU-testing mocks (part of PR-B).
+- **PR-B — helm-image-updater-testing**: §8b gradual soak-progression test + updated `standard`
+  assertions.
+- **release-promoter DESIGN.md**: drop the "helm-image-updater is *not* modified for MVP" note (§2).
+
+## 10. Open questions
+
+- Final home for this spec / Linear linking (currently HIU repo root, matching existing design docs).
+- Is the kbc-stacks `rollout_wave` rollout a separate user-owned PR, or in scope here? (Assumed
+  user-owned for production; test mocks are in PR-B.)
+- Sparse waves: we **require all of 0..3 non-empty** and error otherwise (§4). Auto-renumbering a
+  sparse set into a contiguous `0..k` is deferred — it would require promoter to drop the fixed-0..3
+  assumption (DESIGN notes `release:wave:0` anchoring would be count-agnostic).
+- `releaseId` slug scheme — exact form (truncated SHA-256 of `<chart>\0<tag>` vs trailing tag short-sha)
+  to be picked during implementation; either satisfies the §2 invariants.
+- Confirm GitHub's `add-labels` behavior (does it auto-create absent labels?) — provisioning is
+  defensive either way (§2), but the answer decides whether the pre-create step is strictly required.

--- a/docs/plans/2026-06-05-deploy-strategy-wave-pr-a.md
+++ b/docs/plans/2026-06-05-deploy-strategy-wave-pr-a.md
@@ -1,0 +1,1238 @@
+# PR-A: DEPLOY_STRATEGY & wave PRs (helm-image-updater) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach helm-image-updater to emit promoter-consumable **wave PRs** (created up front, unmerged, labeled `release:id` / `release:wave:N` / `deploy:<strategy>`) behind a new `DEPLOY_STRATEGY` knob, without breaking existing deploys.
+
+**Architecture:** A single `DEPLOY_STRATEGY` enum drives an internal grouping dispatch (inspired by, and superseding, PR #19): `standard` (single PR) / `cloud_multi_stage` (today's multi-stage) / wave strategies (`gradual|critical|critical-manual-gate` → one PR per rollout wave). Auto-merge is decoupled (wave PRs never auto-merge — promoter owns the merges). Wave membership comes from a per-stack `rollout_wave` in `stack-metadata.yaml` (default: dev→0, else→3). `release:id` is a length-bounded, deterministic slug. Re-runs are idempotent (search by `release:id`).
+
+**Tech Stack:** Python 3.13 · pytest · ruamel.yaml · PyGithub · GitPython.
+
+**Spec:** `helm-image-updater/deploy-strategy-promoter-integration.md`. Promoter contract: `release-promoter/DESIGN.md` §2–§5.
+
+**Conventions for every task:** run tests with `python -m pytest <path> -v`. Commit messages end with the trailer `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Work on a new branch off `main` (see Task 0). One logical step per commit. **Do not auto-merge or push** unless the user asks.
+
+---
+
+## File Structure
+
+- **Modify** `helm_image_updater/models.py` — add `DeployStrategy` enum; add `PRPlan.labels`.
+- **Modify** `helm_image_updater/environment.py` — parse + validate `DEPLOY_STRATEGY`.
+- **Create** `helm_image_updater/wave_planning.py` — pure helpers: `compute_release_id`, `resolve_wave`, label builders, wave-grouping.
+- **Modify** `helm_image_updater/plan_builder.py` — dispatch grouping by strategy; standard single-PR; `_create_pr_plan` wave branch/title/labels; idempotency guard in `prepare_plan`.
+- **Modify** `helm_image_updater/plan_executor.py` — thread `labels` to io_layer; dry-run prints labels.
+- **Modify** `helm_image_updater/io_layer.py` — `create_branch_commit_and_pr`/`create_pull_request` accept + provision + apply labels; `find_prs_by_label`.
+- **Modify** `action.yaml` — add `deploy-strategy` input → `DEPLOY_STRATEGY` env.
+- **Create** `tests/test_deploy_strategy.py` — parsing/validation/release_id/resolve_wave (pure).
+- **Create** `tests/test_wave_grouping.py` — wave grouping, auto-merge, labels, idempotency.
+- **Modify** `tests/test_plan_builder.py` — add the `standard` + `automerge=false` single-PR test.
+
+---
+
+## Model & review gates (per task)
+
+The orchestrator dispatches each task to a fresh subagent at the **model** below, does a two-stage
+review of its output, then runs the **Codex gate** where marked before moving on. Codex runs via
+`mcp__codex-cli__review` (or a `codex` prompt) with **model `gpt-5.5`** — the `*-codex` model ids are
+rejected on this ChatGPT account — against the task's commit diff (`base: main` or `commit: <sha>`).
+**Codex findings are claims to verify against the code before acting** (project CLAUDE.md), never applied blind.
+
+| Task | Model | Codex | Why |
+|------|-------|-------|-----|
+| 0 Branch | — | no | mechanical git |
+| 1 DeployStrategy enum + parsing + alias | **sonnet** | **yes** | public-interface contract; the `multi_stage` sync is load-bearing |
+| 2 Validation (unknown→error, wave needs prod) | sonnet | no | straightforward rules, fully unit-tested |
+| 3 `PRPlan.labels` field | **haiku** | no | one-line dataclass field |
+| 4 `compute_release_id` | sonnet | **yes** | 50-char label limit + collision-resistance (the bug class Codex first flagged) |
+| 5 `resolve_wave` | sonnet | no | small pure fn, table-tested |
+| 6 Wave grouping dispatch | **opus** | **yes** | heart of PR-A: labels, contiguity guard, dispatch ordering vs canary/multi-stage |
+| 7 standard automerge=false → 1 PR | sonnet | **yes** | changes a production deploy path — confirm nothing relied on per-stack |
+| 8 `_should_auto_merge` wave→never | **haiku** | no | one branch, unit-tested |
+| 9 `_create_pr_plan` wave branch/title + labels | sonnet | **yes** | edits the shared if/else — risk of regressing non-wave paths |
+| 10 Label plumbing + provisioning | **opus** | **yes** | GitHub label API + threading through 3 layers |
+| 11 Idempotency guard | **opus** | **yes** | safety guard; subtle `get_issues(labels=…)` + `pull_request` filter |
+| 12 `deploy-strategy` action input | **haiku** | no | trivial YAML wiring |
+| 13 Full suite green + supersede #19 | sonnet | **yes (final full-diff)** | whole-PR Codex review (`base: main`) before handoff |
+
+---
+
+## Task 0: Branch
+
+- [ ] **Step 1: Create the working branch off main**
+
+```bash
+cd ~/keboola/devel/helm-image-updater
+git checkout main && git pull
+git checkout -b ST-4034-deploy-strategy-wave
+```
+
+---
+
+## Task 1: `DeployStrategy` enum + `DEPLOY_STRATEGY` parsing
+
+**Files:**
+- Modify: `helm_image_updater/models.py` (after the `UpdateStrategy` enum, ~line 14)
+- Modify: `helm_image_updater/environment.py` (`EnvironmentConfig` + `from_env`)
+- Test: `tests/test_deploy_strategy.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_deploy_strategy.py
+"""Tests for DEPLOY_STRATEGY parsing, validation, and wave helpers (PR-A)."""
+
+from helm_image_updater.environment import EnvironmentConfig
+from helm_image_updater.models import DeployStrategy
+
+
+def _base_env(**overrides):
+    env = {
+        "HELM_CHART": "dummy-service",
+        "IMAGE_TAG": "production-abc123",
+        "GH_TOKEN": "t",
+        "GH_APPROVE_TOKEN": "a",
+    }
+    env.update(overrides)
+    return env
+
+
+def test_deploy_strategy_defaults_to_standard():
+    cfg = EnvironmentConfig.from_env(_base_env())
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+
+
+def test_deploy_strategy_parses_known_values():
+    for raw, expected in [
+        ("standard", DeployStrategy.STANDARD),
+        ("cloud_multi_stage", DeployStrategy.CLOUD_MULTI_STAGE),
+        ("gradual", DeployStrategy.GRADUAL),
+        ("critical", DeployStrategy.CRITICAL),
+        ("critical-manual-gate", DeployStrategy.CRITICAL_MANUAL_GATE),
+    ]:
+        cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY=raw))
+        assert cfg.deploy_strategy == expected
+
+
+def test_multi_stage_true_aliases_to_cloud_multi_stage_when_unset():
+    cfg = EnvironmentConfig.from_env(_base_env(MULTI_STAGE="true"))
+    assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
+
+
+def test_unknown_deploy_strategy_does_not_silently_become_standard():
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="gradul"))
+    # Parsed value stays unset/standard, but an error is recorded for validate() (Task 2).
+    assert cfg._deploy_strategy_error is not None
+
+
+def test_cloud_multi_stage_sets_multi_stage_flag():
+    # DEPLOY_STRATEGY=cloud_multi_stage must drive the legacy multi_stage grouping branch.
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="cloud_multi_stage"))
+    assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
+    assert cfg.multi_stage is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -v`
+Expected: FAIL — `ImportError: cannot import name 'DeployStrategy'`.
+
+- [ ] **Step 3: Add the enum to `models.py`**
+
+Insert after the `UpdateStrategy` enum (after line 14):
+
+```python
+class DeployStrategy(Enum):
+    """Deploy strategy (the DEPLOY_STRATEGY knob). Values double as the `deploy:*`
+    label value for promoter-managed (wave) strategies."""
+    STANDARD = "standard"
+    CLOUD_MULTI_STAGE = "cloud_multi_stage"
+    GRADUAL = "gradual"
+    CRITICAL = "critical"
+    CRITICAL_MANUAL_GATE = "critical-manual-gate"
+
+    @property
+    def is_wave(self) -> bool:
+        return self in (
+            DeployStrategy.GRADUAL,
+            DeployStrategy.CRITICAL,
+            DeployStrategy.CRITICAL_MANUAL_GATE,
+        )
+```
+
+- [ ] **Step 4: Parse it in `environment.py`**
+
+Add the import at the top of `environment.py`:
+
+```python
+from .models import DeployStrategy
+```
+
+Add the field to `EnvironmentConfig` (next to `multi_stage`, ~line 21):
+
+```python
+    deploy_strategy: DeployStrategy = DeployStrategy.STANDARD
+    _deploy_strategy_error: Optional[str] = field(default=None, init=False, repr=False)
+```
+
+In `from_env`, before the `config = cls(...)` call, parse the raw value:
+
+```python
+        # Parse DEPLOY_STRATEGY (default standard). MULTI_STAGE=true is a deprecated
+        # alias for cloud_multi_stage when DEPLOY_STRATEGY is not explicitly set.
+        raw_strategy = env.get("DEPLOY_STRATEGY", "").strip().lower()
+        multi_stage_raw = env.get("MULTI_STAGE", "false").lower() == "true"
+        deploy_strategy = DeployStrategy.STANDARD
+        deploy_strategy_error = None
+        if raw_strategy:
+            try:
+                deploy_strategy = DeployStrategy(raw_strategy)
+            except ValueError:
+                deploy_strategy_error = (
+                    f"Invalid DEPLOY_STRATEGY: '{raw_strategy}'. "
+                    "Must be one of: standard, cloud_multi_stage, gradual, critical, critical-manual-gate"
+                )
+            if multi_stage_raw and deploy_strategy != DeployStrategy.CLOUD_MULTI_STAGE:
+                print("WARNING: MULTI_STAGE=true is ignored because DEPLOY_STRATEGY is set explicitly")
+        elif multi_stage_raw:
+            deploy_strategy = DeployStrategy.CLOUD_MULTI_STAGE
+
+        # Keep the legacy `multi_stage` flag in sync so the existing cloud×stage grouping
+        # branch (which keys off plan.multi_stage) fires for DEPLOY_STRATEGY=cloud_multi_stage too.
+        multi_stage = multi_stage_raw or (deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE)
+```
+
+In the `cls(...)` constructor call, **replace** the existing
+`multi_stage=env.get("MULTI_STAGE", "false").lower() == "true",` line with
+`multi_stage=multi_stage,` and add `deploy_strategy=deploy_strategy,`. After the call set:
+
+```python
+        config._deploy_strategy_error = deploy_strategy_error
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add helm_image_updater/models.py helm_image_updater/environment.py tests/test_deploy_strategy.py
+git commit -m "feat: add DeployStrategy enum + DEPLOY_STRATEGY parsing (MULTI_STAGE alias)"
+```
+
+---
+
+## Task 2: Validation — unknown errors, wave requires production tag
+
+**Files:**
+- Modify: `helm_image_updater/environment.py` (`validate`)
+- Test: `tests/test_deploy_strategy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_deploy_strategy.py  (append)
+def test_unknown_deploy_strategy_is_a_validation_error():
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="gradul"))
+    errors = cfg.validate()
+    assert any("Invalid DEPLOY_STRATEGY" in e for e in errors)
+
+
+def test_wave_strategy_requires_production_tag():
+    cfg = EnvironmentConfig.from_env(_base_env(IMAGE_TAG="dev-abc", DEPLOY_STRATEGY="gradual"))
+    errors = cfg.validate()
+    assert any("requires a production" in e for e in errors)
+
+
+def test_wave_strategy_ok_with_production_tag():
+    cfg = EnvironmentConfig.from_env(_base_env(IMAGE_TAG="production-abc", DEPLOY_STRATEGY="gradual"))
+    assert cfg.validate() == []
+
+
+def test_wave_strategy_rejected_with_override_stack():
+    cfg = EnvironmentConfig.from_env(
+        _base_env(DEPLOY_STRATEGY="critical", OVERRIDE_STACK="kbc-us-east-1")
+    )
+    errors = cfg.validate()
+    assert any("OVERRIDE_STACK" in e for e in errors)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -v`
+Expected: FAIL — the new assertions fail (no such validation yet).
+
+- [ ] **Step 3: Add validation rules in `environment.py` `validate()`**
+
+At the end of `validate()`, before `return errors`, add:
+
+```python
+        # DEPLOY_STRATEGY validation
+        if self._deploy_strategy_error:
+            errors.append(self._deploy_strategy_error)
+
+        if self.deploy_strategy.is_wave:
+            if self.override_stack:
+                errors.append("DEPLOY_STRATEGY wave modes are incompatible with OVERRIDE_STACK")
+            elif self.image_tag:
+                tag_type = detect_tag_type(self.image_tag)
+                if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
+                    errors.append(
+                        f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver "
+                        f"IMAGE_TAG, got '{self.image_tag}'"
+                    )
+```
+
+(`detect_tag_type` and `TagType` are already imported at the top of `validate()`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/environment.py tests/test_deploy_strategy.py
+git commit -m "feat: validate DEPLOY_STRATEGY (unknown=error, wave requires prod tag)"
+```
+
+---
+
+## Task 3: `PRPlan.labels` field
+
+**Files:**
+- Modify: `helm_image_updater/models.py` (`PRPlan`, ~line 36)
+- Test: `tests/test_deploy_strategy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_deploy_strategy.py  (append)
+from helm_image_updater.models import PRPlan
+
+
+def test_prplan_labels_defaults_empty():
+    p = PRPlan(
+        branch_name="b", pr_title="t", pr_body="body", base_branch="main",
+        auto_merge=False, files_to_commit=[], commit_message="c",
+    )
+    assert p.labels == []
+
+
+def test_prplan_labels_can_be_set():
+    p = PRPlan(
+        branch_name="b", pr_title="t", pr_body="body", base_branch="main",
+        auto_merge=False, files_to_commit=[], commit_message="c",
+        labels=["release:wave:0"],
+    )
+    assert p.labels == ["release:wave:0"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -k prplan_labels -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'labels'`.
+
+- [ ] **Step 3: Add the field to `PRPlan` in `models.py`**
+
+Add as the last field of `PRPlan` (after `commit_message`):
+
+```python
+    labels: List[str] = field(default_factory=list)
+```
+
+(`field` and `List` are already imported in `models.py`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -k prplan_labels -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/models.py tests/test_deploy_strategy.py
+git commit -m "feat: add PRPlan.labels field"
+```
+
+---
+
+## Task 4: `compute_release_id` (length-bounded, deterministic slug)
+
+**Files:**
+- Create: `helm_image_updater/wave_planning.py`
+- Test: `tests/test_deploy_strategy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_deploy_strategy.py  (append)
+from helm_image_updater.wave_planning import compute_release_id, release_id_label
+
+GH_LABEL_MAX = 50
+
+
+def test_release_id_label_fits_github_limit_even_for_long_inputs():
+    rid = compute_release_id("infrastructure-plugin-update-components",
+                             "production-633743c4fc2431d3a9727987a3152a8ea5ec38c2")
+    assert len(release_id_label(rid)) <= GH_LABEL_MAX
+
+
+def test_release_id_is_deterministic():
+    a = compute_release_id("connection", "production-abc123")
+    b = compute_release_id("connection", "production-abc123")
+    assert a == b
+
+
+def test_release_id_distinct_for_distinct_tags():
+    a = compute_release_id("connection", "production-aaaa")
+    b = compute_release_id("connection", "production-bbbb")
+    assert a != b
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -k release_id -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'helm_image_updater.wave_planning'`.
+
+- [ ] **Step 3: Create `wave_planning.py` with the helpers**
+
+```python
+# helm_image_updater/wave_planning.py
+"""Pure helpers for promoter-managed (wave) deploys.
+
+No I/O — only data transformation. Consumed by plan_builder.
+"""
+
+import hashlib
+from typing import Dict, List, Optional
+
+from .models import DeployStrategy
+from .stack_classification import classify_stack
+
+# GitHub caps label names at 50 chars; "release:id:" eats 11, leaving 39.
+_RELEASE_ID_PREFIX = "release:id:"
+_RELEASE_ID_MAX = 50 - len(_RELEASE_ID_PREFIX)  # 39
+_HASH_LEN = 12
+
+
+def compute_release_id(helm_chart: str, image_tag: str) -> str:
+    """A stable, collision-resistant, length-bounded grouping key (<chart>-<hash>).
+
+    Promoter treats this as opaque (it gets the app from the PR diff), so the only
+    invariants are: fits the label limit, deterministic, unique per (chart, tag).
+    """
+    digest = hashlib.sha256(f"{helm_chart}\0{image_tag}".encode()).hexdigest()[:_HASH_LEN]
+    chart_room = _RELEASE_ID_MAX - 1 - _HASH_LEN  # room for "<chart>-"
+    chart = helm_chart[:chart_room]
+    return f"{chart}-{digest}"
+
+
+def release_id_label(release_id: str) -> str:
+    return f"{_RELEASE_ID_PREFIX}{release_id}"
+
+
+def wave_label(wave: int) -> str:
+    return f"release:wave:{wave}"
+
+
+def deploy_label(strategy: DeployStrategy) -> str:
+    return f"deploy:{strategy.value}"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -k release_id -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/wave_planning.py tests/test_deploy_strategy.py
+git commit -m "feat: add compute_release_id + label builders (wave_planning)"
+```
+
+---
+
+## Task 5: `resolve_wave` (per-stack wave assignment)
+
+**Files:**
+- Modify: `helm_image_updater/wave_planning.py`
+- Test: `tests/test_deploy_strategy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_deploy_strategy.py  (append)
+from helm_image_updater.wave_planning import resolve_wave
+
+
+def test_resolve_wave_uses_explicit_value():
+    assert resolve_wave("kbc-us-east-1", {"rollout_wave": 2}) == 2
+
+
+def test_resolve_wave_dev_defaults_to_0_when_missing():
+    # dev-keboola-gcp-us-central1 is a dev stack (DEV_STACK_MAPPING)
+    assert resolve_wave("dev-keboola-gcp-us-central1", None) == 0
+    assert resolve_wave("dev-keboola-gcp-us-central1", {}) == 0
+
+
+def test_resolve_wave_non_dev_defaults_to_3_when_missing():
+    assert resolve_wave("kbc-us-east-1", None) == 3
+
+
+def test_resolve_wave_explicit_overrides_dev_default():
+    assert resolve_wave("dev-keboola-gcp-us-central1", {"rollout_wave": 1}) == 1
+
+
+def test_resolve_wave_rejects_out_of_range():
+    import pytest
+    with pytest.raises(ValueError):
+        resolve_wave("kbc-us-east-1", {"rollout_wave": 5})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -k resolve_wave -v`
+Expected: FAIL — `ImportError: cannot import name 'resolve_wave'`.
+
+- [ ] **Step 3: Add `resolve_wave` to `wave_planning.py`**
+
+```python
+def resolve_wave(stack: str, metadata: Optional[Dict]) -> int:
+    """wave(stack) = explicit `rollout_wave` if present (0..3), else dev->0 / other->3."""
+    if metadata and "rollout_wave" in metadata:
+        raw = metadata["rollout_wave"]
+        wave = int(raw)
+        if wave < 0 or wave > 3:
+            raise ValueError(f"rollout_wave for {stack} must be 0..3, got {raw}")
+        return wave
+    return 0 if classify_stack(stack).is_dev else 3
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_deploy_strategy.py -k resolve_wave -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/wave_planning.py tests/test_deploy_strategy.py
+git commit -m "feat: add resolve_wave (explicit rollout_wave, else dev=0/other=3)"
+```
+
+---
+
+## Task 6: Wave grouping dispatch in `plan_builder`
+
+**Files:**
+- Modify: `helm_image_updater/plan_builder.py` (`_group_changes_for_prs`, ~line 401; imports ~line 13-25)
+- Test: `tests/test_wave_grouping.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_wave_grouping.py
+"""Wave-mode grouping, auto-merge, labels, idempotency (PR-A)."""
+
+from unittest.mock import Mock
+from helm_image_updater.models import UpdateStrategy, DeployStrategy
+from helm_image_updater.plan_builder import _group_changes_for_prs
+
+
+def _stack_change(stack):
+    return {"stack": stack, "file_change": Mock(), "changes": []}
+
+
+def _wave_metadata(by_stack):
+    """Return a read_yaml side_effect mapping <stack>/stack-metadata.yaml -> dict."""
+    def _read(path):
+        for stack, wave in by_stack.items():
+            if path == f"{stack}/stack-metadata.yaml":
+                return {"rollout_wave": wave}
+        return None
+    return _read
+
+
+def test_wave_grouping_one_pr_per_wave_with_labels():
+    waves = {
+        "dev-keboola-gcp-us-central1": 0,
+        "com-keboola-azure-north-europe": 1,
+        "kbc-us-east-1": 2,
+        "cloud-keboola-cs": 3,
+    }
+    io = Mock()
+    io.read_yaml.side_effect = _wave_metadata(waves)
+
+    config = Mock()
+    config.deploy_strategy = DeployStrategy.GRADUAL
+
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    plan.multi_stage = False
+    plan.helm_chart = "dummy-service"
+    plan.image_tag = "production-abc123"
+
+    groups = _group_changes_for_prs(
+        [_stack_change(s) for s in waves], plan, config, io
+    )
+
+    assert len(groups) == 4
+    by_wave = {g["wave_number"]: g for g in groups}
+    assert set(by_wave) == {0, 1, 2, 3}
+    g1 = by_wave[1]
+    assert g1["pr_type"] == "wave"
+    assert g1["stacks"] == ["com-keboola-azure-north-europe"]
+    assert any(l.startswith("release:id:") for l in g1["labels"])
+    assert "release:wave:1" in g1["labels"]
+    assert "deploy:gradual" in g1["labels"]
+
+
+def test_wave_grouping_requires_all_waves_0_to_3():
+    import pytest
+    waves = {"dev-keboola-gcp-us-central1": 0, "kbc-us-east-1": 1}  # missing 2 and 3
+    io = Mock()
+    io.read_yaml.side_effect = _wave_metadata(waves)
+    config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
+
+    with pytest.raises(RuntimeError, match="wave"):
+        _group_changes_for_prs([_stack_change(s) for s in waves], plan, config, io)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_wave_grouping.py -v`
+Expected: FAIL — wave grouping not implemented (`KeyError: 'wave_number'` or all stacks in one group).
+
+- [ ] **Step 3: Add the wave branch to `_group_changes_for_prs`**
+
+Add imports at the top of `plan_builder.py` (extend the existing `.models` import and add wave_planning):
+
+```python
+from .models import UpdatePlan, FileChange, PRPlan, UpdateStrategy, TagChange, DeployStrategy
+from .wave_planning import compute_release_id, release_id_label, wave_label, deploy_label, resolve_wave
+```
+
+At the **start** of `_group_changes_for_prs` (before the canary check at line 409), insert the wave dispatch:
+
+```python
+    # Promoter-managed wave strategies: one PR per wave (0..3), unmerged, labeled.
+    if config.deploy_strategy.is_wave:
+        return _group_changes_by_wave(stack_changes, plan, config, io_layer)
+```
+
+Then add the new function (next to `_group_changes_for_prs`):
+
+```python
+def _group_changes_by_wave(stack_changes, plan, config, io_layer):
+    """Group changes into one PR per rollout wave (0..3) for promoter consumption."""
+    release_id = compute_release_id(plan.helm_chart, plan.image_tag)
+    deploy_lbl = deploy_label(config.deploy_strategy)
+
+    by_wave = {}
+    for sc in stack_changes:
+        metadata = io_layer.read_yaml(f"{sc['stack']}/stack-metadata.yaml")
+        wave = resolve_wave(sc['stack'], metadata)
+        by_wave.setdefault(wave, []).append(sc)
+
+    present = set(by_wave)
+    required = {0, 1, 2, 3}
+    if present != required:
+        missing = sorted(required - present)
+        raise RuntimeError(
+            f"Wave deploy requires non-empty waves 0..3 (promoter needs a contiguous "
+            f"release:wave:0..3); missing/empty waves: {missing}. "
+            f"Check rollout_wave in stack-metadata.yaml across target stacks."
+        )
+
+    groups = []
+    for wave in sorted(by_wave):
+        changes = by_wave[wave]
+        groups.append({
+            'stacks': [sc['stack'] for sc in changes],
+            'changes': changes,
+            'base_branch': 'main',
+            'pr_type': 'wave',
+            'wave_number': wave,
+            'release_id': release_id,
+            'labels': [release_id_label(release_id), wave_label(wave), deploy_lbl],
+        })
+    return groups
+```
+
+- [ ] **Step 3b: Fix existing grouping tests that build a `Mock()` config**
+
+Introducing `config.deploy_strategy.is_wave` means any test that passes a bare `Mock()` as
+`config` to `_group_changes_for_prs` now hits the wave branch (a Mock attribute is truthy). In
+`tests/test_plan_builder.py`, every such test (e.g. `test_multi_cloud_grouping_non_multi_stage`,
+`test_multi_cloud_grouping_dev_strategy`, and any multi-stage grouping test) constructs
+`mock_config = Mock()` — add this line to each, right after that construction:
+
+```python
+    from helm_image_updater.models import DeployStrategy
+    mock_config.deploy_strategy = DeployStrategy.STANDARD
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_wave_grouping.py tests/test_plan_builder.py -v`
+Expected: PASS — the 2 new wave tests AND all existing grouping tests (after the Step 3b additions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/plan_builder.py tests/test_wave_grouping.py tests/test_plan_builder.py
+git commit -m "feat: wave grouping (one PR per wave 0..3 with labels) + contiguity guard"
+```
+
+---
+
+## Task 7: `standard` + `automerge=false` → single PR (behavior change)
+
+**Files:**
+- Modify: `helm_image_updater/plan_builder.py` (`_group_changes_for_prs` default tail, ~line 471-490)
+- Test: `tests/test_plan_builder.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_plan_builder.py  (append, near the other grouping tests)
+def test_standard_production_automerge_false_is_single_pr():
+    """standard + automerge=false now produces ONE unmerged PR (was per-stack)."""
+    from helm_image_updater.plan_builder import _group_changes_for_prs
+    from helm_image_updater.models import DeployStrategy
+
+    mock_io_layer = Mock()
+    mock_config = Mock()
+    mock_config.automerge = False
+    mock_config.deploy_strategy = DeployStrategy.STANDARD
+
+    mock_plan = Mock()
+    mock_plan.multi_stage = False
+    mock_plan.strategy = UpdateStrategy.PRODUCTION
+
+    stacks = ["com-keboola-gcp-prod", "com-keboola-azure-prod", "com-keboola-aws-prod"]
+    stack_changes = [{"stack": s, "file_change": Mock(), "changes": []} for s in stacks]
+
+    groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
+
+    assert len(groups) == 1
+    assert len(groups[0]["stacks"]) == 3
+    assert groups[0]["pr_type"] == "standard"
+```
+
+Note: the existing `Mock()`-config grouping tests were already fixed in Task 6 Step 3b (set
+`deploy_strategy = STANDARD`); this task only *adds* the new automerge=false test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_plan_builder.py -k standard_production_automerge_false -v`
+Expected: FAIL — current code returns 3 per-stack groups, not 1.
+
+- [ ] **Step 3: Change the default tail of `_group_changes_for_prs`**
+
+Replace the production `else` (per-stack) branch (lines ~480-490) so production always returns a single group:
+
+```python
+    # Production without multi-stage: a single PR regardless of automerge.
+    # (automerge=false now yields ONE unmerged PR, not one-per-stack.)
+    return [{
+        'stacks': [sc['stack'] for sc in stack_changes],
+        'changes': stack_changes,
+        'base_branch': 'main',
+        'pr_type': 'standard'
+    }]
+```
+
+(The `if config.automerge:` single-PR branch immediately above becomes redundant — collapse both into this single return.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_plan_builder.py tests/test_cli_functional.py -v`
+Expected: PASS. If any functional test asserted the *old* per-stack prod `automerge=false` behavior
+(N PRs), update it to expect **1 PR** — that is the intended behavior change for this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/plan_builder.py tests/
+git commit -m "feat: standard production automerge=false now creates one unmerged PR"
+```
+
+---
+
+## Task 8: `_should_auto_merge` — wave PRs never auto-merge
+
+**Files:**
+- Modify: `helm_image_updater/plan_builder.py` (`_should_auto_merge`, ~line 600)
+- Test: `tests/test_wave_grouping.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_wave_grouping.py  (append)
+from helm_image_updater.plan_builder import _should_auto_merge
+
+
+def test_wave_pr_type_never_auto_merges():
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION
+    assert _should_auto_merge(plan, "wave", user_requested=True) is False
+    assert _should_auto_merge(plan, "wave", user_requested=False) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_wave_grouping.py -k auto_merge -v`
+Expected: FAIL — returns `True` (user_requested) for `pr_type='wave'`.
+
+- [ ] **Step 3: Add the wave rule in `_should_auto_merge`**
+
+After the canary check and before the `multi_stage_prod` check (line ~610):
+
+```python
+    if pr_type == 'wave':
+        print(f"       - result: FALSE (wave PRs are merged by release-promoter)")
+        return False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_wave_grouping.py -k auto_merge -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/plan_builder.py tests/test_wave_grouping.py
+git commit -m "feat: wave PRs are never auto-merged by HIU (promoter owns merges)"
+```
+
+---
+
+## Task 9: `_create_pr_plan` — wave branch/title + labels
+
+**Files:**
+- Modify: `helm_image_updater/plan_builder.py` (`_create_pr_plan`, ~line 493)
+- Test: `tests/test_wave_grouping.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_wave_grouping.py  (append)
+from helm_image_updater.plan_builder import _create_pr_plan
+
+
+def test_create_pr_plan_wave_sets_labels_and_branch_title():
+    config = Mock(); config.automerge = False
+    config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    plan.multi_stage = False
+    plan.helm_chart = "dummy-service"
+    plan.image_tag = "production-abc123"
+    plan.extra_tags = []
+    plan.metadata = {}
+
+    fc = Mock(); fc.file_path = "kbc-us-east-1/dummy-service/tag.yaml"
+    group = {
+        'stacks': ["kbc-us-east-1"],
+        'changes': [{"stack": "kbc-us-east-1", "file_change": fc, "changes": []}],
+        'base_branch': 'main',
+        'pr_type': 'wave',
+        'wave_number': 2,
+        'release_id': 'dummy-service-deadbeef0123',
+        'labels': ["release:id:dummy-service-deadbeef0123", "release:wave:2", "deploy:gradual"],
+    }
+
+    pr_plan = _create_pr_plan(group, plan, config)
+
+    assert pr_plan.labels == group['labels']
+    assert pr_plan.auto_merge is False
+    assert "wave2" in pr_plan.branch_name
+    assert "wave 2" in pr_plan.pr_title
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_wave_grouping.py -k create_pr_plan_wave -v`
+Expected: FAIL — `pr_plan.labels == []` and branch/title lack wave markers.
+
+- [ ] **Step 3: Handle `pr_type='wave'` in `_create_pr_plan`**
+
+In the branch-name `if/elif/else` (lines ~505-515), add a `wave` branch before the `else`:
+
+```python
+    elif pr_type == 'wave':
+        wave = pr_group['wave_number']
+        branch_name = f"{plan.helm_chart}-wave{wave}-{plan.image_tag}-{suffix}"
+```
+
+Replace the PR-title block (lines ~528-544) so wave PRs get a dedicated title (skip `generate_pr_title_prefix` for waves):
+
+```python
+    if pr_type == 'wave':
+        wave = pr_group['wave_number']
+        pr_title = f"[{plan.helm_chart} {config.deploy_strategy.value} wave {wave}] " \
+                   f"{plan.helm_chart}@{plan.image_tag}"
+    else:
+        pr_title_prefix = generate_pr_title_prefix(
+            strategy=plan.strategy,
+            is_multi_stage=plan.multi_stage,
+            user_requested_automerge=config.automerge,
+            target_stacks=pr_group['stacks'],
+            cloud_provider=pr_group.get('cloud_provider'),
+        )
+        pr_title = generate_pr_title(
+            pr_title_prefix=pr_title_prefix,
+            helm_chart=plan.helm_chart,
+            image_tag=plan.image_tag,
+            extra_tags=plan.extra_tags,
+            target_stacks=pr_group['stacks'],
+        )
+```
+
+Finally, pass labels into the returned `PRPlan(...)` (add as a kwarg):
+
+```python
+        labels=pr_group.get('labels', []),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_wave_grouping.py -k create_pr_plan_wave -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/plan_builder.py tests/test_wave_grouping.py
+git commit -m "feat: wave PR branch/title + carry labels into PRPlan"
+```
+
+---
+
+## Task 10: Thread labels through executor → io_layer (provision + apply)
+
+**Files:**
+- Modify: `helm_image_updater/io_layer.py` (`create_pull_request` ~240, `create_branch_commit_and_pr` ~378; add `_ensure_labels_exist`)
+- Modify: `helm_image_updater/plan_executor.py` (`_execute_pr_plans` ~69, dry-run ~72)
+- Test: `tests/test_wave_grouping.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_wave_grouping.py  (append)
+from helm_image_updater.io_layer import IOLayer
+from github.GithubException import GithubException
+
+
+def test_create_pull_request_provisions_and_applies_labels():
+    repo = Mock()
+    # get_label raises 404 for the dynamic release:id label, succeeds otherwise
+    def _get_label(name):
+        if name.startswith("release:id:"):
+            raise GithubException(404, {"message": "Not Found"}, None)
+        return Mock()
+    repo.get_label.side_effect = _get_label
+    pr = Mock(); pr.html_url = "http://x/1"; pr.number = 1
+    repo.create_pull.return_value = pr
+
+    io = IOLayer(Mock(), repo, dry_run=False, approve_github_repo=Mock())
+    io.push_branch = Mock()  # avoid real git push
+
+    io.create_pull_request(
+        title="t", body="b", branch_name="br", base_branch="main",
+        auto_merge=False,
+        labels=["release:id:dummy-service-deadbeef0123", "release:wave:2", "deploy:gradual"],
+    )
+
+    repo.create_label.assert_called()  # created the missing release:id label
+    pr.add_to_labels.assert_called_once_with(
+        "release:id:dummy-service-deadbeef0123", "release:wave:2", "deploy:gradual"
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_wave_grouping.py -k provisions_and_applies_labels -v`
+Expected: FAIL — `create_pull_request() got an unexpected keyword argument 'labels'`.
+
+- [ ] **Step 3: Add label support to `io_layer.py`**
+
+Add a helper method on `IOLayer`:
+
+```python
+    def _ensure_labels_exist(self, names: List[str]) -> None:
+        """Create-if-missing each label (tolerate already-exists)."""
+        for name in names:
+            try:
+                self.github_repo.get_label(name)
+            except GithubException as e:
+                if e.status == 404:
+                    try:
+                        self.github_repo.create_label(name=name, color="ededed")
+                    except GithubException as ce:
+                        if ce.status != 422:  # 422 = already exists (race) → fine
+                            raise
+                else:
+                    raise
+```
+
+Change `create_pull_request` signature to accept `labels`:
+
+```python
+    def create_pull_request(
+        self,
+        title: str,
+        body: str,
+        branch_name: str,
+        base_branch: str = "main",
+        auto_merge: bool = False,
+        labels: Optional[List[str]] = None,
+    ) -> Optional[str]:
+```
+
+In the dry-run block, print labels:
+
+```python
+            if labels:
+                print(f"[DRY RUN] Labels: {', '.join(labels)}")
+```
+
+After `pr = self.github_repo.create_pull(...)` and the `print(f"PR created: ...")`, before the auto-merge block, apply labels:
+
+```python
+        if labels:
+            self._ensure_labels_exist(labels)
+            pr.add_to_labels(*labels)
+            print(f"🏷️  Applied labels: {', '.join(labels)}")
+```
+
+Change `create_branch_commit_and_pr` signature to accept and forward `labels`:
+
+```python
+    def create_branch_commit_and_pr(
+        self,
+        branch_name: str,
+        files_to_commit: List[str],
+        commit_message: str,
+        pr_title: str,
+        pr_body: str,
+        base_branch: str = "main",
+        auto_merge: bool = False,
+        labels: Optional[List[str]] = None,
+    ) -> Optional[str]:
+```
+
+Find the `self.create_pull_request(...)` call inside `create_branch_commit_and_pr` (in the lines after 399) and add `labels=labels` to it.
+
+- [ ] **Step 4: Forward labels from the executor**
+
+In `plan_executor.py` `_execute_pr_plans`, dry-run block (after line 77) add:
+
+```python
+            if pr_plan.labels:
+                print(f"  Labels: {', '.join(pr_plan.labels)}")
+```
+
+And in the real call (line 85), add `labels=pr_plan.labels`:
+
+```python
+            pr_url = io_layer.create_branch_commit_and_pr(
+                branch_name=pr_plan.branch_name,
+                files_to_commit=pr_plan.files_to_commit,
+                commit_message=pr_plan.commit_message,
+                pr_title=pr_plan.pr_title,
+                pr_body=pr_plan.pr_body,
+                base_branch=pr_plan.base_branch,
+                auto_merge=pr_plan.auto_merge,
+                labels=pr_plan.labels,
+            )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_wave_grouping.py -k provisions_and_applies_labels -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add helm_image_updater/io_layer.py helm_image_updater/plan_executor.py tests/test_wave_grouping.py
+git commit -m "feat: provision + apply PR labels through executor and io_layer"
+```
+
+---
+
+## Task 11: Idempotency — skip when `release:id` already exists
+
+**Files:**
+- Modify: `helm_image_updater/io_layer.py` (add `find_prs_by_label`)
+- Modify: `helm_image_updater/plan_builder.py` (`prepare_plan`, after grouping ~line 88)
+- Test: `tests/test_wave_grouping.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_wave_grouping.py  (append)
+import pytest
+from helm_image_updater.plan_builder import _guard_release_not_already_open
+
+
+def test_guard_raises_when_release_id_already_has_open_prs():
+    io = Mock()
+    io.find_prs_by_label.return_value = [101, 102]  # existing open PRs
+    with pytest.raises(RuntimeError, match="already"):
+        _guard_release_not_already_open("dummy-service-deadbeef0123", io)
+
+
+def test_guard_passes_when_no_existing_prs():
+    io = Mock()
+    io.find_prs_by_label.return_value = []
+    # Should not raise.
+    _guard_release_not_already_open("dummy-service-deadbeef0123", io)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_wave_grouping.py -k guard -v`
+Expected: FAIL — `ImportError: cannot import name '_guard_release_not_already_open'`.
+
+- [ ] **Step 3: Add `find_prs_by_label` to io_layer and the guard to plan_builder**
+
+In `io_layer.py` (GitHub Operations section):
+
+```python
+    def find_prs_by_label(self, label: str) -> List[int]:
+        """Return open PR numbers carrying the given label (idempotency check)."""
+        numbers = []
+        for issue in self.github_repo.get_issues(state="open", labels=[label]):
+            if issue.pull_request is not None:
+                numbers.append(issue.number)
+        return numbers
+```
+
+In `plan_builder.py`, add the guard function and import `release_id_label` (already imported in Task 6):
+
+```python
+def _guard_release_not_already_open(release_id: str, io_layer: IOLayer) -> None:
+    """Fail loudly if a release with this id already has open PRs (re-run safety).
+
+    Creating a second set of wave PRs with the same release:id would give promoter
+    duplicate release:wave:N labels -> ¬wellFormed -> Conflicted.
+    """
+    existing = io_layer.find_prs_by_label(release_id_label(release_id))
+    if existing:
+        raise RuntimeError(
+            f"Release '{release_id}' already has open PRs {existing}. "
+            f"Refusing to create duplicate wave PRs (would make the release Conflicted). "
+            f"Close/finish the existing release first."
+        )
+```
+
+Wire it into `prepare_plan` — in wave mode, before creating PR plans (after `pr_groups = _group_changes_for_prs(...)`, ~line 88), and skip in dry-run:
+
+```python
+    # Idempotency: in wave mode, never fan out a duplicate release.
+    if config.deploy_strategy.is_wave and not config.dry_run and pr_groups:
+        _guard_release_not_already_open(pr_groups[0]['release_id'], io_layer)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_wave_grouping.py -k guard -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helm_image_updater/io_layer.py helm_image_updater/plan_builder.py tests/test_wave_grouping.py
+git commit -m "feat: idempotency guard — refuse duplicate wave PRs for an existing release:id"
+```
+
+---
+
+## Task 12: Action input `deploy-strategy`
+
+**Files:**
+- Modify: `action.yaml` (inputs ~line 18-21; env mapping in the run step)
+
+- [ ] **Step 1: Add the input**
+
+After the `multi-stage` input (line ~18-20), add:
+
+```yaml
+  deploy-strategy:
+    description: 'Promoter deploy strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate'
+    required: false
+    default: 'standard'
+```
+
+- [ ] **Step 2: Map it to the `DEPLOY_STRATEGY` env var**
+
+Find the step that maps inputs → env (where `MULTI_STAGE`, `IMAGE_TAG`, etc. are set) and add:
+
+```yaml
+        DEPLOY_STRATEGY: ${{ inputs.deploy-strategy }}
+```
+
+- [ ] **Step 3: Verify the mapping is present**
+
+Run: `grep -n 'deploy-strategy\|DEPLOY_STRATEGY' action.yaml`
+Expected: the input definition and the env mapping both appear.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add action.yaml
+git commit -m "feat: add deploy-strategy action input -> DEPLOY_STRATEGY"
+```
+
+---
+
+## Task 13: Full suite green + docs
+
+**Files:**
+- Run: full test suite
+- Modify: `deploy-strategy-promoter-integration.md` (mark spec implemented — optional)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `python -m pytest -v`
+Expected: PASS (all existing + new tests).
+
+- [ ] **Step 2: Manual dry-run sanity check (optional, local)**
+
+```bash
+# From a kbc-stacks-like checkout (or the testing repo with rollout_wave metadata):
+HELM_CHART=dummy-service IMAGE_TAG=production-abc123 DEPLOY_STRATEGY=gradual \
+DRY_RUN=true GH_TOKEN=x GH_APPROVE_TOKEN=y python -m helm_image_updater
+```
+Expected: 4 "[DRY RUN] Would create PR" lines (waves 0–3) each printing its `release:id:* / release:wave:N / deploy:gradual` labels and `Auto-merge: False`.
+
+- [ ] **Step 3: Commit any doc updates**
+
+```bash
+git add -A
+git commit -m "docs: note PR-A implemented"
+```
+
+- [ ] **Step 4: Supersede PR #19 (requires confirmation — do not run without asking the user)**
+
+```bash
+gh pr close 19 --repo keboola/helm-image-updater \
+  --comment "Superseded by ST-4034 DEPLOY_STRATEGY work (deploy-strategy-promoter-integration.md)."
+```
+
+---
+
+## Self-review notes (gaps intentionally deferred to PR-B / out of scope)
+
+- **`rollout_wave` data** for real production stacks is authored in kbc-stacks (user-owned). The **testing mocks' `stack-metadata.yaml` files** (currently absent — verified 0 present) are created in **PR-B**, alongside the gradual soak-progression integration test.
+- **DESIGN.md note** (drop "HIU is not modified" MVP caveat) is a `release-promoter`-repo change, tracked separately.
+- **Branch-protection / promoter merge authorization** is an external prerequisite surfaced by PR-B's test, not code here.

--- a/docs/plans/2026-06-05-deploy-strategy-wave-pr-a.md
+++ b/docs/plans/2026-06-05-deploy-strategy-wave-pr-a.md
@@ -129,6 +129,14 @@ def test_cloud_multi_stage_sets_multi_stage_flag():
     cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="cloud_multi_stage"))
     assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
     assert cfg.multi_stage is True
+
+
+def test_explicit_standard_overrides_multi_stage_flag():
+    # DEPLOY_STRATEGY=standard wins over MULTI_STAGE=true: multi_stage must be False
+    # (the warning says MULTI_STAGE is ignored — the flag must actually reflect that).
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="standard", MULTI_STAGE="true"))
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+    assert cfg.multi_stage is False
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -196,9 +204,12 @@ In `from_env`, before the `config = cls(...)` call, parse the raw value:
         elif multi_stage_raw:
             deploy_strategy = DeployStrategy.CLOUD_MULTI_STAGE
 
-        # Keep the legacy `multi_stage` flag in sync so the existing cloud×stage grouping
-        # branch (which keys off plan.multi_stage) fires for DEPLOY_STRATEGY=cloud_multi_stage too.
-        multi_stage = multi_stage_raw or (deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE)
+        # The resolved strategy is the SINGLE source of truth for multi_stage: an explicit
+        # DEPLOY_STRATEGY wins over MULTI_STAGE, and an unset DEPLOY_STRATEGY with
+        # MULTI_STAGE=true already resolved to CLOUD_MULTI_STAGE above. (Do NOT OR in
+        # multi_stage_raw — that would keep multi_stage=True for DEPLOY_STRATEGY=standard
+        # MULTI_STAGE=true, contradicting the "ignored" warning.)
+        multi_stage = deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
 ```
 
 In the `cls(...)` constructor call, **replace** the existing
@@ -275,13 +286,30 @@ At the end of `validate()`, before `return errors`, add:
         if self.deploy_strategy.is_wave:
             if self.override_stack:
                 errors.append("DEPLOY_STRATEGY wave modes are incompatible with OVERRIDE_STACK")
-            elif self.image_tag:
+            elif not self.image_tag:
+                errors.append(
+                    f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver IMAGE_TAG"
+                )
+            else:
                 tag_type = detect_tag_type(self.image_tag)
                 if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
                     errors.append(
                         f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver "
                         f"IMAGE_TAG, got '{self.image_tag}'"
                     )
+```
+
+Add the matching test:
+
+```python
+# tests/test_deploy_strategy.py  (append)
+def test_wave_strategy_requires_image_tag_not_just_extra_tag():
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+        "EXTRA_TAG1": "image.tag:production-abc", "DEPLOY_STRATEGY": "gradual",
+    })
+    errors = cfg.validate()
+    assert any("IMAGE_TAG" in e for e in errors)
 ```
 
 (`detect_tag_type` and `TagType` are already imported at the top of `validate()`.)
@@ -502,15 +530,21 @@ Expected: FAIL — `ImportError: cannot import name 'resolve_wave'`.
 
 ```python
 def resolve_wave(stack: str, metadata: Optional[Dict]) -> int:
-    """wave(stack) = explicit `rollout_wave` if present (0..3), else dev->0 / other->3."""
+    """wave(stack) = explicit `rollout_wave` if present (integer 0..3), else dev->0 / other->3."""
     if metadata and "rollout_wave" in metadata:
         raw = metadata["rollout_wave"]
-        wave = int(raw)
-        if wave < 0 or wave > 3:
+        # Reject non-integers (and bool, which is an int subclass) — silent coercion of a
+        # float/str/bool rollout_wave would mask a prod misconfiguration.
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise ValueError(f"rollout_wave for {stack} must be an integer 0..3, got {raw!r}")
+        if raw < 0 or raw > 3:
             raise ValueError(f"rollout_wave for {stack} must be 0..3, got {raw}")
-        return wave
+        return raw
     return 0 if classify_stack(stack).is_dev else 3
 ```
+
+(Codex hardening — also add a test asserting `resolve_wave("kbc-us-east-1", {"rollout_wave": 1.9})` and
+`{"rollout_wave": True}` both raise `ValueError`.)
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -631,6 +665,8 @@ Then add the new function (next to `_group_changes_for_prs`):
 ```python
 def _group_changes_by_wave(stack_changes, plan, config, io_layer):
     """Group changes into one PR per rollout wave (0..3) for promoter consumption."""
+    # Never roll an e2e stack into a production wave (defensive — known e2e are also in EXCLUDED_STACKS).
+    stack_changes = [sc for sc in stack_changes if not sc['stack'].endswith('-e2e')]
     release_id = compute_release_id(plan.helm_chart, plan.image_tag)
     deploy_lbl = deploy_label(config.deploy_strategy)
 
@@ -792,7 +828,8 @@ Expected: FAIL — returns `True` (user_requested) for `pr_type='wave'`.
 
 - [ ] **Step 3: Add the wave rule in `_should_auto_merge`**
 
-After the canary check and before the `multi_stage_prod` check (line ~610):
+**Before** the canary check (so `pr_type=='wave'` is literal regardless of strategy — a wave PR is
+never auto-merged even if some future caller passes a non-production strategy):
 
 ```python
     if pr_type == 'wave':
@@ -1170,8 +1207,11 @@ After the `multi-stage` input (line ~18-20), add:
   deploy-strategy:
     description: 'Promoter deploy strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate'
     required: false
-    default: 'standard'
+    default: ''
 ```
+> **Default is empty, NOT `standard`.** The action always forwards the input as `DEPLOY_STRATEGY`, and
+> `from_env` treats any non-empty value as *explicit* (overriding `MULTI_STAGE`). An empty default lets
+> legacy `multi-stage: true` callers keep aliasing to `cloud_multi_stage`; empty → unset → `standard`.
 
 - [ ] **Step 2: Map it to the `DEPLOY_STRATEGY` env var**
 

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -163,5 +163,20 @@ class EnvironmentConfig:
                 tag_type = detect_tag_type(tag["value"])
                 if tag_type == TagType.INVALID:
                     errors.append(f"Invalid EXTRA_TAG{i} format: '{tag['value']}'. Must start with 'dev-', 'production-', 'canary-' or be a valid semver (e.g., 1.2.3)")
-        
+
+        # DEPLOY_STRATEGY validation
+        if self._deploy_strategy_error:
+            errors.append(self._deploy_strategy_error)
+
+        if self.deploy_strategy.is_wave:
+            if self.override_stack:
+                errors.append("DEPLOY_STRATEGY wave modes are incompatible with OVERRIDE_STACK")
+            elif self.image_tag:
+                tag_type = detect_tag_type(self.image_tag)
+                if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
+                    errors.append(
+                        f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver "
+                        f"IMAGE_TAG, got '{self.image_tag}'"
+                    )
+
         return errors

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -85,7 +85,7 @@ class EnvironmentConfig:
 
         # Keep the legacy `multi_stage` flag in sync so the existing cloud×stage grouping
         # branch (which keys off plan.multi_stage) fires for DEPLOY_STRATEGY=cloud_multi_stage too.
-        multi_stage = multi_stage_raw or (deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE)
+        multi_stage = deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
 
         config = cls(
             helm_chart=env.get("HELM_CHART", ""),
@@ -171,7 +171,11 @@ class EnvironmentConfig:
         if self.deploy_strategy.is_wave:
             if self.override_stack:
                 errors.append("DEPLOY_STRATEGY wave modes are incompatible with OVERRIDE_STACK")
-            elif self.image_tag:
+            elif not self.image_tag:
+                errors.append(
+                    f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver IMAGE_TAG"
+                )
+            else:
                 tag_type = detect_tag_type(self.image_tag)
                 if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
                     errors.append(

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -8,6 +8,8 @@ This is a pure module - no side effects, just data transformation.
 from dataclasses import dataclass, field
 from typing import List, Dict, Optional, Tuple, Any
 
+from .models import DeployStrategy
+
 
 @dataclass
 class EnvironmentConfig:
@@ -19,6 +21,8 @@ class EnvironmentConfig:
     automerge: bool = True
     dry_run: bool = False
     multi_stage: bool = False
+    deploy_strategy: DeployStrategy = DeployStrategy.STANDARD
+    _deploy_strategy_error: Optional[str] = field(default=None, init=False, repr=False)
     target_path: str = "."
     commit_sha: bool = False
     override_stack: str = ""
@@ -60,21 +64,46 @@ class EnvironmentConfig:
             except Exception:
                 pass  # Ignore invalid metadata
         
+        # Parse DEPLOY_STRATEGY (default standard). MULTI_STAGE=true is a deprecated
+        # alias for cloud_multi_stage when DEPLOY_STRATEGY is not explicitly set.
+        raw_strategy = env.get("DEPLOY_STRATEGY", "").strip().lower()
+        multi_stage_raw = env.get("MULTI_STAGE", "false").lower() == "true"
+        deploy_strategy = DeployStrategy.STANDARD
+        deploy_strategy_error = None
+        if raw_strategy:
+            try:
+                deploy_strategy = DeployStrategy(raw_strategy)
+            except ValueError:
+                deploy_strategy_error = (
+                    f"Invalid DEPLOY_STRATEGY: '{raw_strategy}'. "
+                    "Must be one of: standard, cloud_multi_stage, gradual, critical, critical-manual-gate"
+                )
+            if multi_stage_raw and deploy_strategy != DeployStrategy.CLOUD_MULTI_STAGE:
+                print("WARNING: MULTI_STAGE=true is ignored because DEPLOY_STRATEGY is set explicitly")
+        elif multi_stage_raw:
+            deploy_strategy = DeployStrategy.CLOUD_MULTI_STAGE
+
+        # Keep the legacy `multi_stage` flag in sync so the existing cloud×stage grouping
+        # branch (which keys off plan.multi_stage) fires for DEPLOY_STRATEGY=cloud_multi_stage too.
+        multi_stage = multi_stage_raw or (deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE)
+
         config = cls(
             helm_chart=env.get("HELM_CHART", ""),
             image_tag=env.get("IMAGE_TAG", "").strip(),
             github_token=env.get("GH_TOKEN", ""),
             automerge=env.get("AUTOMERGE", "true").lower() == "true",
             dry_run=env.get("DRY_RUN", "false").lower() == "true",
-            multi_stage=env.get("MULTI_STAGE", "false").lower() == "true",
+            multi_stage=multi_stage,
             target_path=env.get("TARGET_PATH", "."),
             commit_sha=env.get("COMMIT_PIPELINE_SHA", "false").lower() == "true",
             override_stack=env.get("OVERRIDE_STACK", "").strip(),
             approve_token=env.get("GH_APPROVE_TOKEN", "").strip(),
             extra_tags=extra_tags,
-            metadata=metadata
+            metadata=metadata,
+            deploy_strategy=deploy_strategy,
         )
         config._extra_tag_errors = extra_tag_errors
+        config._deploy_strategy_error = deploy_strategy_error
         return config
     
     def validate(self) -> List[str]:

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -380,6 +380,14 @@ class IOLayer:
                         pr_url=pr.html_url
                     )
 
+    def find_prs_by_label(self, label: str) -> List[int]:
+        """Return open PR numbers carrying the given label (idempotency check)."""
+        numbers = []
+        for issue in self.github_repo.get_issues(state="open", labels=[label]):
+            if issue.pull_request is not None:
+                numbers.append(issue.number)
+        return numbers
+
     def _ensure_labels_exist(self, names: List[str]) -> None:
         """Create-if-missing each label (tolerate already-exists)."""
         for name in names:

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -243,34 +243,38 @@ class IOLayer:
         body: str,
         branch_name: str,
         base_branch: str = "main",
-        auto_merge: bool = False
+        auto_merge: bool = False,
+        labels: Optional[List[str]] = None,
     ) -> Optional[str]:
         """Create a GitHub pull request.
-        
+
         Args:
             title: PR title
             body: PR body/description
             branch_name: Head branch name
             base_branch: Base branch name
             auto_merge: If True, attempt to auto-merge
-            
+            labels: Optional labels to provision (create-if-missing) and apply
+
         Returns:
             PR URL if created, None if dry run
         """
         print(f"🚀 Creating PR: '{title}'")
         print(f"   - Base: {base_branch}, Head: {branch_name}")
         print(f"   - Auto-merge requested: {'YES' if auto_merge else 'NO'}")
-        
+
         if self.dry_run:
             merge_status = "and auto-merge" if auto_merge else "without auto-merge"
             print(f"[DRY RUN] Would create PR: '{title}' {merge_status}")
             print(f"[DRY RUN] Base: {base_branch}, Head: {branch_name}")
+            if labels:
+                print(f"[DRY RUN] Labels: {', '.join(labels)}")
             print(f"[DRY RUN] Body:\n{body}")
             return None
-        
+
         # Push the branch first
         self.push_branch(branch_name)
-        
+
         # Create the PR
         pr = self.github_repo.create_pull(
             title=title,
@@ -278,9 +282,14 @@ class IOLayer:
             head=branch_name,
             base=base_branch
         )
-        
+
         print(f"PR created: {pr.html_url}")
-        
+
+        if labels:
+            self._ensure_labels_exist(labels)
+            pr.add_to_labels(*labels)
+            print(f"🏷️  Applied labels: {', '.join(labels)}")
+
         # Auto-merge if requested
         if auto_merge:
             print(f"🔄 Auto-merge requested - attempting to merge PR...")
@@ -371,10 +380,25 @@ class IOLayer:
                         pr_url=pr.html_url
                     )
 
+    def _ensure_labels_exist(self, names: List[str]) -> None:
+        """Create-if-missing each label (tolerate already-exists)."""
+        for name in names:
+            try:
+                self.github_repo.get_label(name)
+            except GithubException as e:
+                if e.status == 404:
+                    try:
+                        self.github_repo.create_label(name=name, color="ededed")
+                    except GithubException as ce:
+                        if ce.status != 422:  # 422 = already exists (race) → fine
+                            raise
+                else:
+                    raise
+
     # -----------------------------------------------------------------------------
     # High-Level Combined Operations
     # -----------------------------------------------------------------------------
-    
+
     def create_branch_commit_and_pr(
         self,
         branch_name: str,
@@ -383,7 +407,8 @@ class IOLayer:
         pr_title: str,
         pr_body: str,
         base_branch: str = "main",
-        auto_merge: bool = False
+        auto_merge: bool = False,
+        labels: Optional[List[str]] = None,
     ) -> Optional[str]:
         """Create a branch, commit files, and create a PR in one operation.
         
@@ -403,7 +428,8 @@ class IOLayer:
             pr_body: PR body/description
             base_branch: Base branch for the PR
             auto_merge: If True, attempt to auto-merge
-            
+            labels: Optional labels to provision (create-if-missing) and apply
+
         Returns:
             PR URL if created, None if dry run
         """
@@ -425,5 +451,6 @@ class IOLayer:
             body=pr_body,
             branch_name=branch_name,
             base_branch=base_branch,
-            auto_merge=auto_merge
+            auto_merge=auto_merge,
+            labels=labels,
         )

--- a/helm_image_updater/models.py
+++ b/helm_image_updater/models.py
@@ -60,6 +60,7 @@ class PRPlan:
     auto_merge: bool
     files_to_commit: List[str]  # List of file paths that will be committed
     commit_message: str
+    labels: List[str] = field(default_factory=list)
     
     
 @dataclass

--- a/helm_image_updater/models.py
+++ b/helm_image_updater/models.py
@@ -14,6 +14,24 @@ class UpdateStrategy(Enum):
     INVALID = "invalid"
 
 
+class DeployStrategy(Enum):
+    """Deploy strategy (the DEPLOY_STRATEGY knob). Values double as the `deploy:*`
+    label value for promoter-managed (wave) strategies."""
+    STANDARD = "standard"
+    CLOUD_MULTI_STAGE = "cloud_multi_stage"
+    GRADUAL = "gradual"
+    CRITICAL = "critical"
+    CRITICAL_MANUAL_GATE = "critical-manual-gate"
+
+    @property
+    def is_wave(self) -> bool:
+        return self in (
+            DeployStrategy.GRADUAL,
+            DeployStrategy.CRITICAL,
+            DeployStrategy.CRITICAL_MANUAL_GATE,
+        )
+
+
 @dataclass
 class TagChange:
     """Represents a change to be made to a tag."""

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -529,6 +529,9 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
     elif pr_type == 'canary':
         # Canary: dummy-service-canary-canary-tag-abc1
         branch_name = f"{plan.helm_chart}-canary-{plan.image_tag}-{suffix}"
+    elif pr_type == 'wave':
+        wave = pr_group['wave_number']
+        branch_name = f"{plan.helm_chart}-wave{wave}-{plan.image_tag}-{suffix}"
     else:
         # Standard: dummy-service-production-tag-abc1
         branch_name = f"{plan.helm_chart}-{plan.image_tag}-{suffix}"
@@ -544,23 +547,28 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         target_stacks=pr_group['stacks']
     )
     
-    # Generate PR title prefix
-    pr_title_prefix = generate_pr_title_prefix(
-        strategy=plan.strategy,
-        is_multi_stage=plan.multi_stage,
-        user_requested_automerge=config.automerge,
-        target_stacks=pr_group['stacks'],
-        cloud_provider=pr_group.get('cloud_provider')
-    )
-    
     # Generate PR title
-    pr_title = generate_pr_title(
-        pr_title_prefix=pr_title_prefix,
-        helm_chart=plan.helm_chart,
-        image_tag=plan.image_tag,
-        extra_tags=plan.extra_tags,
-        target_stacks=pr_group['stacks']
-    )
+    if pr_type == 'wave':
+        wave = pr_group['wave_number']
+        pr_title = (
+            f"[{plan.helm_chart} {config.deploy_strategy.value} wave {wave}] "
+            f"{plan.helm_chart}@{plan.image_tag}"
+        )
+    else:
+        pr_title_prefix = generate_pr_title_prefix(
+            strategy=plan.strategy,
+            is_multi_stage=plan.multi_stage,
+            user_requested_automerge=config.automerge,
+            target_stacks=pr_group['stacks'],
+            cloud_provider=pr_group.get('cloud_provider')
+        )
+        pr_title = generate_pr_title(
+            pr_title_prefix=pr_title_prefix,
+            helm_chart=plan.helm_chart,
+            image_tag=plan.image_tag,
+            extra_tags=plan.extra_tags,
+            target_stacks=pr_group['stacks']
+        )
     
     # Collect removed overrides for PR body
     removed_overrides = []
@@ -601,7 +609,8 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         base_branch=pr_group['base_branch'],
         auto_merge=auto_merge,
         files_to_commit=files_to_commit,
-        commit_message=commit_message
+        commit_message=commit_message,
+        labels=pr_group.get('labels', []),
     )
 
 

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -10,7 +10,8 @@ from ruamel.yaml import YAML, YAMLError
 _ryaml = YAML()
 _ryaml.preserve_quotes = True
 
-from .models import UpdatePlan, FileChange, PRPlan, UpdateStrategy, TagChange
+from .models import UpdatePlan, FileChange, PRPlan, UpdateStrategy, TagChange, DeployStrategy
+from .wave_planning import compute_release_id, release_id_label, wave_label, deploy_label, resolve_wave
 from .environment import EnvironmentConfig
 from .io_layer import IOLayer
 from .tag_classification import detect_tag_type, TagType
@@ -405,7 +406,11 @@ def _group_changes_for_prs(
     io_layer: IOLayer
 ) -> List[Dict[str, Any]]:
     """Group changes into pull requests based on strategy."""
-    
+
+    # Promoter-managed wave strategies: one PR per wave (0..3), unmerged, labeled.
+    if config.deploy_strategy.is_wave:
+        return _group_changes_by_wave(stack_changes, plan, config, io_layer)
+
     if plan.strategy == UpdateStrategy.CANARY:
         # Canary: always one PR
         return [{
@@ -488,6 +493,42 @@ def _group_changes_for_prs(
             }
             for sc in stack_changes
         ]
+
+
+def _group_changes_by_wave(stack_changes, plan, config, io_layer):
+    """Group changes into one PR per rollout wave (0..3) for promoter consumption."""
+    release_id = compute_release_id(plan.helm_chart, plan.image_tag)
+    deploy_lbl = deploy_label(config.deploy_strategy)
+
+    by_wave = {}
+    for sc in stack_changes:
+        metadata = io_layer.read_yaml(f"{sc['stack']}/stack-metadata.yaml")
+        wave = resolve_wave(sc['stack'], metadata)
+        by_wave.setdefault(wave, []).append(sc)
+
+    present = set(by_wave)
+    required = {0, 1, 2, 3}
+    if present != required:
+        missing = sorted(required - present)
+        raise RuntimeError(
+            f"Wave deploy requires non-empty waves 0..3 (promoter needs a contiguous "
+            f"release:wave:0..3); missing/empty waves: {missing}. "
+            f"Check rollout_wave in stack-metadata.yaml across target stacks."
+        )
+
+    groups = []
+    for wave in sorted(by_wave):
+        changes = by_wave[wave]
+        groups.append({
+            'stacks': [sc['stack'] for sc in changes],
+            'changes': changes,
+            'base_branch': 'main',
+            'pr_type': 'wave',
+            'wave_number': wave,
+            'release_id': release_id,
+            'labels': [release_id_label(release_id), wave_label(wave), deploy_lbl],
+        })
+    return groups
 
 
 def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: EnvironmentConfig) -> PRPlan:

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -626,7 +626,11 @@ def _should_auto_merge(plan: UpdatePlan, pr_type: str, user_requested: bool) -> 
     if plan.strategy == UpdateStrategy.CANARY:
         print(f"       - result: TRUE (canary always auto-merges)")
         return True  # Always auto-merge canary
-    
+
+    if pr_type == 'wave':
+        print(f"       - result: FALSE (wave PRs are merged by release-promoter)")
+        return False
+
     if pr_type == 'multi_stage_prod':
         print(f"       - result: FALSE (multi-stage prod never auto-merges)")
         return False  # Never auto-merge multi-stage production

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -632,13 +632,13 @@ def _should_auto_merge(plan: UpdatePlan, pr_type: str, user_requested: bool) -> 
     print(f"       - pr_type: {pr_type}")
     print(f"       - user_requested: {user_requested}")
     
-    if plan.strategy == UpdateStrategy.CANARY:
-        print(f"       - result: TRUE (canary always auto-merges)")
-        return True  # Always auto-merge canary
-
     if pr_type == 'wave':
         print(f"       - result: FALSE (wave PRs are merged by release-promoter)")
         return False
+
+    if plan.strategy == UpdateStrategy.CANARY:
+        print(f"       - result: TRUE (canary always auto-merges)")
+        return True  # Always auto-merge canary
 
     if pr_type == 'multi_stage_prod':
         print(f"       - result: FALSE (multi-stage prod never auto-merges)")

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -463,36 +463,14 @@ def _group_changes_for_prs(
         print(f"📊 Total PR groups created: {len(groups)}")
         return groups
     
-    # Default: one PR per stack or all in one
-    if len(stack_changes) == 1 or plan.strategy in (UpdateStrategy.DEV, UpdateStrategy.OVERRIDE):
-        # Single stack or dev or override: one PR
-        return [{
-            'stacks': [sc['stack'] for sc in stack_changes],
-            'changes': stack_changes,
-            'base_branch': 'main',
-            'pr_type': 'standard'
-        }]
-    
-    # Production without multi-stage: based on automerge
-    if config.automerge:
-        # One PR for all
-        return [{
-            'stacks': [sc['stack'] for sc in stack_changes],
-            'changes': stack_changes,
-            'base_branch': 'main',
-            'pr_type': 'standard'
-        }]
-    else:
-        # One PR per stack
-        return [
-            {
-                'stacks': [sc['stack']],
-                'changes': [sc],
-                'base_branch': 'main',
-                'pr_type': 'standard'
-            }
-            for sc in stack_changes
-        ]
+    # Production without multi-stage: a single PR regardless of automerge.
+    # (automerge=false now yields ONE unmerged PR, not one-per-stack.)
+    return [{
+        'stacks': [sc['stack'] for sc in stack_changes],
+        'changes': stack_changes,
+        'base_branch': 'main',
+        'pr_type': 'standard'
+    }]
 
 
 def _group_changes_by_wave(stack_changes, plan, config, io_layer):

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -87,7 +87,11 @@ def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
     
     # Group changes into PRs
     pr_groups = _group_changes_for_prs(stack_changes, plan, config, io_layer)
-    
+
+    # Idempotency: in wave mode, never fan out a duplicate release.
+    if config.deploy_strategy.is_wave and not config.dry_run and pr_groups:
+        _guard_release_not_already_open(pr_groups[0]['release_id'], io_layer)
+
     # Create PR plans
     for pr_group in pr_groups:
         pr_plan = _create_pr_plan(pr_group, plan, config)
@@ -507,6 +511,21 @@ def _group_changes_by_wave(stack_changes, plan, config, io_layer):
             'labels': [release_id_label(release_id), wave_label(wave), deploy_lbl],
         })
     return groups
+
+
+def _guard_release_not_already_open(release_id: str, io_layer: IOLayer) -> None:
+    """Fail loudly if a release with this id already has open PRs (re-run safety).
+
+    Creating a second set of wave PRs with the same release:id would give promoter
+    duplicate release:wave:N labels -> ¬wellFormed -> Conflicted.
+    """
+    existing = io_layer.find_prs_by_label(release_id_label(release_id))
+    if existing:
+        raise RuntimeError(
+            f"Release '{release_id}' already has open PRs {existing}. "
+            f"Refusing to create duplicate wave PRs (would make the release Conflicted). "
+            f"Close/finish the existing release first."
+        )
 
 
 def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: EnvironmentConfig) -> PRPlan:

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -482,6 +482,9 @@ def _group_changes_by_wave(stack_changes, plan, config, io_layer):
     release_id = compute_release_id(plan.helm_chart, plan.image_tag)
     deploy_lbl = deploy_label(config.deploy_strategy)
 
+    # Never roll an e2e stack into a production wave (defensive — known e2e are also in EXCLUDED_STACKS).
+    stack_changes = [sc for sc in stack_changes if not sc['stack'].endswith('-e2e')]
+
     by_wave = {}
     for sc in stack_changes:
         metadata = io_layer.read_yaml(f"{sc['stack']}/stack-metadata.yaml")

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -467,14 +467,36 @@ def _group_changes_for_prs(
         print(f"📊 Total PR groups created: {len(groups)}")
         return groups
     
-    # Production without multi-stage: a single PR regardless of automerge.
-    # (automerge=false now yields ONE unmerged PR, not one-per-stack.)
-    return [{
-        'stacks': [sc['stack'] for sc in stack_changes],
-        'changes': stack_changes,
-        'base_branch': 'main',
-        'pr_type': 'standard'
-    }]
+    # Default: one PR per stack or all in one
+    if len(stack_changes) == 1 or plan.strategy in (UpdateStrategy.DEV, UpdateStrategy.OVERRIDE):
+        # Single stack or dev or override: one PR
+        return [{
+            'stacks': [sc['stack'] for sc in stack_changes],
+            'changes': stack_changes,
+            'base_branch': 'main',
+            'pr_type': 'standard'
+        }]
+
+    # Production without multi-stage: based on automerge
+    if config.automerge:
+        # One PR for all
+        return [{
+            'stacks': [sc['stack'] for sc in stack_changes],
+            'changes': stack_changes,
+            'base_branch': 'main',
+            'pr_type': 'standard'
+        }]
+    else:
+        # One PR per stack
+        return [
+            {
+                'stacks': [sc['stack']],
+                'changes': [sc],
+                'base_branch': 'main',
+                'pr_type': 'standard'
+            }
+            for sc in stack_changes
+        ]
 
 
 def _group_changes_by_wave(stack_changes, plan, config, io_layer):

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -75,6 +75,8 @@ def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResu
             print(f"  Base: {pr_plan.base_branch}")
             print(f"  Auto-merge: {pr_plan.auto_merge}")
             print(f"  Files: {', '.join(pr_plan.files_to_commit)}")
+            if pr_plan.labels:
+                print(f"  Labels: {', '.join(pr_plan.labels)}")
         else:
             # Step 1: Write files to disk first
             relevant_file_changes = [fc for fc in plan.file_changes 
@@ -89,7 +91,8 @@ def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResu
                 pr_title=pr_plan.pr_title,
                 pr_body=pr_plan.pr_body,
                 base_branch=pr_plan.base_branch,
-                auto_merge=pr_plan.auto_merge
+                auto_merge=pr_plan.auto_merge,
+                labels=pr_plan.labels,
             )
 
             if pr_url:

--- a/helm_image_updater/wave_planning.py
+++ b/helm_image_updater/wave_planning.py
@@ -40,11 +40,12 @@ def deploy_label(strategy: DeployStrategy) -> str:
 
 
 def resolve_wave(stack: str, metadata: Optional[Dict]) -> int:
-    """wave(stack) = explicit `rollout_wave` if present (0..3), else dev->0 / other->3."""
+    """wave(stack) = explicit `rollout_wave` if present (integer 0..3), else dev->0 / other->3."""
     if metadata and "rollout_wave" in metadata:
         raw = metadata["rollout_wave"]
-        wave = int(raw)
-        if wave < 0 or wave > 3:
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise ValueError(f"rollout_wave for {stack} must be an integer 0..3, got {raw!r}")
+        if raw < 0 or raw > 3:
             raise ValueError(f"rollout_wave for {stack} must be 0..3, got {raw}")
-        return wave
+        return raw
     return 0 if classify_stack(stack).is_dev else 3

--- a/helm_image_updater/wave_planning.py
+++ b/helm_image_updater/wave_planning.py
@@ -1,0 +1,39 @@
+"""Pure helpers for promoter-managed (wave) deploys.
+
+No I/O — only data transformation. Consumed by plan_builder.
+"""
+
+import hashlib
+from typing import Dict, List, Optional
+
+from .models import DeployStrategy
+from .stack_classification import classify_stack
+
+# GitHub caps label names at 50 chars; "release:id:" eats 11, leaving 39.
+_RELEASE_ID_PREFIX = "release:id:"
+_RELEASE_ID_MAX = 50 - len(_RELEASE_ID_PREFIX)  # 39
+_HASH_LEN = 12
+
+
+def compute_release_id(helm_chart: str, image_tag: str) -> str:
+    """A stable, collision-resistant, length-bounded grouping key (<chart>-<hash>).
+
+    Promoter treats this as opaque (it gets the app from the PR diff), so the only
+    invariants are: fits the label limit, deterministic, unique per (chart, tag).
+    """
+    digest = hashlib.sha256(f"{helm_chart}\0{image_tag}".encode()).hexdigest()[:_HASH_LEN]
+    chart_room = _RELEASE_ID_MAX - 1 - _HASH_LEN  # room for "<chart>-"
+    chart = helm_chart[:chart_room]
+    return f"{chart}-{digest}"
+
+
+def release_id_label(release_id: str) -> str:
+    return f"{_RELEASE_ID_PREFIX}{release_id}"
+
+
+def wave_label(wave: int) -> str:
+    return f"release:wave:{wave}"
+
+
+def deploy_label(strategy: DeployStrategy) -> str:
+    return f"deploy:{strategy.value}"

--- a/helm_image_updater/wave_planning.py
+++ b/helm_image_updater/wave_planning.py
@@ -37,3 +37,14 @@ def wave_label(wave: int) -> str:
 
 def deploy_label(strategy: DeployStrategy) -> str:
     return f"deploy:{strategy.value}"
+
+
+def resolve_wave(stack: str, metadata: Optional[Dict]) -> int:
+    """wave(stack) = explicit `rollout_wave` if present (0..3), else dev->0 / other->3."""
+    if metadata and "rollout_wave" in metadata:
+        raw = metadata["rollout_wave"]
+        wave = int(raw)
+        if wave < 0 or wave > 3:
+            raise ValueError(f"rollout_wave for {stack} must be 0..3, got {raw}")
+        return wave
+    return 0 if classify_stack(stack).is_dev else 3

--- a/tests/test_cli_functional.py
+++ b/tests/test_cli_functional.py
@@ -363,7 +363,7 @@ def test_canary_tag_update(cli_test_env, capsys):
     # Mock create_pr to track PRs created
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base_branch})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base_branch})")
@@ -615,7 +615,7 @@ def test_valid_extra_tag_formats(cli_test_env, capsys):
     # Track PRs
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base_branch})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base_branch})")
@@ -682,7 +682,7 @@ def test_nonexistent_stack_override(cli_test_env, capsys):
     # Track PRs
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base_branch})
 
     # Only mock create_pr, use real config
@@ -727,7 +727,7 @@ def test_multi_cloud_multi_stage_automerge_true(cli_test_env, capsys):
     # Track PRs with their automerge setting
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         created_prs.append(
             {
                 "branch": branch_name,
@@ -819,7 +819,7 @@ def test_multi_cloud_multi_stage_automerge_false(cli_test_env, capsys):
     # Track PRs with their automerge setting
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         created_prs.append(
             {
                 "branch": branch_name,
@@ -950,7 +950,7 @@ def test_custom_tag_with_override_stack(cli_test_env, capsys):
     # Track PRs
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base_branch})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base_branch})")
@@ -1003,7 +1003,7 @@ def test_dev_tag_with_production_override_stack(cli_test_env, capsys):
     # Track PRs
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base_branch})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base_branch})")
@@ -1125,7 +1125,7 @@ def test_semver_main_image_tag(cli_test_env, capsys):
     # Track PRs
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         """Mock PR creation to track PR details."""
         created_prs.append({"branch": branch_name, "title": pr_title, "base": base_branch})
         print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base_branch})")
@@ -1220,7 +1220,7 @@ def test_canary_tag_in_extra_tag_should_update_canary_stack(cli_test_env, mock_g
     # Mock create_pr to track PRs created
     created_prs = []
 
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False):
+    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
         """Mock PR creation to track PR details."""
         created_prs.append({
             "branch": branch_name,

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -161,3 +161,11 @@ def test_resolve_wave_rejects_out_of_range():
     import pytest
     with pytest.raises(ValueError):
         resolve_wave("kbc-us-east-1", {"rollout_wave": 5})
+
+
+def test_resolve_wave_rejects_non_integer():
+    import pytest
+    with pytest.raises(ValueError):
+        resolve_wave("kbc-us-east-1", {"rollout_wave": 1.9})
+    with pytest.raises(ValueError):
+        resolve_wave("kbc-us-east-1", {"rollout_wave": True})

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -169,3 +169,11 @@ def test_resolve_wave_rejects_non_integer():
         resolve_wave("kbc-us-east-1", {"rollout_wave": 1.9})
     with pytest.raises(ValueError):
         resolve_wave("kbc-us-east-1", {"rollout_wave": True})
+
+
+def test_empty_deploy_strategy_with_multi_stage_aliases_to_cloud_multi_stage():
+    # The action passes deploy-strategy='' by default; empty must behave as unset
+    # so MULTI_STAGE=true still aliases to cloud_multi_stage (legacy action callers).
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="", MULTI_STAGE="true"))
+    assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
+    assert cfg.multi_stage is True

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -73,3 +73,23 @@ def test_wave_strategy_rejected_with_override_stack():
     )
     errors = cfg.validate()
     assert any("OVERRIDE_STACK" in e for e in errors)
+
+
+from helm_image_updater.models import PRPlan
+
+
+def test_prplan_labels_defaults_empty():
+    p = PRPlan(
+        branch_name="b", pr_title="t", pr_body="body", base_branch="main",
+        auto_merge=False, files_to_commit=[], commit_message="c",
+    )
+    assert p.labels == []
+
+
+def test_prplan_labels_can_be_set():
+    p = PRPlan(
+        branch_name="b", pr_title="t", pr_body="body", base_branch="main",
+        auto_merge=False, files_to_commit=[], commit_message="c",
+        labels=["release:wave:0"],
+    )
+    assert p.labels == ["release:wave:0"]

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -109,3 +109,27 @@ def test_wave_strategy_requires_image_tag_not_just_extra_tag():
     })
     errors = cfg.validate()
     assert any("IMAGE_TAG" in e for e in errors)
+
+
+# Task 4: compute_release_id + label builders
+from helm_image_updater.wave_planning import compute_release_id, release_id_label
+
+GH_LABEL_MAX = 50
+
+
+def test_release_id_label_fits_github_limit_even_for_long_inputs():
+    rid = compute_release_id("infrastructure-plugin-update-components",
+                             "production-633743c4fc2431d3a9727987a3152a8ea5ec38c2")
+    assert len(release_id_label(rid)) <= GH_LABEL_MAX
+
+
+def test_release_id_is_deterministic():
+    a = compute_release_id("connection", "production-abc123")
+    b = compute_release_id("connection", "production-abc123")
+    assert a == b
+
+
+def test_release_id_distinct_for_distinct_tags():
+    a = compute_release_id("connection", "production-aaaa")
+    b = compute_release_id("connection", "production-bbbb")
+    assert a != b

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -133,3 +133,31 @@ def test_release_id_distinct_for_distinct_tags():
     a = compute_release_id("connection", "production-aaaa")
     b = compute_release_id("connection", "production-bbbb")
     assert a != b
+
+
+# Task 5: resolve_wave
+from helm_image_updater.wave_planning import resolve_wave
+
+
+def test_resolve_wave_uses_explicit_value():
+    assert resolve_wave("kbc-us-east-1", {"rollout_wave": 2}) == 2
+
+
+def test_resolve_wave_dev_defaults_to_0_when_missing():
+    # dev-keboola-gcp-us-central1 is a dev stack (DEV_STACK_MAPPING)
+    assert resolve_wave("dev-keboola-gcp-us-central1", None) == 0
+    assert resolve_wave("dev-keboola-gcp-us-central1", {}) == 0
+
+
+def test_resolve_wave_non_dev_defaults_to_3_when_missing():
+    assert resolve_wave("kbc-us-east-1", None) == 3
+
+
+def test_resolve_wave_explicit_overrides_dev_default():
+    assert resolve_wave("dev-keboola-gcp-us-central1", {"rollout_wave": 1}) == 1
+
+
+def test_resolve_wave_rejects_out_of_range():
+    import pytest
+    with pytest.raises(ValueError):
+        resolve_wave("kbc-us-east-1", {"rollout_wave": 5})

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -48,3 +48,28 @@ def test_cloud_multi_stage_sets_multi_stage_flag():
     cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="cloud_multi_stage"))
     assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
     assert cfg.multi_stage is True
+
+
+def test_unknown_deploy_strategy_is_a_validation_error():
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="gradul"))
+    errors = cfg.validate()
+    assert any("Invalid DEPLOY_STRATEGY" in e for e in errors)
+
+
+def test_wave_strategy_requires_production_tag():
+    cfg = EnvironmentConfig.from_env(_base_env(IMAGE_TAG="dev-abc", DEPLOY_STRATEGY="gradual"))
+    errors = cfg.validate()
+    assert any("requires a production" in e for e in errors)
+
+
+def test_wave_strategy_ok_with_production_tag():
+    cfg = EnvironmentConfig.from_env(_base_env(IMAGE_TAG="production-abc", DEPLOY_STRATEGY="gradual"))
+    assert cfg.validate() == []
+
+
+def test_wave_strategy_rejected_with_override_stack():
+    cfg = EnvironmentConfig.from_env(
+        _base_env(DEPLOY_STRATEGY="critical", OVERRIDE_STACK="kbc-us-east-1")
+    )
+    errors = cfg.validate()
+    assert any("OVERRIDE_STACK" in e for e in errors)

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -93,3 +93,19 @@ def test_prplan_labels_can_be_set():
         labels=["release:wave:0"],
     )
     assert p.labels == ["release:wave:0"]
+
+
+def test_explicit_standard_overrides_multi_stage_flag():
+    # DEPLOY_STRATEGY=standard wins over MULTI_STAGE=true: multi_stage must be False.
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="standard", MULTI_STAGE="true"))
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+    assert cfg.multi_stage is False
+
+
+def test_wave_strategy_requires_image_tag_not_just_extra_tag():
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+        "EXTRA_TAG1": "image.tag:production-abc", "DEPLOY_STRATEGY": "gradual",
+    })
+    errors = cfg.validate()
+    assert any("IMAGE_TAG" in e for e in errors)

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -1,0 +1,50 @@
+"""Tests for DEPLOY_STRATEGY parsing, validation, and wave helpers (PR-A)."""
+
+from helm_image_updater.environment import EnvironmentConfig
+from helm_image_updater.models import DeployStrategy
+
+
+def _base_env(**overrides):
+    env = {
+        "HELM_CHART": "dummy-service",
+        "IMAGE_TAG": "production-abc123",
+        "GH_TOKEN": "t",
+        "GH_APPROVE_TOKEN": "a",
+    }
+    env.update(overrides)
+    return env
+
+
+def test_deploy_strategy_defaults_to_standard():
+    cfg = EnvironmentConfig.from_env(_base_env())
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+
+
+def test_deploy_strategy_parses_known_values():
+    for raw, expected in [
+        ("standard", DeployStrategy.STANDARD),
+        ("cloud_multi_stage", DeployStrategy.CLOUD_MULTI_STAGE),
+        ("gradual", DeployStrategy.GRADUAL),
+        ("critical", DeployStrategy.CRITICAL),
+        ("critical-manual-gate", DeployStrategy.CRITICAL_MANUAL_GATE),
+    ]:
+        cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY=raw))
+        assert cfg.deploy_strategy == expected
+
+
+def test_multi_stage_true_aliases_to_cloud_multi_stage_when_unset():
+    cfg = EnvironmentConfig.from_env(_base_env(MULTI_STAGE="true"))
+    assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
+
+
+def test_unknown_deploy_strategy_does_not_silently_become_standard():
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="gradul"))
+    # Parsed value stays unset/standard, but an error is recorded for validate() (Task 2).
+    assert cfg._deploy_strategy_error is not None
+
+
+def test_cloud_multi_stage_sets_multi_stage_flag():
+    # DEPLOY_STRATEGY=cloud_multi_stage must drive the legacy multi_stage grouping branch.
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="cloud_multi_stage"))
+    assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
+    assert cfg.multi_stage is True

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -323,6 +323,30 @@ def test_multi_cloud_grouping_dev_strategy(test_stacks):
 
 # Override removal tests
 
+def test_standard_production_automerge_false_is_single_pr():
+    """standard + automerge=false now produces ONE unmerged PR (was per-stack)."""
+    from helm_image_updater.plan_builder import _group_changes_for_prs
+    from helm_image_updater.models import DeployStrategy
+
+    mock_io_layer = Mock()
+    mock_config = Mock()
+    mock_config.automerge = False
+    mock_config.deploy_strategy = DeployStrategy.STANDARD
+
+    mock_plan = Mock()
+    mock_plan.multi_stage = False
+    mock_plan.strategy = UpdateStrategy.PRODUCTION
+
+    stacks = ["com-keboola-gcp-prod", "com-keboola-azure-prod", "com-keboola-aws-prod"]
+    stack_changes = [{"stack": s, "file_change": Mock(), "changes": []} for s in stacks]
+
+    groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
+
+    assert len(groups) == 1
+    assert len(groups[0]["stacks"]) == 3
+    assert groups[0]["pr_type"] == "standard"
+
+
 class TestCheckAndRemoveOverride:
     """Tests for _check_and_remove_override function."""
 

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -323,8 +323,12 @@ def test_multi_cloud_grouping_dev_strategy(test_stacks):
 
 # Override removal tests
 
-def test_standard_production_automerge_false_is_single_pr():
-    """standard + automerge=false now produces ONE unmerged PR (was per-stack)."""
+def test_standard_production_automerge_false_is_one_pr_per_stack():
+    """standard production + automerge=false → ONE PR PER STACK (matches main).
+
+    (automerge=true stays a single PR for all stacks — see
+    test_multi_cloud_grouping_non_multi_stage.)
+    """
     from helm_image_updater.plan_builder import _group_changes_for_prs
     from helm_image_updater.models import DeployStrategy
 
@@ -342,9 +346,10 @@ def test_standard_production_automerge_false_is_single_pr():
 
     groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
 
-    assert len(groups) == 1
-    assert len(groups[0]["stacks"]) == 3
-    assert groups[0]["pr_type"] == "standard"
+    assert len(groups) == 3, f"expected one PR per stack, got {len(groups)}"
+    assert all(len(g["stacks"]) == 1 for g in groups)
+    assert {g["stacks"][0] for g in groups} == set(stacks)
+    assert all(g["pr_type"] == "standard" for g in groups)
 
 
 class TestCheckAndRemoveOverride:

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -184,7 +184,9 @@ def test_multi_cloud_multi_stage_grouping_production_tag(test_stacks):
     # Create mock environment config
     mock_config = Mock()
     mock_config.automerge = True
-    
+    from helm_image_updater.models import DeployStrategy
+    mock_config.deploy_strategy = DeployStrategy.STANDARD
+
     # Create mock plan
     mock_plan = Mock()
     mock_plan.multi_stage = True
@@ -244,7 +246,9 @@ def test_multi_cloud_grouping_non_multi_stage(test_stacks):
     # Create mock environment config
     mock_config = Mock()
     mock_config.automerge = True
-    
+    from helm_image_updater.models import DeployStrategy
+    mock_config.deploy_strategy = DeployStrategy.STANDARD
+
     # Create mock plan (non-multi-stage)
     mock_plan = Mock()
     mock_plan.multi_stage = False  # Non-multi-stage
@@ -287,7 +291,9 @@ def test_multi_cloud_grouping_dev_strategy(test_stacks):
     # Create mock environment config
     mock_config = Mock()
     mock_config.automerge = True
-    
+    from helm_image_updater.models import DeployStrategy
+    mock_config.deploy_strategy = DeployStrategy.STANDARD
+
     # Create mock plan (dev strategy, even with multi_stage=True)
     mock_plan = Mock()
     mock_plan.multi_stage = True

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -86,6 +86,15 @@ def test_wave_grouping_requires_all_waves_0_to_3():
         _group_changes_for_prs([_stack_change(s) for s in waves], plan, config, io)
 
 
+from helm_image_updater.plan_builder import _should_auto_merge
+
+
+def test_wave_pr_type_never_auto_merges():
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION
+    assert _should_auto_merge(plan, "wave", user_requested=True) is False
+    assert _should_auto_merge(plan, "wave", user_requested=False) is False
+
+
 def test_wave_grouping_rejects_gap():
     """waves {0,1,3} (no wave-2 stack) → RuntimeError."""
     import pytest

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -52,6 +52,26 @@ def test_wave_grouping_one_pr_per_wave_with_labels():
     assert "release:wave:1" in g1["labels"]
     assert "deploy:gradual" in g1["labels"]
 
+    # Strengthen: all 4 groups must have the correct label structure
+    release_id_labels = [
+        next(l for l in g["labels"] if l.startswith("release:id:"))
+        for g in groups
+    ]
+    # All groups share the same release:id label
+    assert len(set(release_id_labels)) == 1, (
+        f"All groups must share the same release:id:* label, got: {release_id_labels}"
+    )
+    # Each release:id label is ≤ 50 chars
+    for rid_label in release_id_labels:
+        assert len(rid_label) <= 50, f"release:id label too long: {rid_label!r}"
+
+    for g in groups:
+        wave = g["wave_number"]
+        expected_labels = [release_id_labels[0], f"release:wave:{wave}", "deploy:gradual"]
+        assert g["labels"] == expected_labels, (
+            f"Wave {wave} labels {g['labels']} != expected {expected_labels}"
+        )
+
 
 def test_wave_grouping_requires_all_waves_0_to_3():
     import pytest
@@ -64,3 +84,71 @@ def test_wave_grouping_requires_all_waves_0_to_3():
 
     with pytest.raises(RuntimeError, match="wave"):
         _group_changes_for_prs([_stack_change(s) for s in waves], plan, config, io)
+
+
+def test_wave_grouping_rejects_gap():
+    """waves {0,1,3} (no wave-2 stack) → RuntimeError."""
+    import pytest
+    waves = {
+        "dev-keboola-gcp-us-central1": 0,
+        "com-keboola-azure-north-europe": 1,
+        "cloud-keboola-cs": 3,
+    }
+    io = Mock()
+    io.read_yaml.side_effect = _wave_metadata(waves)
+    config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
+
+    with pytest.raises(RuntimeError, match="wave"):
+        _group_changes_for_prs([_stack_change(s) for s in waves], plan, config, io)
+
+
+def test_wave_grouping_rejects_missing_last():
+    """waves {0,1,2} (no wave-3 stack) → RuntimeError."""
+    import pytest
+    waves = {
+        "dev-keboola-gcp-us-central1": 0,
+        "com-keboola-azure-north-europe": 1,
+        "kbc-us-east-1": 2,
+    }
+    io = Mock()
+    io.read_yaml.side_effect = _wave_metadata(waves)
+    config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
+
+    with pytest.raises(RuntimeError, match="wave"):
+        _group_changes_for_prs([_stack_change(s) for s in waves], plan, config, io)
+
+
+def test_wave_grouping_missing_metadata_uses_defaults():
+    """read_yaml returns None for dev stack → defaults to wave 0; others explicit."""
+    waves_explicit = {
+        "com-keboola-azure-north-europe": 1,
+        "kbc-us-east-1": 2,
+        "cloud-keboola-cs": 3,
+    }
+    dev_stack = "dev-keboola-gcp-us-central1"
+
+    def _read(path):
+        # Return None for the dev stack, metadata dict for the others
+        for stack, wave in waves_explicit.items():
+            if path == f"{stack}/stack-metadata.yaml":
+                return {"rollout_wave": wave}
+        return None  # covers the dev stack and any unknown path
+
+    io = Mock()
+    io.read_yaml.side_effect = _read
+    config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc123"
+
+    all_stacks = [dev_stack] + list(waves_explicit.keys())
+    groups = _group_changes_for_prs([_stack_change(s) for s in all_stacks], plan, config, io)
+
+    assert len(groups) == 4
+    by_wave = {g["wave_number"]: g for g in groups}
+    assert set(by_wave) == {0, 1, 2, 3}
+    # The dev stack must have landed in wave 0
+    assert dev_stack in by_wave[0]["stacks"]

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -229,3 +229,21 @@ def test_create_pull_request_provisions_and_applies_labels():
     pr.add_to_labels.assert_called_once_with(
         "release:id:dummy-service-deadbeef0123", "release:wave:2", "deploy:gradual"
     )
+
+
+import pytest
+from helm_image_updater.plan_builder import _guard_release_not_already_open
+
+
+def test_guard_raises_when_release_id_already_has_open_prs():
+    io = Mock()
+    io.find_prs_by_label.return_value = [101, 102]  # existing open PRs
+    with pytest.raises(RuntimeError, match="already"):
+        _guard_release_not_already_open("dummy-service-deadbeef0123", io)
+
+
+def test_guard_passes_when_no_existing_prs():
+    io = Mock()
+    io.find_prs_by_label.return_value = []
+    # Should not raise.
+    _guard_release_not_already_open("dummy-service-deadbeef0123", io)

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -194,3 +194,8 @@ def test_create_pr_plan_wave_sets_labels_and_branch_title():
     assert pr_plan.auto_merge is False
     assert "wave2" in pr_plan.branch_name
     assert "wave 2" in pr_plan.pr_title
+
+
+def test_wave_never_auto_merges_even_for_canary_strategy():
+    plan = Mock(); plan.strategy = UpdateStrategy.CANARY
+    assert _should_auto_merge(plan, "wave", user_requested=True) is False

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -1,0 +1,66 @@
+"""Wave-mode grouping, auto-merge, labels, idempotency (PR-A)."""
+
+from unittest.mock import Mock
+from helm_image_updater.models import UpdateStrategy, DeployStrategy
+from helm_image_updater.plan_builder import _group_changes_for_prs
+
+
+def _stack_change(stack):
+    return {"stack": stack, "file_change": Mock(), "changes": []}
+
+
+def _wave_metadata(by_stack):
+    """Return a read_yaml side_effect mapping <stack>/stack-metadata.yaml -> dict."""
+    def _read(path):
+        for stack, wave in by_stack.items():
+            if path == f"{stack}/stack-metadata.yaml":
+                return {"rollout_wave": wave}
+        return None
+    return _read
+
+
+def test_wave_grouping_one_pr_per_wave_with_labels():
+    waves = {
+        "dev-keboola-gcp-us-central1": 0,
+        "com-keboola-azure-north-europe": 1,
+        "kbc-us-east-1": 2,
+        "cloud-keboola-cs": 3,
+    }
+    io = Mock()
+    io.read_yaml.side_effect = _wave_metadata(waves)
+
+    config = Mock()
+    config.deploy_strategy = DeployStrategy.GRADUAL
+
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    plan.multi_stage = False
+    plan.helm_chart = "dummy-service"
+    plan.image_tag = "production-abc123"
+
+    groups = _group_changes_for_prs(
+        [_stack_change(s) for s in waves], plan, config, io
+    )
+
+    assert len(groups) == 4
+    by_wave = {g["wave_number"]: g for g in groups}
+    assert set(by_wave) == {0, 1, 2, 3}
+    g1 = by_wave[1]
+    assert g1["pr_type"] == "wave"
+    assert g1["stacks"] == ["com-keboola-azure-north-europe"]
+    assert any(l.startswith("release:id:") for l in g1["labels"])
+    assert "release:wave:1" in g1["labels"]
+    assert "deploy:gradual" in g1["labels"]
+
+
+def test_wave_grouping_requires_all_waves_0_to_3():
+    import pytest
+    waves = {"dev-keboola-gcp-us-central1": 0, "kbc-us-east-1": 1}  # missing 2 and 3
+    io = Mock()
+    io.read_yaml.side_effect = _wave_metadata(waves)
+    config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
+
+    with pytest.raises(RuntimeError, match="wave"):
+        _group_changes_for_prs([_stack_change(s) for s in waves], plan, config, io)

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -161,3 +161,36 @@ def test_wave_grouping_missing_metadata_uses_defaults():
     assert set(by_wave) == {0, 1, 2, 3}
     # The dev stack must have landed in wave 0
     assert dev_stack in by_wave[0]["stacks"]
+
+
+from helm_image_updater.plan_builder import _create_pr_plan
+
+
+def test_create_pr_plan_wave_sets_labels_and_branch_title():
+    config = Mock(); config.automerge = False
+    config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    plan.multi_stage = False
+    plan.helm_chart = "dummy-service"
+    plan.image_tag = "production-abc123"
+    plan.extra_tags = []
+    plan.metadata = {}
+
+    fc = Mock(); fc.file_path = "kbc-us-east-1/dummy-service/tag.yaml"
+    group = {
+        'stacks': ["kbc-us-east-1"],
+        'changes': [{"stack": "kbc-us-east-1", "file_change": fc, "changes": []}],
+        'base_branch': 'main',
+        'pr_type': 'wave',
+        'wave_number': 2,
+        'release_id': 'dummy-service-deadbeef0123',
+        'labels': ["release:id:dummy-service-deadbeef0123", "release:wave:2", "deploy:gradual"],
+    }
+
+    pr_plan = _create_pr_plan(group, plan, config)
+
+    assert pr_plan.labels == group['labels']
+    assert pr_plan.auto_merge is False
+    assert "wave2" in pr_plan.branch_name
+    assert "wave 2" in pr_plan.pr_title

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -247,3 +247,22 @@ def test_guard_passes_when_no_existing_prs():
     io.find_prs_by_label.return_value = []
     # Should not raise.
     _guard_release_not_already_open("dummy-service-deadbeef0123", io)
+
+
+def test_wave_grouping_excludes_e2e_stacks():
+    waves = {
+        "dev-keboola-gcp-us-central1": 0,
+        "com-keboola-azure-north-europe": 1,
+        "kbc-us-east-1": 2,
+        "cloud-keboola-cs": 3,
+    }
+    io = Mock(); io.read_yaml.side_effect = _wave_metadata(waves)
+    config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
+    # an unlisted e2e stack must be dropped from waves, not placed in wave 3
+    changes = [_stack_change(s) for s in waves] + [_stack_change("foo-bar-e2e")]
+    groups = _group_changes_for_prs(changes, plan, config, io)
+    all_stacks = [s for g in groups for s in g["stacks"]]
+    assert "foo-bar-e2e" not in all_stacks
+    assert len(groups) == 4

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -199,3 +199,33 @@ def test_create_pr_plan_wave_sets_labels_and_branch_title():
 def test_wave_never_auto_merges_even_for_canary_strategy():
     plan = Mock(); plan.strategy = UpdateStrategy.CANARY
     assert _should_auto_merge(plan, "wave", user_requested=True) is False
+
+
+from helm_image_updater.io_layer import IOLayer
+from github.GithubException import GithubException
+
+
+def test_create_pull_request_provisions_and_applies_labels():
+    repo = Mock()
+    # get_label raises 404 for the dynamic release:id label, succeeds otherwise
+    def _get_label(name):
+        if name.startswith("release:id:"):
+            raise GithubException(404, {"message": "Not Found"}, None)
+        return Mock()
+    repo.get_label.side_effect = _get_label
+    pr = Mock(); pr.html_url = "http://x/1"; pr.number = 1
+    repo.create_pull.return_value = pr
+
+    io = IOLayer(Mock(), repo, dry_run=False, approve_github_repo=Mock())
+    io.push_branch = Mock()  # avoid real git push
+
+    io.create_pull_request(
+        title="t", body="b", branch_name="br", base_branch="main",
+        auto_merge=False,
+        labels=["release:id:dummy-service-deadbeef0123", "release:wave:2", "deploy:gradual"],
+    )
+
+    repo.create_label.assert_called()  # created the missing release:id label
+    pr.add_to_labels.assert_called_once_with(
+        "release:id:dummy-service-deadbeef0123", "release:wave:2", "deploy:gradual"
+    )


### PR DESCRIPTION
## What & why ([ST-4034](https://linear.app/keboola/issue/ST-4034))

Teaches `helm-image-updater` to emit the PRs that **release-promoter** consumes, so promoter can stage a wave-by-wave rollout. Adds a single `DEPLOY_STRATEGY` knob; the wave strategies fan a production deploy into **4 unmerged, labeled wave PRs** that promoter merges as each wave soaks and verifies.

**Purely additive for existing deploys** — `standard` / dev / canary / multi-stage behave exactly as today; only the new `gradual|critical|critical-manual-gate` strategies add behavior.

Supersedes #19 — reuses its "decouple *how many PRs* from *do we merge*" idea, rebuilt around `DEPLOY_STRATEGY`.

## `DEPLOY_STRATEGY` (new input, default `standard`)

| value | grouping | `AUTOMERGE=true` | `AUTOMERGE=false` | promoter labels |
|---|---|---|---|---|
| `standard` (default) | 1 PR — **per-stack** for a prod tag | merge the 1 PR | **per-stack PRs, unmerged** | none |
| `cloud_multi_stage` | cloud×stage PRs | dev merge, prod never | all unmerged | none |
| `gradual` / `critical` / `critical-manual-gate` | per-wave PRs (0–3) | *(ignored)* — promoter merges | promoter merges | `release:id` · `release:wave:N` · `deploy:<strategy>` |

`standard` grouping is **today's HIU logic, unchanged**: one PR for `AUTOMERGE=true` / dev / single-stack / override; one PR **per stack** for a production tag with `AUTOMERGE=false`.

## Behavior changes vs today — none for existing paths

This PR is **purely additive**:

- `standard`, dev, and canary deploys are **unchanged** (`standard` grouping is byte-for-byte today's logic, incl. prod + `AUTOMERGE=false` → per-stack).
- `MULTI_STAGE=true` becomes a **deprecated alias** for `DEPLOY_STRATEGY=cloud_multi_stage` — **behavior identical** (an explicit `DEPLOY_STRATEGY` wins if both are set).
- The only **new** behavior is the wave strategies (`gradual|critical|critical-manual-gate`).

## Test
I have run this branch on helm-image-updater-testing and verified:
- ✅ testing workflow passed on the main branch https://github.com/keboola/helm-image-updater-testing/actions/runs/27137697203
- ✅ testing workflow passed on the [ST-4034-pr-b-gradual-test branch](https://github.com/keboola/helm-image-updater-testing/pull/1661) introducing tests for promoter specific scenarios (gradual, critical, critical-manual-gate...). https://github.com/keboola/helm-image-updater-testing/actions/runs/27134304487

## How wave mode works

- Wave membership: per-stack `rollout_wave` (0–3) in `stack-metadata.yaml`; default **dev→0 / other→3**. Requires contiguous waves 0..3 (errors loudly otherwise); `*-e2e` stacks excluded.
- `release:id` = compact `<chart>-<sha256-slug>`, kept ≤ GitHub's 50-char label limit, opaque to promoter (it derives the app from the PR diff).
- HIU **never merges** wave PRs (promoter owns every merge, incl. wave 0) but still auto-approves them.
- **Idempotency**: a re-run refuses to fan out a duplicate `release:id` (which would make promoter mark the release `Conflicted`).

## Deploy prerequisites (wave strategies only)

Surfaced by the integration test — required wherever wave PRs are produced/merged (e.g. `kbc-stacks`):

1. **The HIU deploy token needs `Issues: write`.** GitHub manages PR **labels** under the *Issues* permission, so creating/attaching `release:*` / `deploy:*` requires it — a token with only `pull-requests: write` returns `403 "Resource not accessible by integration"`. (Standard/multi-stage paths are unaffected — they don't label PRs.)
2. **The promoter's GitHub App needs `Contents: write` + `Pull requests: write` + `Issues: write`** (and `Metadata: read`). Merging a wave PR writes a merge commit to the base branch, and GitHub's *Contents* permission covers "merges" — so `pull-requests: write` **alone is not enough**; without `contents: write` the merge returns `403 "Resource not accessible by integration"`. (`Issues: write` is the promoter's own labels/comments; `Contents: read` already covers commit-ancestry/compare.)
3. **The promoter's merge identity must be a branch-ruleset bypass actor** — *or* HIU must auto-approve each wave PR as the real CODEOWNERS reviewer (`keboola-sre-approve-bot`) so a plain merge satisfies `require_code_owner_review`.

## Out of scope (deferred)

- `rollout_wave` data for real `kbc-stacks` stacks (authored separately).
- No `release-promoter` changes.

## Testing & review

- **115 unit tests**, strict TDD (one logical step per commit). Reviewed per-task and whole-PR with Codex; a blocker (action input defaulting to `standard` would have broken legacy `multi-stage:true` callers) was caught and fixed.
- **End-to-end validated** by the companion **helm-image-updater-testing** PR (PR-B): HIU emits the 4 labeled wave PRs and release-promoter drives them to `promoter:complete` across the full strategy matrix — `gradual` / `critical` / `critical-manual-gate`, two failure-halt scenarios (wave-1 sync + wave-2 UAT), and the per-app-FIFO `parallel` + `same-app-serialize` cases — verifying strict `0→1→2→3` order and sync / UAT / soak gating (UAT runs on every wave, wave 0 included). ✅
- Spec: `deploy-strategy-promoter-integration.md` · Plan: `docs/plans/2026-06-05-deploy-strategy-wave-pr-a.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
