### PR TITLE
ST-4167: list all source PRs in generated PR body

### DIFF
--- a/helm_image_updater/message_generation.py
+++ b/helm_image_updater/message_generation.py
@@ -264,8 +264,12 @@ def format_pr_body_with_metadata(
     # Build the PR line. Prefer listing every source PR in the batch; fall back to the
     # single pr_url for callers that don't forward a PR list (backward compatible).
     if pr_numbers:
+        # Link to the source repo when we know its URL. Without it, render a non-linking
+        # code span (`#123`) rather than a bare `#123`, which GitHub would auto-link to a
+        # PR/issue in the kbc-stacks repo where this body is posted (the wrong repo).
+        repo_url_clean = (repo_url or "").rstrip("/")
         links = ", ".join(
-            f"[#{n}]({repo_url}/pull/{n})" if repo_url else f"#{n}"
+            f"[#{n}]({repo_url_clean}/pull/{n})" if repo_url_clean else f"`#{n}`"
             for n in pr_numbers
         )
         label = "Pull Requests" if len(pr_numbers) > 1 else "Pull Request"

--- a/helm_image_updater/message_generation.py
+++ b/helm_image_updater/message_generation.py
@@ -254,9 +254,26 @@ def format_pr_body_with_metadata(
     workflow_url = source.get("workflow_url", "")
     sha = source.get("sha", "Unknown")
     pr_url = source.get("pr_url", "")
-    
-    # Build PR line for insertion only if it exists
-    pr_line = f"- **Pull Request:** [{pr_url}]({pr_url})\n" if pr_url else ""
+    # All source PRs in the deploy batch (e.g. a connection merge-queue batch, ST-4167).
+    # Booleans are excluded because bool is a subclass of int in Python.
+    pr_numbers = [
+        n for n in (source.get("pr_numbers") or [])
+        if isinstance(n, int) and not isinstance(n, bool)
+    ]
+
+    # Build the PR line. Prefer listing every source PR in the batch; fall back to the
+    # single pr_url for callers that don't forward a PR list (backward compatible).
+    if pr_numbers:
+        links = ", ".join(
+            f"[#{n}]({repo_url}/pull/{n})" if repo_url else f"#{n}"
+            for n in pr_numbers
+        )
+        label = "Pull Requests" if len(pr_numbers) > 1 else "Pull Request"
+        pr_line = f"- **{label}:** {links}\n"
+    elif pr_url:
+        pr_line = f"- **Pull Request:** [{pr_url}]({pr_url})\n"
+    else:
+        pr_line = ""
     
     trigger_info = (
         "### 🔄 Pipeline Trigger\n"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.19.0",
+    version="0.20.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/tests/test_message_generation_pr_body.py
+++ b/tests/test_message_generation_pr_body.py
@@ -1,0 +1,132 @@
+"""Unit tests for format_pr_body_with_metadata PR-line rendering (ST-4167).
+
+Covers the multi-PR batch listing introduced for connection merge-queue
+deploys, the single-PR fallback, and the edge cases flagged in review
+(missing repository_url must not auto-link to the wrong repo; non-int /
+bool entries must be filtered).
+"""
+
+from helm_image_updater.message_generation import format_pr_body_with_metadata
+
+
+def _metadata(**source_overrides):
+    """Build pipeline metadata with a sensible source block, overridable per test."""
+    source = {
+        "repository": "keboola/connection",
+        "repository_url": "https://github.com/keboola/connection",
+        "workflow_url": "https://github.com/keboola/connection/actions/runs/1",
+        "sha": "d049a945387e242f2e58379a964b4758bd076343",
+        "actor": "bot",
+        "timestamp": "2026-06-26T00:00:00Z",
+    }
+    source.update(source_overrides)
+    return {"source": source}
+
+
+def _pr_line(body: str) -> str:
+    """Return the single '- **Pull Request(s):**' line from a rendered body, or ''."""
+    for line in body.splitlines():
+        if "Pull Request" in line:
+            return line.strip()
+    return ""
+
+
+class TestFormatPrBodyPrLine:
+    """PR-line rendering in format_pr_body_with_metadata."""
+
+    def test_multiple_pr_numbers_render_linked_list(self):
+        """A batch renders every PR as a linked #<n>, with a plural label."""
+        body = format_pr_body_with_metadata(
+            "connection", "production-abc",
+            _metadata(pr_numbers=[7008, 6999, 7001]),
+        )
+        line = _pr_line(body)
+        assert line.startswith("- **Pull Requests:**")
+        assert "[#7008](https://github.com/keboola/connection/pull/7008)" in line
+        assert "[#6999](https://github.com/keboola/connection/pull/6999)" in line
+        assert "[#7001](https://github.com/keboola/connection/pull/7001)" in line
+        # comma-separated
+        assert line.count(", ") == 2
+
+    def test_single_pr_number_uses_singular_label(self):
+        """A one-element batch uses the singular 'Pull Request' label."""
+        body = format_pr_body_with_metadata(
+            "connection", "production-abc",
+            _metadata(pr_numbers=[7008]),
+        )
+        line = _pr_line(body)
+        assert line.startswith("- **Pull Request:**")
+        assert "[#7008](https://github.com/keboola/connection/pull/7008)" in line
+
+    def test_falls_back_to_pr_url_when_no_pr_numbers(self):
+        """Without pr_numbers, fall back to the single source.pr_url line."""
+        body = format_pr_body_with_metadata(
+            "connection", "production-abc",
+            _metadata(pr_url="https://github.com/keboola/connection/pull/7008"),
+        )
+        line = _pr_line(body)
+        assert line == (
+            "- **Pull Request:** "
+            "[https://github.com/keboola/connection/pull/7008]"
+            "(https://github.com/keboola/connection/pull/7008)"
+        )
+
+    def test_no_pr_line_when_neither_present(self):
+        """No pr_numbers and no pr_url -> no PR line at all."""
+        body = format_pr_body_with_metadata(
+            "connection", "production-abc", _metadata(),
+        )
+        assert _pr_line(body) == ""
+
+    def test_missing_repository_url_uses_non_linking_code_span(self):
+        """Without repository_url, render `#<n>` code spans, never a bare #<n>
+        (which GitHub would auto-link to the wrong repo where the body is posted)."""
+        body = format_pr_body_with_metadata(
+            "connection", "production-abc",
+            _metadata(repository_url="", pr_numbers=[7008, 6999]),
+        )
+        line = _pr_line(body)
+        assert "`#7008`" in line
+        assert "`#6999`" in line
+        # no markdown links were built
+        assert "](http" not in line
+        # and not a bare, auto-linkable "#7008" (it must be inside backticks)
+        assert " #7008" not in line.replace("`#7008`", "")
+
+    def test_pr_numbers_take_precedence_over_pr_url(self):
+        """When both are present, the batch list wins over the single pr_url."""
+        body = format_pr_body_with_metadata(
+            "connection", "production-abc",
+            _metadata(
+                pr_numbers=[7008, 6999],
+                pr_url="https://github.com/keboola/connection/pull/7008",
+            ),
+        )
+        line = _pr_line(body)
+        assert line.startswith("- **Pull Requests:**")
+        assert "[#6999](https://github.com/keboola/connection/pull/6999)" in line
+
+    def test_filters_non_int_and_bool_entries(self):
+        """Strings, floats, and booleans in pr_numbers are dropped; ints kept."""
+        body = format_pr_body_with_metadata(
+            "connection", "production-abc",
+            _metadata(pr_numbers=[7008, True, "6999", 1.5, 7001]),
+        )
+        line = _pr_line(body)
+        assert "[#7008](https://github.com/keboola/connection/pull/7008)" in line
+        assert "[#7001](https://github.com/keboola/connection/pull/7001)" in line
+        # bool True (== 1) must not become "#1"; "6999" string and 1.5 float dropped
+        assert "#1)" not in line and "#1`" not in line
+        assert "#6999" not in line
+        assert "#1.5" not in line
+
+    def test_trailing_slash_in_repository_url_is_normalized(self):
+        """A trailing slash on repository_url does not double up in the PR link."""
+        body = format_pr_body_with_metadata(
+            "connection", "production-abc",
+            _metadata(repository_url="https://github.com/keboola/connection/",
+                      pr_numbers=[7008]),
+        )
+        line = _pr_line(body)
+        assert "[#7008](https://github.com/keboola/connection/pull/7008)" in line
+        assert "//pull/" not in line


### PR DESCRIPTION
## Release Notes
The auto-generated kbc-stacks PR body now lists **all** source PRs in a deploy batch, not just one. When connection's production build bundles several merged PRs (merge queue), the trigger forwards the full set as `metadata.source.pr_numbers`; `format_pr_body_with_metadata` renders each as a linked `#<number>`.

**Linear:** [ST-4167](https://linear.app/keboola/issue/ST-4167/handle-connection-multi-prs-merge-ci)

## E2E tests ✅ 
https://github.com/keboola/helm-image-updater-testing/actions/runs/28370801074

## Impact analysis
- **What changes:** `format_pr_body_with_metadata` reads `source.pr_numbers` (a list of ints, already parsed into `config.metadata` by `environment.py`) and renders every PR: `- **Pull Requests:** [#7008](…/pull/7008), [#6999](…/pull/6999)`.
- **Backward compatible:** when `pr_numbers` is absent it falls back to the existing single `source.pr_url` line; when both are absent, no PR line (unchanged).
- **Robustness:** non-int / boolean entries are filtered out; links are only built when `repository_url` is present.
- **No interface change:** the PR list rides inside the existing `metadata` input — no new action input.
- Existing suite: **244 passed**. Pure-function change, no behavior change for non-batch callers.

## Change type
Enhancement to PR-body generation (no deploy-strategy logic touched — strategy selection lives in kbc-stacks `update-image-tag.yaml`).

## Justification
Operators reviewing the kbc-stacks sync PR need to see every PR that went into the batch, for traceability and rollback scoping.

## Deployment
Merge & automatic deploy.

⚠️ **Release ordering:** this is part of the producer/consumer chain:
- Producer: keboola/connection#7776 forwards `pr_numbers`.
- Consumer (strategy + metadata passthrough): keboola/kbc-stacks#19944.
- kbc-stacks pins `keboola/helm-image-updater@v0.17.0`; this change takes effect only after a new release tag is cut **and** the pin in `update-image-tag.yaml` is bumped to it. (`setup.py` is already at `0.18.0`, unreleased.)

## Rollback plan
Revert of this PR.

## Post release support plan
None.
