### PR TITLE
fix(executor): close orphaned wave PRs on partial fan-out [ST-4126]

### DIFF
--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -426,6 +426,9 @@ class IOLayer:
         """Close an open PR and delete its head branch (best-effort). Used to clean up the
         already-created lower-wave PRs after a partial fan-out, so no orphaned manifest-less
         release:wave:0 anchor is left behind for the idempotency guard to miss."""
+        if self.dry_run:
+            print(f"[DRY RUN] Would close PR #{number} and delete its head branch")
+            return
         pr = self.github_repo.get_pull(number)
         head_ref = pr.head.ref
         pr.edit(state="closed")

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -422,6 +422,18 @@ class IOLayer:
             anchors.append((issue.number, pr.body or ""))
         return anchors
 
+    def close_pr(self, number: int) -> None:
+        """Close an open PR and delete its head branch (best-effort). Used to clean up the
+        already-created lower-wave PRs after a partial fan-out, so no orphaned manifest-less
+        release:wave:0 anchor is left behind for the idempotency guard to miss."""
+        pr = self.github_repo.get_pull(number)
+        head_ref = pr.head.ref
+        pr.edit(state="closed")
+        try:
+            self.github_repo.get_git_ref(f"heads/{head_ref}").delete()
+        except Exception as exc:
+            print(f"  (head branch '{head_ref}' delete skipped: {exc})")
+
     def _ensure_labels_exist(self, names: List[str]) -> None:
         """Create-if-missing each label (tolerate already-exists)."""
         for name in names:

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -183,6 +183,21 @@ def _patch_anchor_manifest(plan: UpdatePlan, io_layer: IOLayer, wave_pr_numbers:
             f"(collected {sorted(wave_pr_numbers)}) or wave-0 body unavailable; refusing to "
             f"emit a partial manifest that would orphan wave PRs (F3)."
         )
+        # The release is incomplete and its manifest is withheld — so the already-created
+        # wave PRs are dead. Close them (single point covering every partial-fan-out path)
+        # so no orphaned, MANIFEST-LESS release:wave:0 anchor is left behind: the rerun guard
+        # detects duplicates by parsing the instanceId from an anchor body, which such an
+        # anchor lacks, so an orphan would let a duplicate fan-out through next run. Wave PRs
+        # are unmerged (auto_merge=False), so closing them deploys nothing. (Halama review.)
+        for w in sorted(wave_pr_numbers):
+            num = wave_pr_numbers[w]
+            try:
+                io_layer.close_pr(num)
+                print(f"Closed orphaned wave {w} PR #{num} (incomplete release; manifest withheld).")
+            except Exception as exc:
+                result.errors.append(
+                    f"Could not close orphaned wave {w} PR #{num}: {exc}. Close it manually."
+                )
         return
     anchor = wave_pr_numbers[0]
     manifest = build_manifest(

--- a/tests/test_io_layer.py
+++ b/tests/test_io_layer.py
@@ -408,6 +408,24 @@ def test_update_pull_request_body_noop_in_dry_run():
     gh.get_pull.assert_not_called()
 
 
+def test_close_pr_closes_and_deletes_head_branch():
+    gh = MagicMock()
+    pr = MagicMock(); pr.head.ref = "feat/wave-1"
+    gh.get_pull.return_value = pr
+    _io(gh).close_pr(11)
+    gh.get_pull.assert_called_once_with(11)
+    pr.edit.assert_called_once_with(state="closed")
+    gh.get_git_ref.assert_called_once_with("heads/feat/wave-1")
+    gh.get_git_ref.return_value.delete.assert_called_once_with()
+
+
+def test_close_pr_noop_in_dry_run():
+    gh = MagicMock()
+    _io(gh, dry_run=True).close_pr(11)
+    gh.get_pull.assert_not_called()
+    gh.get_git_ref.assert_not_called()
+
+
 def test_find_open_release_anchors_returns_number_and_body():
     gh = MagicMock()
     issue = MagicMock(); issue.number = 7; issue.pull_request = object()

--- a/tests/test_plan_executor.py
+++ b/tests/test_plan_executor.py
@@ -135,6 +135,28 @@ def test_executor_wave_creation_exception_caught_breaks_and_reports():
     assert any("waves [2, 3]" in e and "[0, 1]" in e for e in result.errors)
 
 
+def test_executor_closes_orphan_wave_prs_when_manifest_withheld():
+    """A partial fan-out (a wave PR fails to create) withholds the manifest (F3) AND closes
+    the already-created lower-wave PRs, so no orphaned manifest-less release:wave:0 anchor is
+    left behind — HIU's rerun guard detects duplicates by parsing the instanceId from an
+    anchor body, which a manifest-less (withheld) anchor lacks, so an orphan would otherwise
+    let a duplicate fan-out through on the next run (Halama review of #37)."""
+    plan = _wave_plan()
+    io = MagicMock()
+    io.create_branch_commit_and_pr.side_effect = [
+        "https://github.com/keboola/kbc-stacks/pull/10",  # wave 0 (the anchor)
+        "https://github.com/keboola/kbc-stacks/pull/11",  # wave 1
+        Exception("boom-502"),                            # wave 2 creation raises
+    ]
+    result = execute_plan(plan, io)
+
+    assert result.success is False
+    io.update_pull_request_body.assert_not_called()        # manifest withheld (F3)
+    # the already-created lower-wave PRs are closed → no orphan anchor for the guard to miss
+    closed = {c.args[0] for c in io.close_pr.call_args_list}
+    assert closed == {10, 11}
+
+
 def test_executor_wave_auto_approve_failure_keeps_fanout_and_manifest():
     """AutoApproveError means the PR EXISTS (creation succeeded, only the CODEOWNERS
     approval failed) — the executor must keep fanning out and still emit the manifest


### PR DESCRIPTION
## What

When a wave-N PR fails to **create** mid-fan-out (e.g. a transient GitHub 5xx — exactly what we saw in recent e2e runs), `_execute_pr_plans` records the error and aborts. The manifest is then withheld by the F3 partial-manifest guard (`_patch_anchor_manifest`) — but the **already-created lower-wave PRs stayed open**, leaving a **manifest-less `release:wave:0` anchor**.

HIU's rerun guard (`_guard_release_not_already_open`) detects a duplicate fan-out by parsing the `instanceId` out of each open anchor body (`extract_instance_id`). A manifest-less body returns `None`, so the orphan is **invisible to the guard** → on the next run a **duplicate fan-out** is created.

## Fix

Close the already-created wave PRs at the single point where a partial release is detected and the manifest withheld (the withhold branch of `_patch_anchor_manifest`), via a new `io_layer.close_pr(number)` (close the PR + best-effort delete its head branch).

- Wave PRs are created unmerged (`auto_merge=False`), so closing them **deploys nothing** — it's a clean abort.
- Centralised in `_patch_anchor_manifest`, so it covers **every** partial-fan-out path (create-failure `break`, unparseable PR URL).
- The `AutoApproveError` path is **unaffected**: there the PR was created (only CODEOWNERS approval failed), so the fan-out continues and the manifest IS emitted — that release is valid and kept.

## Scope

Base-code hardening (shared by all promoter-managed wave strategies — `gradual`/`critical`/`standard`); branched off `main`, independent of the ST-4126 feature PRs. Found in Halama's review of [#37](https://github.com/keboola/helm-image-updater/pull/37).

## Test

`test_executor_closes_orphan_wave_prs_when_manifest_withheld` — wave-2 create raises after waves 0/1 created → manifest withheld **and** PRs #10/#11 closed. Full suite green (195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
