### PR TITLE
chore(release): bump setup.py to 0.17.0 to match the v0.17.0 tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.16.0",
+    version="0.17.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
## What

Bump `setup.py` version `0.16.0` → `0.17.0`.

## Why

`v0.17.0` was tagged (#37 + #38) while `setup.py` still read `0.16.0`, so the **"Verify tag matches package version"** guard in `main.yaml` failed and the release publish was blocked ([run 28160348681](https://github.com/keboola/helm-image-updater/actions/runs/28160348681) — tests green, publish job failed at the verify step). This also means the composite action's source install (`pip install "$GITHUB_ACTION_PATH"`) reports the wrong version (`0.16.0`).

## Release procedure (the tag must be recreated from `main` *after* this merges)

1. Delete the existing `v0.17.0` tag + GitHub release (publish never completed; not yet consumed in prod — kbc-stacks#19828 is still draft).
2. Merge this PR to `main`.
3. Re-create the `v0.17.0` tag on the new `main` HEAD → the verify guard passes and the publish completes.

Mirrors the v0.16.0 bump (#36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
