### PR TITLE
refactor(release): versioned releases, install action from own source [ST-4064]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,8 +3,10 @@ name: Build and Publish
 on:
   workflow_dispatch:
   push:
+    # Releases trigger only on plain semver tags (vMAJOR.MINOR.PATCH).
+    # Pre-release tags like v1.2.3-rc.1 intentionally do NOT publish.
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
     branches:
       - "**"
 
@@ -66,17 +68,35 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
-      - name: Install dependencies
+          python-version: "3.13"
+      - name: Verify tag matches package version
+        run: |
+          # Portable sed (works on GNU + BSD) — keeps setup.py version honest and
+          # blocks tagging a release whose embedded version disagrees with the tag.
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(sed -n 's/.*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' setup.py)
+          echo "tag=$TAG package=$PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match setup.py version $PKG. Bump setup.py before tagging."
+            exit 1
+          fi
+      - name: Install build tooling
         run: |
           python -m pip install --upgrade pip
           pip install build
-      - name: Build package
-        run: python -m build
-      - name: Create Release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "./dist/helm_image_updater-*.tar.gz"
-          allowUpdates: true
-          replacesArtifacts: true
-          generateReleaseNotes: true
+      - name: Build sdist
+        # The sdist is a TRANSITIONAL asset: consumers still pinned to an old action
+        # ref pull the latest *.tar.gz. Drop this step once every consumer is pinned
+        # to a new versioned ref that installs from source (see docs/plans ST-4064).
+        run: python -m build --sdist
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Idempotent: gh release create fails if the release already exists, so
+          # re-runs update the asset instead (replaces ncipollo allowUpdates).
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" ./dist/helm_image_updater-*.tar.gz --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag ./dist/helm_image_updater-*.tar.gz
+          fi

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ jobs:
         with:
           user: bot
 
-      - uses: keboola/helm-image-updater@main
+      - uses: keboola/helm-image-updater@v0.15.0
         with:
           helm-chart: ${{ inputs.helm-chart }}
           image-tag: ${{ inputs.image-tag }}

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Dry run:
 
 ### GitHub Actions
 
-Minimal usage example:
+Minimal usage example (always pin to a released version — see [Releasing](#releasing); the action runs the code from the pinned tag):
 
 ```yaml
-- uses: "keboola/helm-image-updater@main"
+- uses: "keboola/helm-image-updater@v0.15.0"
   with:
     helm-chart: "dummy-service"
     image-tag: "dev-b10536c41180e420eaf083451a1ddee132f512c6"
@@ -287,6 +287,42 @@ If `argocdApplication` only contained `appManifestsRevision`, the entire block i
 
 > **Prerequisite (wave strategies):** the deploy token needs `Issues: write` (PR labels go through the Issues API), and release-promoter's merge identity needs `Contents: write` + `Pull requests: write` and must be a bypass actor on the target branch's ruleset.
 
+## Releasing
+
+A release ships **one coherent version**: the pinned tag determines both the `action.yaml`
+orchestration and the matching Python code (the action installs from its own source at that
+tag — there is no separate "latest package" that can drift).
+
+To cut a new release:
+
+1. **Merge your change into `main`** (PR reviewed, unit tests + E2E green).
+2. **Bump the version** in [`setup.py`](setup.py) (`version="X.Y.Z"`) to the new semver.
+   This is normally part of the same PR. CI **fails the release** if the git tag does not
+   match this version.
+3. **Tag and push:**
+
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   The [release workflow](.github/workflows/main.yaml) then: runs the tests → verifies the
+   tag matches `setup.py` → builds the sdist → publishes a GitHub Release with auto-generated
+   notes. Only plain semver tags (`vX.Y.Z`) trigger a release; pre-release tags do not.
+4. **Bump the consumers.** In `kbc-stacks` (and any other repo using this action), update
+   the pin to the new tag:
+
+   ```yaml
+   - uses: keboola/helm-image-updater@vX.Y.Z   # was @vA.B.C
+   ```
+
+   Consumers stay on their pinned version until you deliberately bump it — a HIU release does
+   not change anyone's behavior until they move the pin.
+
+> **Why the version must be bumped before tagging:** the package version lives in `setup.py`
+> and the release job refuses to publish a tag whose number disagrees with it, so the GitHub
+> Release, the git tag, and `pip show helm_image_updater` always agree.
+
 ## Development
 
 Create virtual environment:
@@ -304,64 +340,21 @@ Run tests:
     pip install pytest
     pytest tests/
 
-### Testing Changes in sre-playground
+### Testing a branch before release
 
-To test your changes in the real environment (sre-playground repository) before creating a release:
+The action installs its Python code from its **own checked-out source at the ref you pin** (`pip install "$GITHUB_ACTION_PATH"`). That means testing an unreleased branch needs no `action.yaml` surgery — just point a consumer at your branch:
 
-1. **Modify action.yaml** to use source code instead of release:
+```yaml
+- uses: keboola/helm-image-updater@your-feature-branch
+  with:
+    helm-chart: metastore
+    image-tag: canary-orion-metastore-0.0.5
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
 
-   ```yaml
-   # Comment out the release downloader
-   # - uses: robinraju/release-downloader@v1.9
-   #   with:
-   #     repository: "keboola/helm-image-updater"
-   #     latest: true
+Both `action.yaml` and the Python code then come from `your-feature-branch`, in lockstep.
 
-   # Add source checkout and installation
-   - name: Checkout helm-image-updater source
-     uses: actions/checkout@v4
-     with:
-       repository: keboola/helm-image-updater
-       ref: your-feature-branch-name  # Replace with your branch
-       path: helm-image-updater-src
-
-   - name: Install helm-image-updater from source
-     shell: bash
-     run: |
-       echo "Installing helm-image-updater from source code..."
-       cd helm-image-updater-src
-       pip install -e .
-   ```
-
-   And update the final step to remove the pip install line:
-
-   ```yaml
-   - name: Update image tags and create PRs
-     shell: bash
-     env:
-       # ... environment variables ...
-     run: |
-       # pip install helm_image_updater-*.tar.gz  # Comment this out
-       helm-image-updater
-   ```
-
-2. **Commit and push your feature branch** with the changes
-
-3. **In sre-playground**, update the workflow to use your branch:
-
-   ```yaml
-   - uses: keboola/helm-image-updater@your-feature-branch
-     with:
-       helm-chart: metastore
-       image-tag: canary-orion-metastore-0.0.5
-       github-token: ${{ secrets.GITHUB_TOKEN }}
-   ```
-
-4. **Test your changes** by running the workflow in sre-playground
-
-5. **When satisfied**, revert the action.yaml changes and create a proper release
-
-This approach allows you to test fixes in the "real" environment without needing to create releases for testing purposes.
+The preferred way to validate a branch is the **E2E suite** in [helm-image-updater-testing](https://github.com/keboola/helm-image-updater-testing/actions/workflows/test-suite.yaml) — trigger the "Test suite" workflow and pass your branch name. See [e2e tests](#e2e-tests) below.
 
 ## Testing
 

--- a/action.yaml
+++ b/action.yaml
@@ -63,12 +63,6 @@ runs:
       with:
         python-version: '3.13'
 
-    - uses: robinraju/release-downloader@v1.12
-      with:
-        repository: "keboola/helm-image-updater"
-        latest: true
-        fileName: "*.tar.gz"
-
     - name: Configure git and fetch branches
       shell: bash
       run: |
@@ -102,5 +96,9 @@ runs:
         GH_APPROVE_TOKEN: ${{ inputs.approve-token }}
         COMMIT_PIPELINE_SHA: ${{ inputs.commit-sha }}
       run: |
-        pip install helm_image_updater-*.tar.gz
+        # Install HIU from this action's OWN checked-out source at the pinned ref.
+        # $GITHUB_ACTION_PATH points at the action repo checkout (not the caller's
+        # workspace), so a consumer's `@vX.Y.Z` pin deterministically runs both this
+        # action.yaml and the matching Python code from the same commit.
+        pip install "$GITHUB_ACTION_PATH"
         helm-image-updater

--- a/action.yaml
+++ b/action.yaml
@@ -100,5 +100,5 @@ runs:
         # $GITHUB_ACTION_PATH points at the action repo checkout (not the caller's
         # workspace), so a consumer's `@vX.Y.Z` pin deterministically runs both this
         # action.yaml and the matching Python code from the same commit.
-        pip install "$GITHUB_ACTION_PATH"
+        python -m pip install "$GITHUB_ACTION_PATH"
         helm-image-updater

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     python_requires=">=3.13",
     description="Tool for updating Helm chart image tags across different stacks",
     author="Keboola",
-    author_email="michal.kozak@keboola.com",
+    author_email="team-sre@keboola.com ",
     url="https://github.com/keboola/helm-image-updater",
 )

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.2.0",
+    version="0.15.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
[ST-4064](https://linear.app/keboola/issue/ST-4064/refactor-helm-image-updater-release-process)

## Release Notes
Makes the release of this GitHub Action explicit and deterministic, eliminating the previous "always latest" split-brain where `action.yaml` came from `@main` while the Python code came from whatever release was newest.

**What changed (implemented in this PR):**
- **`action.yaml`** — removed `robinraju/release-downloader`; the composite action now installs **its own checked-out source** with `python -m pip install "$GITHUB_ACTION_PATH"`. A consumer's pinned ref (`@vX.Y.Z`) now runs both the orchestration and the matching Python code from the same commit.
- **`.github/workflows/main.yaml`** — release triggers only on plain semver tags (`v[0-9]+.[0-9]+.[0-9]+`); a guard fails the release if the tag ≠ `setup.py` version; publish job aligned to Python 3.13; publishing via the built-in `gh` CLI (dropped `ncipollo/release-action`), idempotent on re-run, **still builds + attaches the sdist** as a transitional asset for any consumer not yet pinned.
- **`setup.py`** — version `0.2.0` → `0.15.0` (was stale; latest tag was `v0.14.0`).
- **`README.md`** — new **Releasing** section; pinned the usage examples to a released tag; removed the obsolete "edit action.yaml to test from source" instructions (branch testing is now just `@your-branch`).

## Plans for customer communication
None.

## Impact analysis
Changes only how the action is built/released and how its Python code is installed at runtime — **no functional code change** (`helm_image_updater/*.py` untouched; 188/188 unit tests unchanged & green). `kbc-stacks` is on `@main` today and keeps working after merge because main's HEAD is `v0.14.0` and this PR adds no `.py` changes. The sdist is kept so older/unpinned consumers do not break.

**Safe to merge before `v0.15.0` exists:** `setup.py` version is plain metadata — `pip install` from source labels the package `0.15.0` regardless of whether the git tag exists, and the tag↔version guard only runs on a tag push (not on merge). No runtime code reads the package version.

## Change type
CI / release process + docs. No behavior change.

## Justification
Previously two independent "always latest" layers (`@main` action source + `latest` package download) could drift; consumers couldn't pin or reproduce a known-good version; the packaged version was stale and meaningless. ST-4064 requires: merge → release a version → bump that version in kbc-stacks.

## Deployment — rollout sequence
1. **Merge this PR** into `helm-image-updater` `main`. (`kbc-stacks` on `@main` keeps running v0.14.0-equivalent behavior — no break.)
2. **Cut the release:** `git tag v0.15.0 && git push origin v0.15.0`. The workflow runs tests → verifies tag == `setup.py` version → builds the sdist → publishes the GitHub Release with generated notes.
3. **Bump the consumer:** one-line PR in `kbc-stacks` — `keboola/helm-image-updater@main` → `@v0.15.0` (no other edits; inputs/secrets unchanged).

> No intermediate `@v0.14.0` pin is needed: this PR is backward-compatible, so `kbc-stacks` can move straight from `@main` to `@v0.15.0` once the release exists.

## Rollback plan
Revert of this PR. Consumers remain on their pinned ref regardless.

## Post release support plan
None.

## Code review
GitHub Copilot review addressed:
- ✅ `action.yaml`: use `python -m pip` — fixed.
- ✅ `README.md`: pin the full example (was `@main`) — fixed.
- ❌ semver tag filter "won't match" — **not a bug**: GitHub filter-pattern syntax treats `+` as "one or more of the preceding char" and `.` as literal (docs example `v[12].[0-9]+.[0-9]+`), so `v[0-9]+.[0-9]+.[0-9]+` matches `v0.15.0` and excludes pre-releases. Left as-is.

## E2E tests
All scenarios pass against this branch in [helm-image-updater-testing](https://github.com/keboola/helm-image-updater-testing/actions/workflows/test-suite.yaml):
- ✅ Run 1 — 19/19: https://github.com/keboola/helm-image-updater-testing/actions/runs/27543387605
- ✅ Run 2 (clean re-run, final action content) — 19/19: https://github.com/keboola/helm-image-updater-testing/actions/runs/27545821008
