### PR TITLE
chore(release): bump setup.py to 0.16.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.15.0",
+    version="0.16.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
The `app:<service>` label feature ([#35](https://github.com/keboola/helm-image-updater/pull/35)) was released as **v0.16.0**, but `setup.py` was never bumped — it's still `0.15.0`. The release workflow's *"Verify tag matches package version"* step caught this and failed:

```
tag=0.16.0 package=0.15.0
::error::Tag v0.16.0 does not match setup.py version 0.15.0. Bump setup.py before tagging.
```

(failed run: https://github.com/keboola/helm-image-updater/actions/runs/27949256702)

This bumps `setup.py` `0.15.0 → 0.16.0` to match the tag (and the established minor-bump-per-release scheme).

### ⚠️ Required follow-up after merge
The existing **v0.16.0** tag points at the pre-bump commit, so merging this alone won't make the publish job pass. After merge, re-point the tag at the bump commit:

```
git fetch origin main
git tag -f v0.16.0 origin/main        # bump commit
git push origin :refs/tags/v0.16.0    # delete remote tag
git push origin v0.16.0               # re-push at the bump commit
```

(or delete + recreate the GitHub Release v0.16.0 on the new commit). The earlier publish failed at the verify step, so nothing was published under v0.16.0 — reusing the number is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)