### PR TITLE
ST-4157: emit manual-per-stack (one PR per stack + flat-member manifest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optional:
 - `AUTOMERGE`: Whether to automatically merge PRs (default: "true", note: canary updates are always auto-merged). When set to `false`, PRs are auto-approved by the machine user instead, satisfying CODEOWNERS requirements so humans can merge without waiting for additional reviews.
 - `DRY_RUN`: Whether to perform a dry run (default: "false")
 - `MULTI_STAGE`: Enable multi-stage deployment (default: "false"). **Deprecated** — alias for `DEPLOY_STRATEGY=cloud_multi_stage`; prefer `DEPLOY_STRATEGY`.
-- `DEPLOY_STRATEGY`: Rollout strategy (default: "standard"): `standard`, `cloud_multi_stage`, `gradual`, `critical`, or `critical-manual-gate`. See [Deploy Strategies](#deploy-strategies).
+- `DEPLOY_STRATEGY`: Rollout strategy (default: "standard"): `standard`, `cloud_multi_stage`, `gradual`, `critical`, `critical-manual-gate`, or `manual-per-stack`. See [Deploy Strategies](#deploy-strategies).
 - `TARGET_PATH`: Path to the directory containing the stacks (default: ".")
 - `OVERRIDE_STACK`: Stack ID to explicitly target for the update, bypassing automatic stack selection (default: None)
 - `EXTRA_TAG1`, `EXTRA_TAG2`: Additional tags to update (format: "path:value")
@@ -90,7 +90,7 @@ Minimal usage example (always pin to a released version — see [Releasing](#rel
     automerge: "true"
     dry-run: "false"
     multi-stage: "false"
-    deploy-strategy: ""  # standard | cloud_multi_stage | gradual | critical | critical-manual-gate
+    deploy-strategy: ""  # standard | cloud_multi_stage | gradual | critical | critical-manual-gate | manual-per-stack
     override-stack: "dev-keboola-gcp-us-central1"
     extra-tag1: "agent.image.tag:dev-2.0.0"
     extra-tag2: "messenger.image.tag:dev-2.0.0"
@@ -130,7 +130,7 @@ on:
         type: boolean
         default: false
       deploy-strategy:
-        description: "Rollout strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate"
+        description: "Rollout strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate | manual-per-stack"
         required: false
         type: string
         default: ''
@@ -275,6 +275,7 @@ If `argocdApplication` only contained `appManifestsRevision`, the entire block i
 | `standard` (explicit) | promoter-managed **2-wave dev→prod**: wave 0 = all dev stacks (anchor, carries the manifest), wave 1 = all prod stacks | *(ignored)* — **2 unmerged wave PRs**, release-promoter merges dev → prod | **2 unmerged wave PRs** — release-promoter merges dev → prod |
 | `cloud_multi_stage` | dev + prod PRs per cloud | merge dev, leave prod | leave all unmerged |
 | `gradual` · `critical` · `critical-manual-gate` | 4 unmerged **wave** PRs (waves 0–3) | *(ignored — release-promoter merges)* | *(release-promoter merges)* |
+| `manual-per-stack` | promoter-managed **one PR per prod stack, no waves** | *(ignored)* — **N unmerged member PRs**, a human merges each in any order | **N unmerged member PRs** — a human merges each in any order |
 
 ### New vs. old parameters
 
@@ -291,6 +292,10 @@ Only **`PRODUCTION`** deploys are staged: a `dev-*` tag (DEV), a `canary-*` tag,
 ### Wave strategies (release-promoter)
 
 `gradual`, `critical`, and `critical-manual-gate` emit 4 unmerged PRs labeled `release:wave:<0-3>` and `deploy:<strategy>`. Release grouping/identity is carried by a JSON **release manifest** that helm-image-updater writes into the wave-0 anchor PR body (machine-read by release-promoter); the legacy `release:id` label is retired. [release-promoter](https://github.com/keboola/release-promoter) merges them wave-by-wave (0 → 3) as each wave syncs, passes UAT, and soaks; `critical-manual-gate` additionally waits for a human gate before the later waves. helm-image-updater itself never merges wave PRs (it still auto-approves them).
+
+### Manual-per-stack (one PR per stack)
+
+An **explicit** `DEPLOY_STRATEGY=manual-per-stack` on a **`production-`/semver tag** emits a deliberately **order-independent** release: **one unmerged PR per prod stack** (no waves), each labelled `deploy:manual-per-stack` and auto-approved. A human merges each member PR in **any order**; [release-promoter](https://github.com/keboola/release-promoter) completes the release once **all** members are merged + synced (no sequencing, soak, UAT, or out-of-order hole). The **anchor** = the **lowest-numbered member PR**: it carries the `release:anchor` discovery label and the JSON **release manifest** (`mode:"manual-per-stack"` + the flat `members` list). Dev stacks are excluded (they go via the fast non-production path); only `PRODUCTION` deploys are managed (`override-stack`/`canary`/`dev-*` keep their own handling). Identity is `instanceId = <app>-<sha12>`; a duplicate fan-out for the same `instanceId` is refused while an anchor is still open (the rerun guard scans both `release:wave:0` and `release:anchor` anchors).
 
 > **Prerequisite (wave strategies):** the deploy token needs `Issues: write` (PR labels go through the Issues API), and release-promoter's merge identity needs `Contents: write` + `Pull requests: write` and must be a bypass actor on the target branch's ruleset.
 

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -27,6 +27,9 @@ class EnvironmentConfig:
     # legacy default (empty strategy → STANDARD) leaves this False so historical single-PR /
     # per-stack behaviour is unchanged.
     promoter_managed_standard: bool = False
+    # True for DEPLOY_STRATEGY=manual-per-stack (ST-4157): one PR per prod stack, no waves.
+    # Always promoter-managed when selected (never a legacy default), AUTOMERGE ignored.
+    promoter_managed_manual_per_stack: bool = False
     _deploy_strategy_error: Optional[str] = field(default=None, init=False, repr=False)
     target_path: str = "."
     commit_sha: bool = False
@@ -81,7 +84,8 @@ class EnvironmentConfig:
             except ValueError:
                 deploy_strategy_error = (
                     f"Invalid DEPLOY_STRATEGY: '{raw_strategy}'. "
-                    "Must be one of: standard, cloud_multi_stage, gradual, critical, critical-manual-gate"
+                    "Must be one of: standard, cloud_multi_stage, gradual, critical, "
+                    "critical-manual-gate, manual-per-stack"
                 )
             if multi_stage_raw and deploy_strategy != DeployStrategy.CLOUD_MULTI_STAGE:
                 print("WARNING: MULTI_STAGE=true is ignored because DEPLOY_STRATEGY is set explicitly")
@@ -105,6 +109,10 @@ class EnvironmentConfig:
             and deploy_strategy == DeployStrategy.STANDARD
         )
 
+        # manual-per-stack (ST-4157) is ALWAYS promoter-managed when selected (no legacy
+        # default — it is never the empty-string default), so a simple equality is enough.
+        promoter_managed_manual_per_stack = deploy_strategy == DeployStrategy.MANUAL_PER_STACK
+
         config = cls(
             helm_chart=env.get("HELM_CHART", ""),
             image_tag=env.get("IMAGE_TAG", "").strip(),
@@ -113,6 +121,7 @@ class EnvironmentConfig:
             dry_run=env.get("DRY_RUN", "false").lower() == "true",
             multi_stage=multi_stage,
             promoter_managed_standard=promoter_managed_standard,
+            promoter_managed_manual_per_stack=promoter_managed_manual_per_stack,
             target_path=env.get("TARGET_PATH", "."),
             commit_sha=env.get("COMMIT_PIPELINE_SHA", "false").lower() == "true",
             override_stack=env.get("OVERRIDE_STACK", "").strip(),
@@ -199,6 +208,22 @@ class EnvironmentConfig:
                 if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
                     errors.append(
                         f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver "
+                        f"IMAGE_TAG, got '{self.image_tag}'"
+                    )
+
+        # manual-per-stack (ST-4157): a production rollout (one PR per prod stack), so it
+        # requires a production/semver tag and is incompatible with OVERRIDE_STACK — same
+        # as the wave strategies (kept separate so the wave error strings stay unchanged).
+        if self.deploy_strategy == DeployStrategy.MANUAL_PER_STACK:
+            if self.override_stack:
+                errors.append("DEPLOY_STRATEGY manual-per-stack is incompatible with OVERRIDE_STACK")
+            elif not self.image_tag:
+                errors.append("DEPLOY_STRATEGY 'manual-per-stack' requires a production/semver IMAGE_TAG")
+            else:
+                tag_type = detect_tag_type(self.image_tag)
+                if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
+                    errors.append(
+                        f"DEPLOY_STRATEGY 'manual-per-stack' requires a production/semver "
                         f"IMAGE_TAG, got '{self.image_tag}'"
                     )
 

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -422,14 +422,23 @@ class IOLayer:
         print(f"🏷️  Added label '{label}' to PR #{pr_number}")
 
     def find_open_release_anchors(self) -> List[Tuple[int, str]]:
-        """Return (number, body) for every OPEN wave-0 anchor PR (label release:wave:0).
-        Used by the idempotency guard to detect an existing open release by instanceId."""
+        """Return (number, body) for every OPEN release anchor PR. Used by the idempotency
+        guard to detect an existing open release by instanceId.
+
+        Two discovery labels (queried separately — `labels=[...]` is an AND filter): the
+        wave-0 anchor (`release:wave:0`) for wave-ordered/standard releases, and the
+        anchor-only `release:anchor` for manual-per-stack (ST-4157). Deduped by PR number."""
         anchors: List[Tuple[int, str]] = []
-        for issue in self.github_repo.get_issues(state="open", labels=["release:wave:0"]):
-            if issue.pull_request is None:
-                continue
-            pr = self.github_repo.get_pull(issue.number)
-            anchors.append((issue.number, pr.body or ""))
+        seen: set = set()
+        for label in ("release:wave:0", "release:anchor"):
+            for issue in self.github_repo.get_issues(state="open", labels=[label]):
+                if issue.pull_request is None:
+                    continue
+                if issue.number in seen:
+                    continue
+                seen.add(issue.number)
+                pr = self.github_repo.get_pull(issue.number)
+                anchors.append((issue.number, pr.body or ""))
         return anchors
 
     def close_pr(self, number: int) -> None:

--- a/helm_image_updater/io_layer.py
+++ b/helm_image_updater/io_layer.py
@@ -411,6 +411,16 @@ class IOLayer:
         pr.edit(body=body)
         print(f"📝 Updated PR #{pr_number} body (release manifest injected)")
 
+    def add_label(self, pr_number: int, label: str) -> None:
+        """Add a single label to an existing PR (used to mark the manual-per-stack anchor
+        with `release:anchor` once the lowest member PR number is known — ST-4157)."""
+        if self.dry_run:
+            print(f"[DRY RUN] Would add label '{label}' to PR #{pr_number}")
+            return
+        self._ensure_labels_exist([label])
+        self.github_repo.get_pull(pr_number).add_to_labels(label)
+        print(f"🏷️  Added label '{label}' to PR #{pr_number}")
+
     def find_open_release_anchors(self) -> List[Tuple[int, str]]:
         """Return (number, body) for every OPEN wave-0 anchor PR (label release:wave:0).
         Used by the idempotency guard to detect an existing open release by instanceId."""

--- a/helm_image_updater/manifest.py
+++ b/helm_image_updater/manifest.py
@@ -79,11 +79,51 @@ def build_manifest(
     return manifest
 
 
+def build_manual_manifest(
+    *,
+    app: str,
+    instance_id: str,
+    display_name: str,
+    members,
+    source_sha: Optional[str] = None,
+    source_pr: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the manual-per-stack (ST-4157) v1 manifest: a flat member set, NO waves.
+    `members` are the member PR numbers (sorted for determinism; anchor = min)."""
+    manifest: Dict[str, Any] = {
+        "manifestVersion": "v1",
+        "mode": "manual-per-stack",
+        "instanceId": instance_id,
+        "displayName": display_name,
+        "app": app,
+        "members": sorted(members),
+    }
+    if source_sha:
+        manifest["sourceSha"] = source_sha
+    if source_pr:
+        manifest["sourcePr"] = source_pr
+    return manifest
+
+
 def manifest_block(manifest: Dict[str, Any]) -> str:
     """Render the markdown block (heading + ```json fence) to append to the wave-0
     PR body. The fence shape matches the promoter's extractManifest regex."""
     body = json.dumps(manifest, indent=2, ensure_ascii=False)
     return f"{MANIFEST_HEADING}\n\n```json\n{body}\n```"
+
+
+def _is_valid_members(v: Any) -> bool:
+    """members (manual-per-stack): non-empty list of distinct positive ints (PR numbers).
+    Mirrors the promoter's isValidMembers (manifest.ts)."""
+    if not isinstance(v, list) or not v:
+        return False
+    seen = set()
+    for m in v:
+        # bool is an int subclass — exclude it explicitly.
+        if not isinstance(m, int) or isinstance(m, bool) or m <= 0 or m in seen:
+            return False
+        seen.add(m)
+    return True
 
 
 def is_manifest_v1(x: Any) -> bool:
@@ -101,6 +141,22 @@ def is_manifest_v1(x: Any) -> bool:
     app = x.get("app")
     if not isinstance(app, str) or not app:
         return False
+    for opt in ("sourceSha", "sourcePr"):
+        if opt in x and not isinstance(x[opt], str):
+            return False
+    # mode discriminator (ST-4157): "manual-per-stack" ⇒ flat members set, NO waves.
+    # A manual manifest carrying wave fields is a contradictory shape → reject.
+    mode = x.get("mode")
+    if mode == "manual-per-stack":
+        if "waves" in x or "anchorWave" in x:
+            return False
+        return _is_valid_members(x.get("members"))
+    # Mirror the promoter's `hasOwnProperty('mode') && mode !== undefined` reject (manifest.ts):
+    # JSON has no `undefined`, so ANY present `mode` key (incl. null) that isn't
+    # "manual-per-stack" is rejected — only an ABSENT mode key is the wave variant.
+    if "mode" in x:
+        return False
+    # wave-ordered manifest (no mode).
     if x.get("anchorWave") != 0:
         return False
     waves = x.get("waves")
@@ -114,9 +170,6 @@ def is_manifest_v1(x: Any) -> bool:
         if not isinstance(val, int) or isinstance(val, bool) or val <= 0 or val in seen:
             return False
         seen.add(val)
-    for opt in ("sourceSha", "sourcePr"):
-        if opt in x and not isinstance(x[opt], str):
-            return False
     return True
 
 

--- a/helm_image_updater/models.py
+++ b/helm_image_updater/models.py
@@ -22,13 +22,15 @@ class DeployStrategy(Enum):
     GRADUAL = "gradual"
     CRITICAL = "critical"
     CRITICAL_MANUAL_GATE = "critical-manual-gate"
+    MANUAL_PER_STACK = "manual-per-stack"
 
     @property
     def is_wave(self) -> bool:
         """Strategies routed through the strict waves-0..3 grouping
         (`_group_changes_by_wave`). MUST exclude STANDARD — its 2-wave dev→prod
         grouping is contiguous-from-0 by construction and must not hit the
-        0..3-required guard."""
+        0..3-required guard. MUST also exclude MANUAL_PER_STACK (ST-4157) — it has
+        NO waves (one PR per stack, flat member set)."""
         return self in (
             DeployStrategy.GRADUAL,
             DeployStrategy.CRITICAL,
@@ -38,8 +40,9 @@ class DeployStrategy(Enum):
     @property
     def is_promoter_managed(self) -> bool:
         """Strategy-level CAPABILITY: strategies that *can* be promoter-managed (PRs
-        created unmerged, labelled, carrying a wave-0 manifest). Superset of `is_wave`:
-        also includes STANDARD, which ST-4126 can emit as a 2-wave dev→prod release.
+        created unmerged, labelled, carrying a manifest). Superset of `is_wave`: also
+        includes STANDARD (ST-4126, 2-wave dev→prod) and MANUAL_PER_STACK (ST-4157,
+        one PR per stack).
 
         NOTE: this is about the STRATEGY, not a given run. Whether a specific run is
         actually promoter-managed depends on more than the strategy — for STANDARD it
@@ -47,7 +50,7 @@ class DeployStrategy(Enum):
         DEPLOY_STRATEGY=standard) AND a PRODUCTION/DEV deploy. Do NOT use this predicate
         as the run-time gate: it is True for STANDARD even for a legacy default single-PR
         deploy. The run-time condition lives in `plan_builder._is_promoter_managed_standard`."""
-        return self.is_wave or self is DeployStrategy.STANDARD
+        return self.is_wave or self in (DeployStrategy.STANDARD, DeployStrategy.MANUAL_PER_STACK)
 
 
 @dataclass
@@ -80,6 +83,9 @@ class PRPlan:
     commit_message: str
     labels: List[str] = field(default_factory=list)
     wave_number: Optional[int] = None  # set only for pr_type == 'wave'
+    # manual-per-stack (ST-4157): True for a member PR (pr_type == 'manual'). The executor
+    # collects these, anchors the lowest-numbered one (adds release:anchor + the manifest).
+    manual_member: bool = False
 
 
 @dataclass

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -43,6 +43,17 @@ def _is_promoter_managed_standard(config: EnvironmentConfig, plan: UpdatePlan) -
     )
 
 
+def _is_promoter_managed_manual_per_stack(config: EnvironmentConfig, plan: UpdatePlan) -> bool:
+    """True iff this run is a promoter-managed `manual-per-stack` release (ST-4157): an
+    explicit DEPLOY_STRATEGY=manual-per-stack AND a `PRODUCTION` deploy. Like the standard
+    gate, ONLY production is managed — DEV/CANARY/OVERRIDE are orthogonal axes that keep
+    their own handling and are never promoter-managed. One PR per prod stack, no waves."""
+    return (
+        config.deploy_strategy == DeployStrategy.MANUAL_PER_STACK
+        and plan.strategy == UpdateStrategy.PRODUCTION
+    )
+
+
 def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
     """
     Prepare a complete execution plan.
@@ -105,9 +116,14 @@ def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
     # Group changes into PRs
     pr_groups = _group_changes_for_prs(stack_changes, plan, config, io_layer)
 
-    # Promoter-managed modes (wave strategies + promoter-managed `standard`, ST-4126):
-    # derive the manifest identity, then guard against a duplicate fan-out.
-    promoter_managed = config.deploy_strategy.is_wave or _is_promoter_managed_standard(config, plan)
+    # Promoter-managed modes (wave strategies + promoter-managed `standard` ST-4126 +
+    # `manual-per-stack` ST-4157): derive the manifest identity, then guard against a
+    # duplicate fan-out.
+    promoter_managed = (
+        config.deploy_strategy.is_wave
+        or _is_promoter_managed_standard(config, plan)
+        or _is_promoter_managed_manual_per_stack(config, plan)
+    )
     if promoter_managed and pr_groups:
         plan.manifest_context = _build_manifest_context(plan)
         if not config.dry_run:
@@ -445,6 +461,11 @@ def _group_changes_for_prs(
     if _is_promoter_managed_standard(config, plan):
         return _group_changes_standard_2wave(stack_changes, plan, config, io_layer)
 
+    # Promoter-managed `manual-per-stack` (ST-4157): one PR per prod stack, no waves.
+    # Same gating discipline as standard — PRODUCTION only; CANARY/OVERRIDE fall through.
+    if _is_promoter_managed_manual_per_stack(config, plan):
+        return _group_changes_manual_per_stack(stack_changes, plan, config)
+
     if plan.strategy == UpdateStrategy.CANARY:
         # Canary: always one PR
         return [{
@@ -620,6 +641,32 @@ def _group_changes_standard_2wave(stack_changes, plan, config, io_layer):
     return groups
 
 
+def _group_changes_manual_per_stack(stack_changes, plan, config):
+    """Group a promoter-managed `manual-per-stack` deploy into ONE PR per prod stack (ST-4157).
+
+    No waves: each member PR carries `deploy:manual-per-stack` (the anchor gets `release:anchor`
+    + the manifest at executor time, once PR numbers are known). Only PROD stacks are members —
+    dev goes via the fast non-production path (§3.3). e2e stacks are dropped defensively.
+    """
+    deploy_lbl = deploy_label(config.deploy_strategy)  # deploy:manual-per-stack
+
+    members = [
+        sc for sc in stack_changes
+        if classify_stack(sc['stack']).is_production and not sc['stack'].endswith('-e2e')
+    ]
+
+    return [
+        {
+            'stacks': [sc['stack']],
+            'changes': [sc],
+            'base_branch': 'main',
+            'pr_type': 'manual',
+            'labels': [deploy_lbl],
+        }
+        for sc in members
+    ]
+
+
 def _guard_release_not_already_open(instance_id: str, io_layer: IOLayer) -> None:
     """Fail loudly if an open release with this instanceId already exists (re-run safety).
 
@@ -658,6 +705,10 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
     elif pr_type == 'wave':
         wave = pr_group['wave_number']
         branch_name = f"{plan.helm_chart}-wave{wave}-{plan.image_tag}-{suffix}"
+    elif pr_type == 'manual':
+        # manual-per-stack: one PR per stack — name it after the stack.
+        stack = pr_group['stacks'][0]
+        branch_name = f"{plan.helm_chart}-manual-{stack}-{plan.image_tag}-{suffix}"
     else:
         # Standard: dummy-service-production-tag-abc1
         branch_name = f"{plan.helm_chart}-{plan.image_tag}-{suffix}"
@@ -680,6 +731,12 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         # search link quotes — they must match or the search finds nothing (ST-4035).
         pr_title = (
             f"[{plan.helm_chart} {config.deploy_strategy.value} wave {wave}] "
+            f"{build_tag_string(plan.helm_chart, plan.image_tag, plan.extra_tags)}"
+        )
+    elif pr_type == 'manual':
+        stack = pr_group['stacks'][0]
+        pr_title = (
+            f"[{plan.helm_chart} manual-per-stack {stack}] "
             f"{build_tag_string(plan.helm_chart, plan.image_tag, plan.extra_tags)}"
         )
     else:
@@ -750,6 +807,7 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         commit_message=commit_message,
         labels=pr_group.get('labels', []),
         wave_number=pr_group.get('wave_number'),
+        manual_member=(pr_type == 'manual'),
     )
 
 
@@ -773,6 +831,10 @@ def _should_auto_merge(plan: UpdatePlan, pr_type: str, user_requested: bool) -> 
     
     if pr_type == 'wave':
         print(f"       - result: FALSE (wave PRs are merged by release-promoter)")
+        return False
+
+    if pr_type == 'manual':
+        print(f"       - result: FALSE (manual-per-stack members are merged by a human)")
         return False
 
     if plan.strategy == UpdateStrategy.CANARY:

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -4,7 +4,7 @@ import re
 from typing import Dict, List, Optional
 from .models import UpdatePlan, ExecutionResult
 from .io_layer import IOLayer
-from .manifest import build_manifest, manifest_block
+from .manifest import build_manifest, build_manual_manifest, manifest_block
 from .exceptions import AutoApproveError
 
 _PR_NUM_RE = re.compile(r"/pull/(\d+)")
@@ -77,9 +77,12 @@ def _group_files_by_pr(plan: UpdatePlan) -> Dict[str, Dict[str, any]]:
 
 
 def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResult):
-    """Create all pull requests; then (wave mode) patch the wave-0 anchor manifest."""
+    """Create all pull requests; then patch the anchor manifest — the wave-0 PR (wave mode)
+    or the lowest-numbered member PR (manual-per-stack, ST-4157)."""
     wave_pr_numbers: Dict[int, int] = {}   # wave -> PR number
     wave0_body: Optional[str] = None       # the wave-0 PR's created body
+    manual_pr_numbers: List[int] = []      # manual-per-stack member PR numbers
+    manual_bodies: Dict[int, str] = {}     # member PR number -> its created body
 
     for pr_plan in plan.pr_plans:
         if plan.dry_run:
@@ -91,6 +94,15 @@ def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResu
             if pr_plan.labels:
                 print(f"  Labels: {', '.join(pr_plan.labels)}")
             continue
+
+        # A "member" PR is promoter-managed (a wave PR or a manual-per-stack member): it is
+        # created unmerged + labelled, and a creation failure must withhold the manifest
+        # rather than abort via the historical catch-all (which is for legacy single PRs).
+        is_member = pr_plan.wave_number is not None or pr_plan.manual_member
+        member_desc = (
+            f"Wave {pr_plan.wave_number}" if pr_plan.wave_number is not None
+            else f"Manual member '{pr_plan.branch_name}'"
+        )
 
         relevant_file_changes = [fc for fc in plan.file_changes
                                  if fc.file_path in pr_plan.files_to_commit]
@@ -108,29 +120,27 @@ def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResu
                 labels=pr_plan.labels,
             )
         except AutoApproveError as exc:
-            if pr_plan.wave_number is None or not exc.pr_url:
-                raise  # non-wave keeps historical behavior; no pr_url -> treat as creation failure
+            if not is_member or not exc.pr_url:
+                raise  # non-member keeps historical behavior; no pr_url -> creation failure
             # The PR EXISTS (creation succeeded; only the post-create CODEOWNERS
             # auto-approval failed). Keep fanning out and still emit the manifest —
-            # an unapproved wave PR just waits for a human approval before the
-            # promoter can merge it. Treating this as a creation failure would orphan
-            # a labelled, manifest-less anchor the rerun guard cannot see.
+            # an unapproved member PR just waits for a human approval. Treating this as a
+            # creation failure would orphan a labelled, manifest-less anchor the rerun
+            # guard cannot see.
             result.success = False
             result.errors.append(
-                f"Wave {pr_plan.wave_number} PR created but auto-approve FAILED: {exc}. "
+                f"{member_desc} PR created but auto-approve FAILED: {exc}. "
                 f"Approve {exc.pr_url} manually; the release manifest is still emitted.")
             pr_url = exc.pr_url
         except Exception as exc:
-            if pr_plan.wave_number is None:
-                raise  # non-wave plans keep the historical abort-via-catch-all behavior
-            # A failed wave PR already makes the release unusable (F3 withholds the
-            # manifest), so creating further wave PRs would only add orphans to clean
-            # up. Record an actionable error and stop fanning out; the fall-through to
-            # _patch_anchor_manifest reports the collected-vs-missing wave picture.
+            if not is_member:
+                raise  # non-member plans keep the historical abort-via-catch-all behavior
+            # A failed member PR already makes the release unusable (F3 withholds the
+            # manifest), so creating further member PRs would only add orphans to clean
+            # up. Record an actionable error and stop fanning out; the fall-through to the
+            # patch step reports the collected-vs-missing picture.
             result.success = False
-            result.errors.append(
-                f"Failed to create wave {pr_plan.wave_number} PR "
-                f"('{pr_plan.pr_title}'): {exc}")
+            result.errors.append(f"Failed to create {member_desc.lower()} PR ('{pr_plan.pr_title}'): {exc}")
             break
 
         if pr_url:
@@ -147,13 +157,25 @@ def _execute_pr_plans(plan: UpdatePlan, io_layer: IOLayer, result: ExecutionResu
                     result.errors.append(
                         f"Could not parse PR number from URL '{pr_url}' for wave "
                         f"{pr_plan.wave_number}; manifest will be withheld (F3).")
+            elif pr_plan.manual_member:
+                num = _pr_number_from_url(pr_url)
+                if num is not None:
+                    manual_pr_numbers.append(num)
+                    manual_bodies[num] = pr_plan.pr_body
+                else:
+                    result.success = False
+                    result.errors.append(
+                        f"Could not parse PR number from URL '{pr_url}' for manual member; "
+                        f"manifest will be withheld (F3).")
         else:
             result.errors.append(f"Failed to create PR: {pr_plan.pr_title}")
-            if pr_plan.wave_number is not None:
-                result.success = False  # a missing wave PR → withhold the manifest (F3)
+            if is_member:
+                result.success = False  # a missing member PR → withhold the manifest (F3)
 
     if not plan.dry_run and plan.manifest_context and wave_pr_numbers:
         _patch_anchor_manifest(plan, io_layer, wave_pr_numbers, wave0_body, result)
+    if not plan.dry_run and plan.manifest_context and manual_pr_numbers:
+        _patch_manual_anchor(plan, io_layer, manual_pr_numbers, manual_bodies, result)
 
 
 def _wave_links_md(wave_pr_numbers: Dict[int, int]) -> str:
@@ -219,3 +241,90 @@ def _patch_anchor_manifest(plan: UpdatePlan, io_layer: IOLayer, wave_pr_numbers:
         return
     print(f"Release manifest written to wave-0 anchor PR #{anchor} "
           f"(instanceId={ctx['instance_id']}, waves={manifest['waves']})")
+
+
+def _manual_members_md(members: List[int], anchor: int) -> str:
+    """Render a clickable member-PR list for the manual anchor body (#N auto-links)."""
+    lines = ["### Release members (manual-per-stack)"]
+    for n in sorted(members):
+        suffix = " (anchor — this PR)" if n == anchor else ""
+        lines.append(f"- #{n}{suffix}")
+    return "\n".join(lines)
+
+
+def _patch_manual_anchor(plan: UpdatePlan, io_layer: IOLayer, manual_pr_numbers: List[int],
+                         manual_bodies: Dict[int, str], result: ExecutionResult) -> None:
+    """manual-per-stack (ST-4157): the anchor is the LOWEST-numbered member PR. Stamp it with
+    `release:anchor` (discovery), then patch the flat-member manifest into its body.
+
+    F3: refuse a PARTIAL manifest. Every declared manual member PRPlan must have a parsed PR
+    number, else withhold the manifest entirely and close the created members (a manifest-less
+    `release:anchor` would otherwise leak past the rerun guard, exactly like a manifest-less
+    wave-0 anchor).
+
+    Ordering mirrors the wave create-then-patch: `release:anchor` is applied BEFORE the body
+    patch so a body-patch failure leaves a DISCOVERABLE (manifest-less → grace-skipped, then
+    Conflicted) anchor rather than a silent, undiscovered release."""
+    ctx = plan.manifest_context
+    expected = sum(1 for p in plan.pr_plans if p.manual_member)
+    anchor = min(manual_pr_numbers)
+    anchor_body = manual_bodies.get(anchor)
+    if len(manual_pr_numbers) != expected or anchor_body is None:
+        result.success = False
+        result.errors.append(
+            f"Manifest NOT written: collected {sorted(manual_pr_numbers)} of {expected} manual "
+            f"member PRs (or anchor body unavailable); refusing to emit a partial manifest that "
+            f"would orphan member PRs (F3)."
+        )
+        for n in sorted(manual_pr_numbers):
+            try:
+                io_layer.close_pr(n)
+                print(f"Closed orphaned manual member PR #{n} (incomplete release; manifest withheld).")
+            except Exception as exc:
+                result.errors.append(
+                    f"Could not close orphaned manual member PR #{n}: {exc}. Close it manually."
+                )
+        return
+
+    members = sorted(manual_pr_numbers)
+    # release:anchor FIRST (discovery), so a later body-patch failure stays visible.
+    try:
+        io_layer.add_label(anchor, "release:anchor")
+    except Exception as exc:
+        # The label-add is the FIRST mutation: nothing discoverable exists yet (no
+        # release:anchor, no manifest). Leaving the members open would strand an
+        # undiscoverable set a rerun could duplicate — so close them (mirror the F3
+        # cleanup). They are unmerged, so closing deploys nothing. (Codex review.)
+        result.success = False
+        result.errors.append(
+            f"Failed to apply 'release:anchor' to manual anchor PR #{anchor}: {exc}. "
+            f"Closing the created member PRs {members} (manifest withheld); re-run to retry."
+        )
+        for n in members:
+            try:
+                io_layer.close_pr(n)
+                print(f"Closed manual member PR #{n} (release:anchor failed; manifest withheld).")
+            except Exception as close_exc:
+                result.errors.append(
+                    f"Could not close manual member PR #{n}: {close_exc}. Close it manually."
+                )
+        return
+
+    manifest = build_manual_manifest(
+        app=ctx["app"], instance_id=ctx["instance_id"], display_name=ctx["display_name"],
+        members=members, source_sha=ctx.get("source_sha"), source_pr=ctx.get("source_pr"),
+    )
+    links_md = _manual_members_md(members, anchor)
+    new_body = f"{anchor_body}\n\n{links_md}\n\n{manifest_block(manifest)}"
+    try:
+        io_layer.update_pull_request_body(anchor, new_body)
+    except Exception as exc:
+        result.success = False
+        result.errors.append(
+            f"Manifest patch FAILED on manual anchor PR #{anchor}: {exc}. The release is "
+            f"manifest-less; close member PRs {members} before re-running, or patch the anchor "
+            f"body manually."
+        )
+        return
+    print(f"Release manifest written to manual anchor PR #{anchor} "
+          f"(instanceId={ctx['instance_id']}, members={members}); release:anchor applied.")

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.17.0",
+    version="0.18.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/tests/test_io_layer.py
+++ b/tests/test_io_layer.py
@@ -434,7 +434,11 @@ def test_find_open_release_anchors_returns_number_and_body():
     pr = MagicMock(); pr.body = "BODY"
     gh.get_pull.return_value = pr
     anchors = _io(gh).find_open_release_anchors()
-    gh.get_issues.assert_called_once_with(state="open", labels=["release:wave:0"])
+    # ST-4157: anchors are discovered by BOTH release:wave:0 and release:anchor (queried
+    # separately, deduped by PR number). The same issue returned by both queries appears once.
+    label_calls = [c.kwargs.get("labels") for c in gh.get_issues.call_args_list]
+    assert ["release:wave:0"] in label_calls
+    assert ["release:anchor"] in label_calls
     assert anchors == [(7, "BODY")]
 
 

--- a/tests/test_io_layer.py
+++ b/tests/test_io_layer.py
@@ -443,6 +443,27 @@ def test_find_open_release_anchors_returns_number_and_body():
 
 
 # ---------------------------------------------------------------------------
+# ST-4157: IOLayer.add_label (used to stamp release:anchor on the manual anchor)
+# ---------------------------------------------------------------------------
+
+def test_add_label_applies_to_correct_pr_and_ensures_label_exists():
+    gh = MagicMock()
+    pr = MagicMock()
+    gh.get_pull.return_value = pr
+    _io(gh).add_label(7, "release:anchor")
+    gh.get_label.assert_any_call("release:anchor")   # _ensure_labels_exist ran
+    gh.get_pull.assert_called_once_with(7)            # applied to the correct PR number
+    pr.add_to_labels.assert_called_once_with("release:anchor")
+
+
+def test_add_label_dry_run_is_a_noop():
+    gh = MagicMock()
+    _io(gh, dry_run=True).add_label(7, "release:anchor")
+    gh.get_pull.assert_not_called()
+    gh.get_label.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # ST-4128: every PR HIU creates carries the `app:<service>` label
 # ---------------------------------------------------------------------------
 

--- a/tests/test_manual_per_stack.py
+++ b/tests/test_manual_per_stack.py
@@ -1,0 +1,323 @@
+"""ST-4157: promoter-managed `manual-per-stack` deploy = one PR per prod stack, NO waves.
+
+A human merges each member PR in any order; release-promoter completes the release once
+all are merged + synced. Activation: explicit DEPLOY_STRATEGY=manual-per-stack on a
+production/semver tag (AUTOMERGE ignored, like the wave strategies). The anchor = the
+lowest-numbered member PR; it carries `release:anchor` + a `mode:"manual-per-stack"`
+manifest whose `members` are the member PR numbers. Members carry `deploy:manual-per-stack`
+but no `release:wave:*` / `release:anchor`.
+"""
+
+import os
+import re
+from unittest.mock import Mock
+
+import pytest
+
+from helm_image_updater.models import UpdateStrategy, DeployStrategy
+from helm_image_updater.environment import EnvironmentConfig
+from helm_image_updater.io_layer import IOLayer
+from helm_image_updater.manifest import build_manual_manifest, is_manifest_v1, extract_instance_id, manifest_block
+from helm_image_updater.plan_builder import (
+    prepare_plan,
+    _group_changes_for_prs,
+    _group_changes_manual_per_stack,
+    _is_promoter_managed_manual_per_stack,
+    _should_auto_merge,
+)
+from helm_image_updater.plan_executor import execute_plan
+
+
+PROD_STACKS = [
+    "com-keboola-azure-north-europe",
+    "kbc-us-east-1",
+    "cloud-keboola-cs",
+]
+DEV_STACKS = [
+    "dev-keboola-gcp-us-central1",
+    "dev-keboola-aws-eu-west-1",
+]
+
+
+def _stack_change(stack):
+    return {"stack": stack, "file_change": Mock(), "changes": []}
+
+
+def _manual_config():
+    config = Mock()
+    config.deploy_strategy = DeployStrategy.MANUAL_PER_STACK
+    config.automerge = False
+    # Mock auto-creates truthy attrs; pin the OTHER promoter gates off so routing
+    # exercises the manual branch (a real manual EnvironmentConfig has these False).
+    config.promoter_managed_standard = False
+    return config
+
+
+def _manual_plan():
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    plan.multi_stage = False
+    plan.helm_chart = "dummy-service"
+    plan.image_tag = "production-abc123"
+    return plan
+
+
+# --- models / enum -----------------------------------------------------------------
+
+
+def test_manual_per_stack_is_not_a_wave_strategy():
+    assert DeployStrategy("manual-per-stack") is DeployStrategy.MANUAL_PER_STACK
+    assert DeployStrategy.MANUAL_PER_STACK.is_wave is False
+
+
+# --- grouping: one PR per prod stack, deploy label, no wave -------------------------
+
+
+def test_group_manual_one_pr_per_prod_stack():
+    changes = [_stack_change(s) for s in PROD_STACKS]
+    groups = _group_changes_manual_per_stack(changes, _manual_plan(), _manual_config())
+
+    assert len(groups) == len(PROD_STACKS)
+    for g in groups:
+        assert len(g["stacks"]) == 1
+        assert g["pr_type"] == "manual"
+        assert g["base_branch"] == "main"
+        assert g["labels"] == ["deploy:manual-per-stack"]
+        assert "wave_number" not in g
+        assert not any(l.startswith("release:wave:") for l in g["labels"])
+        assert not any(l == "release:anchor" for l in g["labels"])  # added at executor time
+    assert sorted(s for g in groups for s in g["stacks"]) == sorted(PROD_STACKS)
+
+
+def test_group_manual_excludes_dev_stacks():
+    # dev stacks go via the fast non-production path — never a manual member.
+    changes = [_stack_change(s) for s in PROD_STACKS + DEV_STACKS]
+    groups = _group_changes_manual_per_stack(changes, _manual_plan(), _manual_config())
+    all_stacks = [s for g in groups for s in g["stacks"]]
+    for d in DEV_STACKS:
+        assert d not in all_stacks
+    assert sorted(all_stacks) == sorted(PROD_STACKS)
+
+
+def test_group_manual_excludes_e2e_stacks():
+    changes = [_stack_change(s) for s in PROD_STACKS]
+    changes.append(_stack_change("foo-bar-e2e"))
+    groups = _group_changes_manual_per_stack(changes, _manual_plan(), _manual_config())
+    assert "foo-bar-e2e" not in [s for g in groups for s in g["stacks"]]
+
+
+# --- routing + auto-merge ----------------------------------------------------------
+
+
+def test_group_changes_for_prs_routes_manual_per_stack():
+    changes = [_stack_change(s) for s in PROD_STACKS]
+    groups = _group_changes_for_prs(changes, _manual_plan(), _manual_config(), Mock())
+    assert len(groups) == len(PROD_STACKS)
+    assert all(g["pr_type"] == "manual" for g in groups)
+
+
+def test_should_auto_merge_manual_is_false():
+    plan = _manual_plan()
+    assert _should_auto_merge(plan, "manual", user_requested=True) is False
+    assert _should_auto_merge(plan, "manual", user_requested=False) is False
+
+
+def test_is_promoter_managed_manual_per_stack_production_only():
+    assert _is_promoter_managed_manual_per_stack(_manual_config(), _manual_plan()) is True
+    # OVERRIDE / CANARY / DEV are orthogonal axes — never the manual path.
+    for axis in (UpdateStrategy.OVERRIDE, UpdateStrategy.CANARY, UpdateStrategy.DEV):
+        plan = _manual_plan()
+        plan.strategy = axis
+        assert _is_promoter_managed_manual_per_stack(_manual_config(), plan) is False
+
+
+# --- guard regressions: canary / override not hijacked -----------------------------
+
+
+def test_canary_not_hijacked_by_manual_per_stack():
+    config = _manual_config()
+    config.image_tag = "canary-orion-abc123"
+    plan = _manual_plan()
+    plan.strategy = UpdateStrategy.CANARY
+    plan.image_tag = "canary-orion-abc123"
+    changes = [_stack_change(s) for s in PROD_STACKS]
+    groups = _group_changes_for_prs(changes, plan, config, Mock())
+    assert len(groups) == 1
+    assert groups[0]["pr_type"] == "canary"
+
+
+def test_override_not_hijacked_by_manual_per_stack():
+    config = _manual_config()
+    plan = _manual_plan()
+    plan.strategy = UpdateStrategy.OVERRIDE
+    changes = [_stack_change("kbc-us-east-1")]
+    groups = _group_changes_for_prs(changes, plan, config, Mock())
+    assert len(groups) == 1
+    assert groups[0]["pr_type"] == "standard"
+    assert groups[0].get("labels", []) == []
+
+
+# --- manifest: manual variant ------------------------------------------------------
+
+
+def test_build_manual_manifest_shape():
+    m = build_manual_manifest(
+        app="dummy-service", instance_id="dummy-service-abc123def456",
+        display_name="dummy-service@production-abc123", members=[18, 12, 15],
+    )
+    assert m["manifestVersion"] == "v1"
+    assert m["mode"] == "manual-per-stack"
+    assert m["members"] == [12, 15, 18]  # sorted
+    assert "waves" not in m and "anchorWave" not in m
+    assert is_manifest_v1(m) is True
+    # extractable for the idempotency guard
+    assert extract_instance_id(manifest_block(m)) == "dummy-service-abc123def456"
+
+
+def test_is_manifest_v1_rejects_manual_with_empty_or_bad_members():
+    base = dict(manifestVersion="v1", mode="manual-per-stack", instanceId="x-1",
+                displayName="x", app="x")
+    assert is_manifest_v1({**base, "members": []}) is False
+    assert is_manifest_v1({**base, "members": [1, 1]}) is False
+    assert is_manifest_v1({**base, "members": [0]}) is False
+    assert is_manifest_v1({**base, "members": [1, 2]}) is True
+
+
+def test_is_manifest_v1_rejects_wave_manifest_with_present_mode_key(monkeypatch=None):
+    # F2 mirror (Codex): the promoter rejects ANY present `mode` key that isn't
+    # "manual-per-stack" (JSON null is present-and-non-undefined → reject), even on an
+    # otherwise-valid wave manifest. HIU must reject the same.
+    wave = {"manifestVersion": "v1", "instanceId": "x-1", "displayName": "x", "app": "x",
+            "anchorWave": 0, "waves": {"0": 10}}
+    assert is_manifest_v1(wave) is True                 # no mode key → valid wave manifest
+    assert is_manifest_v1({**wave, "mode": None}) is False     # present null mode → reject
+    assert is_manifest_v1({**wave, "mode": "wave"}) is False   # present unknown mode → reject
+
+
+# --- prepare_plan + execute_plan (integration) -------------------------------------
+
+
+def _make_tag_yaml(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("image:\n  tag: old-tag\n")
+
+
+@pytest.fixture
+def manual_stacks(tmp_path):
+    """Three real PROD stacks on disk for a `test-chart` deploy."""
+    for s in PROD_STACKS:
+        _make_tag_yaml(tmp_path / s / "test-chart" / "tag.yaml")
+    return tmp_path
+
+
+def _manual_env(base_dir, dry_run="true", automerge="false"):
+    return {
+        "HELM_CHART": "test-chart",
+        "IMAGE_TAG": "production-abc123",
+        "GH_TOKEN": "t",
+        "GH_APPROVE_TOKEN": "a",
+        "DEPLOY_STRATEGY": "manual-per-stack",
+        "AUTOMERGE": automerge,
+        "DRY_RUN": dry_run,
+        "TARGET_PATH": str(base_dir),
+    }
+
+
+def test_env_recognises_manual_per_stack():
+    config = EnvironmentConfig.from_env(_manual_env("/tmp"))
+    assert config.deploy_strategy == DeployStrategy.MANUAL_PER_STACK
+    assert config.promoter_managed_manual_per_stack is True
+    assert config.validate() == []
+
+
+def test_prepare_plan_manual_one_pr_per_stack_unmerged_labelled(manual_stacks):
+    os.chdir(manual_stacks)
+    config = EnvironmentConfig.from_env(_manual_env(manual_stacks))
+    plan = prepare_plan(config, IOLayer(Mock(), Mock(), dry_run=True, approve_github_repo=Mock()))
+
+    assert plan.manifest_context is not None
+    assert plan.manifest_context["instance_id"].startswith("test-chart-")
+    assert len(plan.pr_plans) == len(PROD_STACKS)
+    for p in plan.pr_plans:
+        assert p.auto_merge is False
+        assert p.labels == ["deploy:manual-per-stack"]
+        assert p.wave_number is None
+        assert p.manual_member is True
+
+
+def test_execute_plan_manual_anchors_lowest_pr_and_patches_member_manifest(manual_stacks):
+    os.chdir(manual_stacks)
+    config = EnvironmentConfig.from_env(_manual_env(manual_stacks, dry_run="false"))
+
+    # io: 3 PR creates returning sequential numbers; capture body-patch + label-add.
+    io = IOLayer(Mock(), Mock(), dry_run=False, approve_github_repo=Mock())
+    io.find_open_release_anchors = Mock(return_value=[])
+    pr_seq = iter([105, 101, 108])  # creation order ≠ numeric order; anchor must be min(101)
+
+    create_calls = []
+
+    def _create(**kw):
+        n = next(pr_seq)
+        create_calls.append({"labels": kw.get("labels"), "auto_merge": kw.get("auto_merge"), "num": n})
+        return f"https://github.com/keboola/kbc-stacks/pull/{n}"
+
+    io.create_branch_commit_and_pr = Mock(side_effect=_create)
+    io.write_file_changes = Mock()
+    io.update_pull_request_body = Mock()
+    io.add_label = Mock()
+
+    plan = prepare_plan(config, io)
+    result = execute_plan(plan, io)
+
+    # 3 member PRs, each unmerged + deploy:manual-per-stack, no release:wave/anchor at create.
+    assert len(create_calls) == 3
+    for c in create_calls:
+        assert c["auto_merge"] is False
+        assert c["labels"] == ["deploy:manual-per-stack"]
+        assert not any(str(l).startswith("release:wave:") for l in c["labels"])
+        assert "release:anchor" not in c["labels"]
+
+    # release:anchor added to the LOWEST-numbered PR (101), exactly once.
+    io.add_label.assert_called_once_with(101, "release:anchor")
+
+    # the manifest is patched into the anchor (101) with mode + all member numbers.
+    assert io.update_pull_request_body.call_count == 1
+    anchor_arg, body_arg = io.update_pull_request_body.call_args[0]
+    assert anchor_arg == 101
+    iid = extract_instance_id(body_arg)
+    assert iid is not None and iid.startswith("test-chart-")
+    # parse the embedded manifest and check it's the manual variant with all 3 members
+    m = re.search(r"```json\n(.*?)```", body_arg, re.DOTALL)
+    assert m is not None
+    import json
+    manifest = json.loads(m.group(1))
+    assert manifest["mode"] == "manual-per-stack"
+    assert sorted(manifest["members"]) == [101, 105, 108]
+    assert is_manifest_v1(manifest) is True
+    assert result.success is True
+
+
+def test_execute_plan_manual_anchor_label_failure_closes_members(manual_stacks):
+    # Codex finding: release:anchor is applied BEFORE the body patch, so if the label-add
+    # fails the members exist with no anchor + no manifest (undiscoverable, rerun-duplicable).
+    # The executor must close the created members (mirror the F3 cleanup), not leave them.
+    os.chdir(manual_stacks)
+    config = EnvironmentConfig.from_env(_manual_env(manual_stacks, dry_run="false"))
+    io = IOLayer(Mock(), Mock(), dry_run=False, approve_github_repo=Mock())
+    io.find_open_release_anchors = Mock(return_value=[])
+    pr_seq = iter([101, 105, 108])
+    io.create_branch_commit_and_pr = Mock(
+        side_effect=lambda **kw: f"https://github.com/keboola/kbc-stacks/pull/{next(pr_seq)}")
+    io.write_file_changes = Mock()
+    io.update_pull_request_body = Mock()
+    io.close_pr = Mock()
+    io.add_label = Mock(side_effect=Exception("label boom"))
+
+    plan = prepare_plan(config, io)
+    result = execute_plan(plan, io)
+
+    assert result.success is False
+    io.update_pull_request_body.assert_not_called()  # never reached the manifest patch
+    closed = sorted(c.args[0] for c in io.close_pr.call_args_list)
+    assert closed == [101, 105, 108]

--- a/tests/test_manual_per_stack.py
+++ b/tests/test_manual_per_stack.py
@@ -298,6 +298,45 @@ def test_execute_plan_manual_anchors_lowest_pr_and_patches_member_manifest(manua
     assert result.success is True
 
 
+def test_find_open_release_anchors_searches_wave0_and_release_anchor(monkeypatch=None):
+    # H2: the idempotency guard must also see manual anchors (release:anchor), not just
+    # wave-0 anchors — else a re-run double-opens a manual release.
+    gh = Mock()
+    gh.get_issues = Mock(return_value=[])
+    io = IOLayer(Mock(), gh, dry_run=False, approve_github_repo=Mock())
+
+    io.find_open_release_anchors()
+
+    label_args = [c.kwargs.get("labels") for c in gh.get_issues.call_args_list]
+    assert ["release:wave:0"] in label_args
+    assert ["release:anchor"] in label_args
+
+
+def test_prepare_plan_manual_invokes_idempotency_guard(manual_stacks):
+    # H2: a non-dry-run with an already-open MANUAL anchor (same instanceId) must raise.
+    import base64
+    import json as _json
+    from helm_image_updater.manifest import build_manual_manifest, manifest_block, compute_instance_id
+
+    os.chdir(manual_stacks)
+    env = _manual_env(manual_stacks, dry_run="false")
+    env["METADATA"] = base64.b64encode(
+        _json.dumps({"source": {"sha": "deadbeef0123abc"}}).encode()
+    ).decode()
+    config = EnvironmentConfig.from_env(env)
+
+    iid = compute_instance_id("test-chart", "deadbeef0123abc", "production-abc123")
+    anchor_body = manifest_block(build_manual_manifest(
+        app="test-chart", instance_id=iid, display_name="test-chart@production-abc123",
+        members=[9, 12, 15],
+    ))
+    io = IOLayer(Mock(), Mock(), dry_run=False, approve_github_repo=Mock())
+    io.find_open_release_anchors = Mock(return_value=[(9, anchor_body)])
+
+    with pytest.raises(RuntimeError, match="already has an open anchor"):
+        prepare_plan(config, io)
+
+
 def test_execute_plan_manual_anchor_label_failure_closes_members(manual_stacks):
     # Codex finding: release:anchor is applied BEFORE the body patch, so if the label-add
     # fails the members exist with no anchor + no manifest (undiscoverable, rerun-duplicable).


### PR DESCRIPTION
## ST-4157 — emit `manual-per-stack` (helm-image-updater, **Part H**)

Adds the helm-image-updater side of the new **`manual-per-stack`** deploy strategy: an order-independent rollout where HIU opens **one PR per prod stack** (no waves), a human merges each in **any order**, and [release-promoter](https://github.com/keboola/release-promoter) completes the release once **all** are merged + synced. Mirrors the ST-4126 `standard` 2-wave emission.

Pairs with the promoter side: **[release-promoter#18](https://github.com/keboola/release-promoter/pull/18)** (Part P).

### E2E tests ✅ 
https://github.com/keboola/helm-image-updater-testing/actions/runs/28175550945

### H1 — emission
- `DeployStrategy.MANUAL_PER_STACK = "manual-per-stack"`; `is_wave` still **excludes** it (no waves); `is_promoter_managed` includes it.
- `environment.py`: recognise it (parse + error message), `promoter_managed_manual_per_stack` (always on when selected, AUTOMERGE ignored), validate production/semver tag + OVERRIDE_STACK-incompatible.
- `plan_builder.py`: `_is_promoter_managed_manual_per_stack` (PRODUCTION-only); `_group_changes_manual_per_stack` opens **one PR per prod stack** (dev excluded, e2e dropped), `pr_type 'manual'`, labels `[deploy:manual-per-stack]`, no wave label; routing + `_should_auto_merge('manual')=False`.
- `plan_executor.py`: create N member PRs, then anchor the **lowest-numbered** member — apply `release:anchor` (before the body-patch so a patch failure stays discoverable) and patch a `mode:"manual-per-stack"` manifest whose `members` are all member PR numbers. F3 partial-fanout safety (close orphans) generalised from the wave path.
- `manifest.py`: `build_manual_manifest` (mode + sorted members, no waves); `is_manifest_v1` accepts the manual variant and rejects manual+waves AND any present non-manual `mode` key (F2 mirror).
- `io_layer.add_label` for the post-creation `release:anchor` stamp.

### H2 — idempotency guard + docs
- `find_open_release_anchors` now scans **both** `release:wave:0` and `release:anchor` (queried separately, deduped), so the duplicate-fan-out guard refuses to double-open an open manual release on a same-source re-run.
- README: `manual-per-stack` strategy table row + a dedicated section; strategy lists updated.

### Review & verification
- **Codex** (gpt-5.5, read-only, high) reviewed the H1 diff. Two findings reproduced + fixed: (1) close created members if `release:anchor` application fails; (2) `is_manifest_v1` mirrors the promoter's present-`mode` reject for JSON null.
- `.venv/bin/python -m pytest -q` → **242 passed**.

Production opt-in (kbc-stacks routing label + HIU pin) is deferred to ST-4131, as with `standard`.

Linear: **ST-4157**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
