### PR TITLE
feat: wave-PR cross-links — search link + anchor wave list [ST-4035]

### DIFF
--- a/helm_image_updater/message_generation.py
+++ b/helm_image_updater/message_generation.py
@@ -113,7 +113,9 @@ def build_tag_string(
     extra_tags: Optional[List[Dict[str, str]]]
 ) -> str:
     """
-    Build the chart+tags string shared by all wave PR titles.
+    Build the chart+tags string used in PR titles (all types, via generate_pr_title)
+    and quoted by the wave release-search link. Wave PR titles embed it verbatim,
+    so the quoted-phrase search matches every wave PR of a release.
 
     Pure function returning e.g. "connection@production-abc path@value".
 

--- a/helm_image_updater/message_generation.py
+++ b/helm_image_updater/message_generation.py
@@ -6,6 +6,7 @@ This module contains no side effects - only text formatting logic.
 """
 
 from typing import List, Dict, Optional, Any
+from urllib.parse import quote
 
 from .stack_classification import classify_stack
 from .models import UpdateStrategy
@@ -106,6 +107,55 @@ def generate_pr_title_prefix(
         return "[prod sync]"
 
 
+def build_tag_string(
+    helm_chart: str,
+    image_tag: str,
+    extra_tags: Optional[List[Dict[str, str]]]
+) -> str:
+    """
+    Build the chart+tags string shared by all wave PR titles.
+
+    Pure function returning e.g. "connection@production-abc path@value".
+
+    Args:
+        helm_chart: Name of the Helm chart
+        image_tag: The image tag
+        extra_tags: Optional list of extra tags
+
+    Returns:
+        Tag string of the form "<chart>@<tag> <path>@<value> ..."
+    """
+    image_tag_str = (f"@{image_tag}" if image_tag else "") + "".join(
+        f" {tag['path']}@{tag['value']}" for tag in (extra_tags or [])
+    )
+    return f"{helm_chart}{image_tag_str}"
+
+
+def wave_release_search_link(
+    repo_full_name: str,
+    helm_chart: str,
+    image_tag: str,
+    extra_tags: Optional[List[Dict[str, str]]]
+) -> str:
+    """
+    Build a GitHub PR-search URL matching every wave PR of this release.
+
+    Pure function. All wave PR titles contain the exact chart+tags substring,
+    so a quoted-phrase search finds all of them without knowing PR numbers.
+
+    Args:
+        repo_full_name: GitHub repo as "owner/repo"
+        helm_chart: Name of the Helm chart
+        image_tag: The image tag
+        extra_tags: Optional list of extra tags
+
+    Returns:
+        Search URL string
+    """
+    phrase = f'is:pr "{build_tag_string(helm_chart, image_tag, extra_tags)}"'
+    return f"https://github.com/{repo_full_name}/pulls?q={quote(phrase, safe='')}"
+
+
 def generate_pr_title(
     pr_title_prefix: str,
     helm_chart: str,
@@ -115,22 +165,18 @@ def generate_pr_title(
 ) -> str:
     """
     Generate a complete PR title.
-    
+
     Args:
         pr_title_prefix: The prefix for the PR title
         helm_chart: Name of the Helm chart
         image_tag: The image tag
         extra_tags: Optional list of extra tags
         target_stacks: List of target stacks
-        
+
     Returns:
         Complete PR title string
     """
-    # Build tag string representation
-    image_tag_str = (f"@{image_tag}" if image_tag else "") + "".join(
-        f" {tag['path']}@{tag['value']}" for tag in (extra_tags or [])
-    )
-    
+
     # Determine stack description for title
     if len(target_stacks) == 1:
         stack_desc = f" in {target_stacks[0]}"
@@ -145,8 +191,9 @@ def generate_pr_title(
             stack_desc = ""
     else:
         stack_desc = ""
-    
-    return f"{pr_title_prefix} {helm_chart}{image_tag_str}{stack_desc}".strip()
+
+    tag_string = build_tag_string(helm_chart, image_tag, extra_tags)
+    return f"{pr_title_prefix} {tag_string}{stack_desc}".strip()
 
 
 def format_pr_body_with_metadata(

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -650,8 +650,9 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         removed_overrides=removed_overrides,
     )
 
-    # Wave PRs: link a PR search that finds every wave PR of this release
-    # (all wave PR titles share the "<chart>@<tag>" substring; no PR numbers needed).
+    # Wave PRs: link a PR search that finds every wave PR of this release. The link
+    # quotes the full chart+tags string (incl. extra tags), which every wave PR title
+    # embeds verbatim (see build_tag_string above); no PR numbers needed.
     if pr_type == 'wave':
         search_link = wave_release_search_link(
             GITHUB_REPO, plan.helm_chart, plan.image_tag, plan.extra_tags

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -22,8 +22,9 @@ from .message_generation import (
     generate_pr_title,
     generate_pr_title_prefix,
     format_pr_body_with_metadata,
+    wave_release_search_link,
 )
-from .config import CANARY_STACKS, IGNORED_FOLDERS, DEV_STACK_MAPPING
+from .config import CANARY_STACKS, IGNORED_FOLDERS, DEV_STACK_MAPPING, GITHUB_REPO
 from .cloud_detection import get_stack_cloud_provider
 
 
@@ -645,7 +646,16 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         metadata=plan.metadata,
         removed_overrides=removed_overrides,
     )
-    
+
+    # Wave PRs: link a PR search that finds every wave PR of this release
+    # (all wave PR titles share the "<chart>@<tag>" substring; no PR numbers needed).
+    if pr_type == 'wave':
+        search_link = wave_release_search_link(
+            GITHUB_REPO, plan.helm_chart, plan.image_tag, plan.extra_tags
+        )
+        pr_body += f"\n\n### Release\n[All wave PRs of this release]({search_link})"
+
+
     # Determine auto-merge
     auto_merge = _should_auto_merge(plan, pr_group['pr_type'], config.automerge)
     

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -18,6 +18,7 @@ from .io_layer import IOLayer
 from .tag_classification import detect_tag_type, TagType
 from .stack_classification import classify_stack, get_dev_stacks
 from .message_generation import (
+    build_tag_string,
     generate_commit_message,
     generate_pr_title,
     generate_pr_title_prefix,
@@ -610,9 +611,11 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
     # Generate PR title
     if pr_type == 'wave':
         wave = pr_group['wave_number']
+        # The suffix is the same chart+tags string (incl. extra tags) the release
+        # search link quotes — they must match or the search finds nothing (ST-4035).
         pr_title = (
             f"[{plan.helm_chart} {config.deploy_strategy.value} wave {wave}] "
-            f"{plan.helm_chart}@{plan.image_tag}"
+            f"{build_tag_string(plan.helm_chart, plan.image_tag, plan.extra_tags)}"
         )
     else:
         pr_title_prefix = generate_pr_title_prefix(

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -142,6 +142,15 @@ def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResu
         _patch_anchor_manifest(plan, io_layer, wave_pr_numbers, wave0_body, result)
 
 
+def _wave_links_md(wave_pr_numbers: Dict[int, int]) -> str:
+    """Render a clickable wave -> PR list for the anchor body (#N auto-links on GitHub)."""
+    lines = ["### Release waves"]
+    for wave in sorted(wave_pr_numbers):
+        suffix = " (anchor — this PR)" if wave == 0 else ""
+        lines.append(f"- wave {wave}: #{wave_pr_numbers[wave]}{suffix}")
+    return "\n".join(lines)
+
+
 def _patch_anchor_manifest(plan: UpdatePlan, io_layer: IOLayer, wave_pr_numbers: Dict[int, int],
                             wave0_body: Optional[str], result: ExecutionResult) -> None:
     """Build the v1 manifest from the collected {wave -> PR#} and patch the wave-0 body.
@@ -166,7 +175,8 @@ def _patch_anchor_manifest(plan: UpdatePlan, io_layer: IOLayer, wave_pr_numbers:
         app=ctx["app"], instance_id=ctx["instance_id"], display_name=ctx["display_name"],
         waves=wave_pr_numbers, source_sha=ctx.get("source_sha"), source_pr=ctx.get("source_pr"),
     )
-    new_body = f"{wave0_body}\n\n{manifest_block(manifest)}"
+    links_md = _wave_links_md(wave_pr_numbers)
+    new_body = f"{wave0_body}\n\n{links_md}\n\n{manifest_block(manifest)}"
     try:
         io_layer.update_pull_request_body(anchor, new_body)
     except Exception as exc:

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 from .models import UpdatePlan, ExecutionResult
 from .io_layer import IOLayer
 from .manifest import build_manifest, manifest_block
+from .exceptions import AutoApproveError
 
 _PR_NUM_RE = re.compile(r"/pull/(\d+)")
 
@@ -106,6 +107,19 @@ def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResu
                 auto_merge=pr_plan.auto_merge,
                 labels=pr_plan.labels,
             )
+        except AutoApproveError as exc:
+            if pr_plan.wave_number is None or not exc.pr_url:
+                raise  # non-wave keeps historical behavior; no pr_url -> treat as creation failure
+            # The PR EXISTS (creation succeeded; only the post-create CODEOWNERS
+            # auto-approval failed). Keep fanning out and still emit the manifest —
+            # an unapproved wave PR just waits for a human approval before the
+            # promoter can merge it. Treating this as a creation failure would orphan
+            # a labelled, manifest-less anchor the rerun guard cannot see.
+            result.success = False
+            result.errors.append(
+                f"Wave {pr_plan.wave_number} PR created but auto-approve FAILED: {exc}. "
+                f"Approve {exc.pr_url} manually; the release manifest is still emitted.")
+            pr_url = exc.pr_url
         except Exception as exc:
             if pr_plan.wave_number is None:
                 raise  # non-wave plans keep the historical abort-via-catch-all behavior

--- a/tests/test_plan_executor.py
+++ b/tests/test_plan_executor.py
@@ -135,6 +135,33 @@ def test_executor_wave_creation_exception_caught_breaks_and_reports():
     assert any("waves [2, 3]" in e and "[0, 1]" in e for e in result.errors)
 
 
+def test_executor_wave_auto_approve_failure_keeps_fanout_and_manifest():
+    """AutoApproveError means the PR EXISTS (creation succeeded, only the CODEOWNERS
+    approval failed) — the executor must keep fanning out and still emit the manifest
+    (an unapproved wave PR just waits for a human approval), instead of orphaning a
+    labelled, manifest-less anchor the rerun guard cannot see. Run still fails loudly."""
+    from helm_image_updater.exceptions import AutoApproveError
+    plan = _wave_plan()
+    io = MagicMock()
+    io.create_branch_commit_and_pr.side_effect = [
+        "https://github.com/keboola/kbc-stacks/pull/10",
+        "https://github.com/keboola/kbc-stacks/pull/11",
+        AutoApproveError("approval boom", pr_url="https://github.com/keboola/kbc-stacks/pull/12"),
+        "https://github.com/keboola/kbc-stacks/pull/13",
+    ]
+    result = execute_plan(plan, io)
+
+    assert io.create_branch_commit_and_pr.call_count == 4  # fan-out NOT aborted
+    io.update_pull_request_body.assert_called_once()       # manifest still patched
+    (anchor_num, new_body), _ = io.update_pull_request_body.call_args
+    assert anchor_num == 10
+    manifest = json.loads(JSON_FENCE_RE.findall(new_body)[0])
+    assert manifest["waves"] == {"0": 10, "1": 11, "2": 12, "3": 13}  # incl. the unapproved PR
+    assert result.success is False  # loud: operator must approve manually
+    assert any("auto-approve FAILED" in e and "Wave 2" in e for e in result.errors)
+    assert "https://github.com/keboola/kbc-stacks/pull/12" in result.pr_urls
+
+
 def test_executor_non_wave_creation_exception_still_propagates_to_catch_all():
     """Non-wave plans keep the historical behavior: a raising creation aborts the run via
     execute_plan's catch-all (no per-PR continue/break semantics change)."""

--- a/tests/test_plan_executor.py
+++ b/tests/test_plan_executor.py
@@ -41,6 +41,13 @@ def test_executor_patches_wave0_anchor_with_manifest():
     assert manifest["anchorWave"] == 0
     assert manifest["waves"] == {"0": 10, "1": 11, "2": 12, "3": 13}
     assert new_body.startswith("BODY0")  # appended to the original wave-0 body
+    # ST-4035: clickable wave list sits between the original body and the manifest,
+    # so the FIRST ```json fence (asserted above) still parses to the manifest.
+    assert "### Release waves" in new_body
+    assert "- wave 0: #10 (anchor — this PR)" in new_body
+    assert "- wave 1: #11" in new_body
+    assert "- wave 2: #12" in new_body
+    assert "- wave 3: #13" in new_body
 
 
 def test_executor_no_patch_when_not_wave_mode():

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -350,3 +350,66 @@ def test_wave_grouping_excludes_e2e_stacks():
     all_stacks = [s for g in groups for s in g["stacks"]]
     assert "foo-bar-e2e" not in all_stacks
     assert len(groups) == 4
+
+
+# --- ST-4035: release search link in wave PR bodies --------------------------
+
+from unittest.mock import patch
+from helm_image_updater.message_generation import wave_release_search_link
+
+
+def _pr_plan_mocks(pr_type, wave_number=None):
+    config = Mock(); config.automerge = False
+    config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    plan.multi_stage = False
+    plan.helm_chart = "dummy-service"
+    plan.image_tag = "production-abc123"
+    plan.extra_tags = [{"path": "agent.tag", "value": "production-xyz"}]
+    plan.metadata = {}
+
+    fc = Mock(); fc.file_path = "kbc-us-east-1/dummy-service/tag.yaml"
+    group = {
+        'stacks': ["kbc-us-east-1"],
+        'changes': [{"stack": "kbc-us-east-1", "file_change": fc, "changes": []}],
+        'base_branch': 'main',
+        'pr_type': pr_type,
+    }
+    if wave_number is not None:
+        group['wave_number'] = wave_number
+        group['labels'] = [f"release:wave:{wave_number}", "deploy:gradual"]
+    return group, plan, config
+
+
+def test_wave_release_search_link_quotes_full_tag_string():
+    link = wave_release_search_link(
+        "mock-org/mock-repo",
+        "dummy-service",
+        "production-abc123",
+        [{"path": "agent.tag", "value": "production-xyz"}],
+    )
+    assert link == (
+        "https://github.com/mock-org/mock-repo/pulls?q="
+        "is%3Apr%20%22dummy-service%40production-abc123%20agent.tag%40production-xyz%22"
+    )
+
+
+def test_wave_pr_body_contains_release_search_link():
+    group, plan, config = _pr_plan_mocks('wave', wave_number=1)
+    with patch("helm_image_updater.plan_builder.GITHUB_REPO", "mock-org/mock-repo"):
+        pr_plan = _create_pr_plan(group, plan, config)
+    assert "### Release" in pr_plan.pr_body
+    assert (
+        "[All wave PRs of this release]("
+        "https://github.com/mock-org/mock-repo/pulls?q="
+        "is%3Apr%20%22dummy-service%40production-abc123%20agent.tag%40production-xyz%22)"
+    ) in pr_plan.pr_body
+
+
+def test_non_wave_pr_body_has_no_release_search_link():
+    group, plan, config = _pr_plan_mocks('standard')
+    with patch("helm_image_updater.plan_builder.GITHUB_REPO", "mock-org/mock-repo"):
+        pr_plan = _create_pr_plan(group, plan, config)
+    assert "All wave PRs of this release" not in pr_plan.pr_body
+    assert "### Release\n" not in pr_plan.pr_body

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -183,6 +183,39 @@ def test_create_pr_plan_wave_sets_labels_and_branch_title():
     assert pr_plan.wave_number == 2
 
 
+def test_create_pr_plan_wave_title_includes_extra_tags():
+    """Wave titles must carry the SAME chart+tags string the release search link quotes —
+    with extra tags, otherwise the quoted-phrase search matches nothing (ST-4035)."""
+    config = Mock(); config.automerge = False
+    config.deploy_strategy = DeployStrategy.GRADUAL
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    plan.multi_stage = False
+    plan.helm_chart = "dummy-service"
+    plan.image_tag = "production-abc123"
+    plan.extra_tags = [{"path": "agent.tag", "value": "production-agent-xyz"}]
+    plan.metadata = {}
+
+    fc = Mock(); fc.file_path = "kbc-us-east-1/dummy-service/tag.yaml"
+    group = {
+        'stacks': ["kbc-us-east-1"],
+        'changes': [{"stack": "kbc-us-east-1", "file_change": fc, "changes": []}],
+        'base_branch': 'main',
+        'pr_type': 'wave',
+        'wave_number': 2,
+        'labels': ["release:wave:2", "deploy:gradual"],
+    }
+
+    pr_plan = _create_pr_plan(group, plan, config)
+
+    from helm_image_updater.message_generation import build_tag_string
+    tag_string = build_tag_string(plan.helm_chart, plan.image_tag, plan.extra_tags)
+    assert tag_string == "dummy-service@production-abc123 agent.tag@production-agent-xyz"
+    # The searchable phrase must appear verbatim in the title.
+    assert tag_string in pr_plan.pr_title
+    assert pr_plan.pr_title.startswith("[dummy-service gradual wave 2] ")
+
+
 def test_wave_never_auto_merges_even_for_canary_strategy():
     plan = Mock(); plan.strategy = UpdateStrategy.CANARY
     assert _should_auto_merge(plan, "wave", user_requested=True) is False


### PR DESCRIPTION
## What

Two navigation aids for wave-mode releases:

1. **Release search link in every wave PR body** — each wave PR now ends with a `### Release` section linking a GitHub PR search for the quoted `<chart>@<tag> [path@value ...]` phrase, so an operator can jump from any wave PR to all sibling wave PRs.
2. **Clickable wave list on the wave-0 anchor** — `_patch_anchor_manifest` now inserts a `### Release waves` list (`- wave N: #PR`) between the original body and the manifest block. `#N` references auto-link on GitHub; the manifest stays the FIRST ```json fence, so promoter/harness parsing is untouched.


See example PR it would create https://github.com/keboola/helm-image-updater-testing/pull/3434


## Tests
I have successfully run e2e tests with built dev- image from [promoter branch](https://github.com/keboola/release-promoter/pull/14) + [this helm image updater dev branch](https://github.com/keboola/helm-image-updater/pull/33) 
https://github.com/keboola/helm-image-updater-testing/actions/runs/27346716246

## Why

- Operators need to hop between the 4 wave PRs of a release; today that means manual searching.
- The search link needs no PR numbers (works at plan time) and covers extra tags.
- The anchor list rides the existing manifest patch call — zero extra API calls.

Linear: [ST-4035](https://linear.app/keboola/issue/ST-4035/implementation-33-release-trains-enablement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
