### PR TITLE
ST-4169 + ST-4159: tag/stack-based auto-merge + legacy deploy-path removal (HIU never merges to prod)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,16 @@ The tool determines update strategy based on image tag prefix:
 - Stack types are defined in `config.py` as constants (`DEV_STACKS`, `CANARY_STACKS`)
 - Ignored folders and excluded stacks are also configured in `config.py`
 
-### Multi-Stage Deployment
+### Deploy strategies (production is always promoter-managed)
 
-When `MULTI_STAGE=true`:
-1. Creates and auto-merges PR for dev stacks (if automerge is enabled)
-2. Creates separate PR for production stacks (without auto-merge)
+Every production/semver deploy is release-promoter-managed — HIU creates the PRs
+**unmerged** (auto-approved) and never merges a PR that targets a production stack.
+`DEPLOY_STRATEGY` (empty = `standard`) selects the fan-out: `standard` (2-wave
+dev→prod), `gradual`/`critical`/`critical-manual-gate` (4 waves), or `manual-per-stack`
+(one PR per stack). Non-production deploys (`dev-*`/`canary-*` tags, `override-stack`
+targets) ignore `DEPLOY_STRATEGY` and are auto-merged by HIU. Auto-merge is decided by
+tag class + target stacks — there is no `AUTOMERGE`/`MULTI_STAGE`/`cloud_multi_stage`
+(removed in ST-4169/ST-4159).
 
 ### GitHub Actions Integration
 
@@ -101,19 +106,18 @@ The tool is designed to run as a GitHub Action via `action.yaml`. It:
 - `HELM_CHART`: Name of the Helm chart to update (required)
 - `IMAGE_TAG`: New image tag (must match specific prefixes)
 - `GH_TOKEN`: GitHub access token (required)
-- `AUTOMERGE`: Auto-merge PRs (default: "true")
 - `DRY_RUN`: Perform dry run (default: "false")
-- `MULTI_STAGE`: Enable multi-stage deployment (default: "false")
+- `DEPLOY_STRATEGY`: Rollout strategy (empty = `standard`): standard | gradual | critical | critical-manual-gate | manual-per-stack
 - `OVERRIDE_STACK`: Target specific stack bypassing automatic selection
 - `EXTRA_TAG1`, `EXTRA_TAG2`: Additional tags in format "path.in.yaml:value"
 
 ## Testing Strategy
 
 The test suite covers:
-- Development tag handling and single stack updates
-- Production tag handling with multiple stack updates
+- Development tag handling and single stack updates (auto-merged)
+- Production tag handling: promoter-managed rollout (unmerged PRs), never merged by HIU
 - Canary tag handling with stack-specific updates
-- Multi-stage deployment scenarios
+- Deploy-strategy grouping (standard 2-wave, wave strategies, manual-per-stack)
 - Git operations and PR creation
 - Configuration validation and error handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ tag class + target stacks — there is no `AUTOMERGE`/`MULTI_STAGE`/`cloud_multi
 ### GitHub Actions Integration
 
 The tool is designed to run as a GitHub Action via `action.yaml`. It:
-- Downloads the latest release package
+- Installs HIU from the action's own checked-out source at the pinned ref (`$GITHUB_ACTION_PATH`), so `action.yaml` and the Python code always run in lockstep
 - Sets up Python 3.13 environment
 - Configures git with canary branch support
 - Runs the update process with environment variables

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A Python tool for automating image tag updates across Helm charts in different K
 - Updates image tags in Helm charts across multiple stacks
 - Supports both development and production deployments
 - Creates pull requests with detailed descriptions
-- Optional auto-merge functionality
+- Production deploys are always release-promoter-managed; dev/canary/override deploys are auto-merged fast by HIU
 - Dry-run mode for testing changes
-- Multi-stage deployment support
+- Promoter rollout strategies (standard 2-wave, gradual/critical waves, manual-per-stack)
 - Extra tag updates for complex configurations
 - Detailed logging and error handling
 - Automatically removes ArgoCD branch overrides (`appManifestsRevision`) from `values.yaml` in the same PR
@@ -52,10 +52,8 @@ Required:
 
 Optional:
 
-- `AUTOMERGE`: Whether to automatically merge PRs (default: "true", note: canary updates are always auto-merged). When set to `false`, PRs are auto-approved by the machine user instead, satisfying CODEOWNERS requirements so humans can merge without waiting for additional reviews.
 - `DRY_RUN`: Whether to perform a dry run (default: "false")
-- `MULTI_STAGE`: Enable multi-stage deployment (default: "false"). **Deprecated** — alias for `DEPLOY_STRATEGY=cloud_multi_stage`; prefer `DEPLOY_STRATEGY`.
-- `DEPLOY_STRATEGY`: Rollout strategy (default: "standard"): `standard`, `cloud_multi_stage`, `gradual`, `critical`, `critical-manual-gate`, or `manual-per-stack`. See [Deploy Strategies](#deploy-strategies).
+- `DEPLOY_STRATEGY`: Rollout strategy (default/empty: `standard`): `standard`, `gradual`, `critical`, `critical-manual-gate`, or `manual-per-stack`. See [Deploy Strategies](#deploy-strategies). Whether a PR auto-merges is decided by tag class + target stacks (see [Auto-merge](#auto-merge-and-auto-approve)), not by a knob.
 - `TARGET_PATH`: Path to the directory containing the stacks (default: ".")
 - `OVERRIDE_STACK`: Stack ID to explicitly target for the update, bypassing automatic stack selection (default: None)
 - `EXTRA_TAG1`, `EXTRA_TAG2`: Additional tags to update (format: "path:value")
@@ -83,14 +81,12 @@ Dry run:
 Minimal usage example (always pin to a released version — see [Releasing](#releasing); the action runs the code from the pinned tag):
 
 ```yaml
-- uses: "keboola/helm-image-updater@v0.15.0"
+- uses: "keboola/helm-image-updater@v0.23.0"
   with:
     helm-chart: "dummy-service"
     image-tag: "dev-b10536c41180e420eaf083451a1ddee132f512c6"
-    automerge: "true"
     dry-run: "false"
-    multi-stage: "false"
-    deploy-strategy: ""  # standard | cloud_multi_stage | gradual | critical | critical-manual-gate | manual-per-stack
+    deploy-strategy: ""  # empty = standard | gradual | critical | critical-manual-gate | manual-per-stack
     override-stack: "dev-keboola-gcp-us-central1"
     extra-tag1: "agent.image.tag:dev-2.0.0"
     extra-tag2: "messenger.image.tag:dev-2.0.0"
@@ -114,23 +110,13 @@ on:
         required: false
         type: string
         default: ''
-      automerge:
-        description: "Automatically merge PRs"
-        required: false
-        type: boolean
-        default: true
       dry-run:
         description: "Do a dry run"
         required: false
         type: boolean
         default: false
-      multi-stage:
-        description: "Enable multi-stage deployment (auto-merge dev, manual prod). Deprecated alias for deploy-strategy=cloud_multi_stage."
-        required: false
-        type: boolean
-        default: false
       deploy-strategy:
-        description: "Rollout strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate | manual-per-stack"
+        description: "Rollout strategy (empty = standard): standard | gradual | critical | critical-manual-gate | manual-per-stack"
         required: false
         type: string
         default: ''
@@ -179,13 +165,11 @@ jobs:
         with:
           user: bot
 
-      - uses: keboola/helm-image-updater@v0.15.0
+      - uses: keboola/helm-image-updater@v0.23.0
         with:
           helm-chart: ${{ inputs.helm-chart }}
           image-tag: ${{ inputs.image-tag }}
-          automerge: ${{ inputs.automerge }}
           dry-run: ${{ inputs.dry-run }}
-          multi-stage: ${{ inputs.multi-stage }}
           deploy-strategy: ${{ inputs.deploy-strategy }}
           override-stack: ${{ inputs.override-stack }}
           extra-tag1: ${{ inputs.extra-tag1 }}
@@ -212,25 +196,30 @@ Image tags must follow these formats:
 
 ### Development Updates
 
-- Updates only development stacks
-- Auto-merge behavior follows the `automerge` setting
+- Updates only development (and, via `override-stack`, e2e) stacks
+- Auto-merged fast by HIU (a dev/e2e target is never production)
 
 ### Production Updates
 
-- Updates production stacks
-- Auto-merge behavior follows the `automerge` setting
-- In multi-stage mode, creates separate PRs for dev and prod stacks
+- Updates all stacks the production tag lands on (dev + prod)
+- Always release-promoter-managed: HIU creates the PRs **unmerged** (and auto-approved); release-promoter merges them. HIU never merges a PR that targets a production stack.
+- Fanned out per the selected strategy — `standard` (2-wave dev→prod, the default), the wave strategies, or `manual-per-stack`
 
 ### Canary Updates
 
 - Updates only the specific canary stack matching the tag prefix
-- Always auto-merges regardless of the `automerge` setting
+- Always auto-merged by HIU (targets its own `canary-*` branch)
 - Uses stack-specific base branches (e.g., `canary-orion`)
 - Supports extra tags for complex configurations
 
-## Auto-Approve
+## Auto-merge and Auto-approve
 
-When `AUTOMERGE` is set to `false`, created PRs are automatically approved using the `GH_APPROVE_TOKEN` (machine user `keboola-sre-approve-bot`). This satisfies CODEOWNERS approval requirements so that humans can merge PRs without waiting for additional reviews. Auto-approve is skipped when `AUTOMERGE=true` (since PRs are merged immediately) and during dry runs.
+HIU decides whether to **merge** a PR itself purely from the **effective tag class** (across `image_tag` + extra tags) and the **target stacks** — there is no `AUTOMERGE` knob (ST-4169/ST-4159):
+
+- **Production/semver-class** deploy, or any PR whose targets include a production stack → **not merged** by HIU. It is created unmerged and **auto-approved** with `GH_APPROVE_TOKEN` (machine user `keboola-sre-approve-bot`, satisfying CODEOWNERS) so release-promoter — or a human, for `manual-per-stack` — can merge it.
+- **Dev / canary / `pr-test-*` (non-production-class)** deploy to non-production stacks (dev, e2e, canary, override) → **auto-merged** by HIU immediately.
+
+Auto-approve and merge are both skipped during dry runs. `wave` and `manual-per-stack` PRs are always created unmerged regardless of tag class.
 
 ## Override Removal
 
@@ -267,27 +256,21 @@ If `argocdApplication` only contained `appManifestsRevision`, the entire block i
 
 ## Deploy Strategies
 
-`DEPLOY_STRATEGY` (action input `deploy-strategy`, default `standard`) selects how a production update is fanned out into PRs and who merges them. It supersedes the older boolean `MULTI_STAGE` flag.
+`DEPLOY_STRATEGY` (action input `deploy-strategy`) selects how a **production** update is fanned out into PRs. Every production deploy is release-promoter-managed — HIU creates the PRs unmerged and the promoter (or, for `manual-per-stack`, a human) merges them. An **empty** `DEPLOY_STRATEGY` resolves to `standard`, the universal default (ST-4131/ST-4159). There is no `cloud_multi_stage`, `MULTI_STAGE`, or `AUTOMERGE` any more.
 
-| `DEPLOY_STRATEGY` | grouping | `AUTOMERGE=true` | `AUTOMERGE=false` |
-|---|---|---|---|
-| _unset_ (legacy default) | one PR (per-stack for a production tag) | merge the PR(s) | leave unmerged (per-stack) |
-| `standard` (explicit) | promoter-managed **2-wave dev→prod**: wave 0 = all dev stacks (anchor, carries the manifest), wave 1 = all prod stacks | *(ignored)* — **2 unmerged wave PRs**, release-promoter merges dev → prod | **2 unmerged wave PRs** — release-promoter merges dev → prod |
-| `cloud_multi_stage` | dev + prod PRs per cloud | merge dev, leave prod | leave all unmerged |
-| `gradual` · `critical` · `critical-manual-gate` | 4 unmerged **wave** PRs (waves 0–3) | *(ignored — release-promoter merges)* | *(release-promoter merges)* |
-| `manual-per-stack` | promoter-managed **one PR per stack (dev + prod), no waves** | *(ignored)* — **N unmerged member PRs**, a human merges each in any order | **N unmerged member PRs** — a human merges each in any order |
+| `DEPLOY_STRATEGY` | grouping | who merges |
+|---|---|---|
+| empty → `standard` | promoter-managed **2-wave dev→prod**: wave 0 = all dev stacks (anchor, carries the manifest), wave 1 = all prod stacks | release-promoter merges dev → prod |
+| `gradual` · `critical` · `critical-manual-gate` | 4 unmerged **wave** PRs (waves 0–3) | release-promoter merges wave-by-wave |
+| `manual-per-stack` | **one PR per stack (dev + prod), no waves** | a human merges each in any order; release-promoter completes |
 
-### New vs. old parameters
-
-- **`DEPLOY_STRATEGY` is the single knob.** Leaving it unset keeps today's behavior — existing deploys are unaffected. An **explicit** `DEPLOY_STRATEGY=standard` opts the app into the promoter-managed 2-wave dev→prod release (see below); the unset default does **not**, so this is a deliberate, app-by-app opt-in.
-- **`MULTI_STAGE=true` is a deprecated alias for `DEPLOY_STRATEGY=cloud_multi_stage`** — identical behavior, kept for backward compatibility. If both are set, the explicit `DEPLOY_STRATEGY` wins.
-- **`AUTOMERGE`** still controls merging for the legacy default and `cloud_multi_stage`. For an **explicit `standard`** and the wave strategies (`gradual` / `critical` / `critical-manual-gate`) it is **ignored** — those PRs are always created unmerged (and auto-approved) and merged later by release-promoter.
+Non-production deploys (`dev-*` / `canary-*` tags and `override-stack` targets) ignore `DEPLOY_STRATEGY` — they stay single-PR deploys and are auto-merged by HIU (see [Auto-merge](#auto-merge-and-auto-approve)).
 
 ### Promoter-managed `standard` (2-wave dev→prod)
 
-An **explicit** `DEPLOY_STRATEGY=standard` on a **`production-` tag** emits the app as a promoter-managed **2-wave** release (`AUTOMERGE` is ignored, like the wave strategies): **wave 0 = all dev stacks** (the anchor — it carries the JSON release manifest), **wave 1 = all prod stacks** (the positive `is_production` set, so canary/excluded stacks are never mis-binned into prod). The cloud dimension is collapsed (no per-cloud split). Both PRs are created unmerged and labelled `release:wave:{0,1}` + `deploy:standard`. [release-promoter](https://github.com/keboola/release-promoter) merges the dev wave, waits for its ArgoCD **sync** (no UAT, no soak), then merges the prod wave. An app present in only one tier (no dev stacks → 1-wave prod) degenerates to a **single-wave** release (wave 0 only), which the promoter handles count-agnostically. Identity is `instanceId = <app>-<image_tag>` (no cloud suffix), derived from the deployed tag(s) — the image tag, or for an `image.tag`-untouched deploy the extra tag(s) as `<path>=<value>` — so each build is unique; a duplicate fan-out for the same `instanceId` is refused while an anchor is still open.
+A **`production-`/semver tag** with `DEPLOY_STRATEGY` resolving to `standard` (i.e. the default — empty or explicit) emits the app as a promoter-managed **2-wave** release: **wave 0 = all dev stacks** (the anchor — it carries the JSON release manifest), **wave 1 = all prod stacks** (the positive `is_production` set, so canary/excluded stacks are never mis-binned into prod). The cloud dimension is collapsed (no per-cloud split). Both PRs are created unmerged and labelled `release:wave:{0,1}` + `deploy:standard`. [release-promoter](https://github.com/keboola/release-promoter) merges the dev wave, waits for its ArgoCD **sync** (no UAT, no soak), then merges the prod wave. An app present in only one tier (no dev stacks → 1-wave prod) degenerates to a **single-wave** release (wave 0 only), which the promoter handles count-agnostically. Identity is `instanceId = <app>-<image_tag>` (no cloud suffix), derived from the deployed tag(s) — the image tag, or for an `image.tag`-untouched deploy the extra tag(s) as `<path>=<value>` — so each build is unique; a duplicate fan-out for the same `instanceId` is refused while an anchor is still open.
 
-Only **`PRODUCTION`** deploys are staged: a `dev-*` tag (DEV), a `canary-*` tag, and an `override-stack` deploy are **not** promoter-managed even with explicit `DEPLOY_STRATEGY=standard` — they keep their existing handling (a dev push stays a fast, auto-merged deploy; canary auto-merges to its own branch; override is a single PR). This keeps routine dev deploys from being turned into unmerged wave PRs the promoter must merge.
+Only **`PRODUCTION`** deploys are staged: a `dev-*` tag (DEV), a `canary-*` tag, and an `override-stack` deploy are **not** promoter-managed — they keep their existing handling (a dev push stays a fast, auto-merged deploy; canary auto-merges to its own branch; override is a single PR). This keeps routine dev deploys from being turned into unmerged wave PRs the promoter must merge. HIU has **no code path** that merges a PR whose targets include a production stack.
 
 ### Wave strategies (release-promoter)
 
@@ -377,19 +360,19 @@ The test suite verifies the following functionality:
 - Development tag handling (`dev-*`)
 
   - Single stack updates
-  - Automerge functionality
+  - Auto-merged by HIU (non-production target)
   - Tag file modifications
 
 - Production tag handling (`production-*`)
 
-  - Multiple stack updates
-  - Multi-stage deployment support
+  - Promoter-managed rollout (unmerged PRs); never merged by HIU
+  - Standard 2-wave / wave / manual-per-stack grouping
   - Concurrent stack updates
 
 - Canary tag handling (`canary-*`)
 
   - Stack-specific updates
-  - Automatic auto-merge
+  - Auto-merged by HIU to the canary branch
   - Base branch targeting
   - Extra tag support
 

--- a/action.yaml
+++ b/action.yaml
@@ -7,20 +7,12 @@ inputs:
   image-tag:
     description: 'Updates image.tag in tag.yaml'
     required: true
-  automerge:
-    description: 'Automatically merge PRs'
-    required: false
-    default: 'true'
   dry-run:
     description: 'Do a dry run'
     required: false
     default: 'false'
-  multi-stage:
-    description: 'Enable multi-stage deployment'
-    required: false
-    default: 'false'
   deploy-strategy:
-    description: 'Promoter deploy strategy: standard | cloud_multi_stage | gradual | critical | critical-manual-gate'
+    description: 'Promoter deploy strategy: standard | gradual | critical | critical-manual-gate | manual-per-stack (empty = standard). Production deploys are always promoter-managed; auto-merge is decided by tag class + target stacks.'
     required: false
     default: ''
   commit-sha:
@@ -44,7 +36,7 @@ inputs:
     required: false
     default: ''
   approve-token:
-    description: 'GitHub token from a machine user (CODEOWNERS team member) to auto-approve PRs when automerge is false'
+    description: 'GitHub token from a machine user (CODEOWNERS team member) to auto-approve the unmerged PRs so release-promoter (or a human) can merge them'
     required: true
   github-token:
     description: 'GitHub token for authentication'
@@ -84,9 +76,7 @@ runs:
       env:
         HELM_CHART: ${{ inputs.helm-chart }}
         IMAGE_TAG: ${{ inputs.image-tag }}
-        AUTOMERGE: ${{ inputs.automerge }}
         DRY_RUN: ${{ inputs.dry-run }}
-        MULTI_STAGE: ${{ inputs.multi-stage }}
         DEPLOY_STRATEGY: ${{ inputs.deploy-strategy }}
         EXTRA_TAG1: ${{ inputs.extra-tag1 }}
         EXTRA_TAG2: ${{ inputs.extra-tag2 }}

--- a/docs/superpowers/plans/2026-07-13-st4159-legacy-removal-plan.md
+++ b/docs/superpowers/plans/2026-07-13-st4159-legacy-removal-plan.md
@@ -1,0 +1,553 @@
+# HIU Legacy Deploy-Path Removal (ST-4159 folded into PR #43) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** HIU never merges anything to a production stack — release-promoter owns every production merge; dev/e2e/canary merges stay fast via HIU — by deleting all legacy deploy paths (`cloud_multi_stage`, `AUTOMERGE`, legacy no-strategy production grouping) from helm-image-updater and the legacy scenarios from helm-image-updater-testing.
+
+**Architecture:** Extend existing draft PR keboola/helm-image-updater#43 (branch `tomaskacur-st-4169-tag-type-automerge`, worktree `/Users/tomaskacur/keboola/devel/helm-image-updater-st4169`, rebased on v0.22.0) with the ST-4159 removal commits → one release v0.23.0 closing ST-4169 + ST-4159. One new PR in `helm-image-updater-testing` (local checkout `/Users/tomaskacur/keboola/devel/helm-image-updater-testing`) replaces legacy scenarios with tag/stack-rule scenarios; the suite run (testing branch × HIU branch) is the release gate. A third, follow-up PR in kbc-stacks bumps the pin and strips the knob forwarding (workflow *inputs* stay — ~15 external dispatchers still send them).
+
+**Tech Stack:** Python 3.13 + pytest (HIU), GitHub Actions matrix + `actions/github-script` JS (testing repo), GH workflows (kbc-stacks).
+
+## Global Constraints
+
+- Never remove the `automerge`/`multi-stage` **workflow inputs** from `kbc-stacks/.github/workflows/update-image-tag.yaml` — ~15 repos dispatch them directly; a removed input = 422, silently swallowed by the Azure dispatch scripts (deploy outage). Removing the *forwarding* (env/`with:` to HIU) is the goal; removing the declarations is a separate org-wide migration ticket.
+- HIU env vars are NOT validated like workflow inputs — HIU simply not reading `AUTOMERGE`/`MULTI_STAGE` is safe regardless of what callers send.
+- Composite-action inputs (HIU `action.yaml`) that a caller passes but the action no longer declares produce only a *warning*, not a failure. Old pins (`@v0.20.0`) are immutable and unaffected.
+- End-state invariants (each must have a test):
+  1. PRODUCTION/SEMVER-class deploy (any strategy, incl. empty) → PRs created **unmerged** (promoter- or human-merged). HIU has **no code path** that merges a PR whose stacks include a production stack.
+  2. DEV/CANARY/INVALID-class deploy to non-production stacks (dev, e2e, canary, override) → auto-merged by HIU, fast.
+  3. Non-production-class tag on a production override target → `validate()` error (already on the branch).
+  4. Empty `DEPLOY_STRATEGY` ≡ `standard` (matches kbc-stacks' universal default since ST-4131/#20151); `OVERRIDE_STACK` runs stay single-PR regardless of strategy.
+  5. Stray `MULTI_STAGE`/`AUTOMERGE` env from old dispatchers is ignored (warning for `MULTI_STAGE=true`); `DEPLOY_STRATEGY=cloud_multi_stage` is now an *invalid strategy* error.
+- HIU tests run as: `cd /Users/tomaskacur/keboola/devel/helm-image-updater-st4169 && PYTHONPATH=$PWD /Users/tomaskacur/keboola/devel/helm-image-updater/.venv/bin/python -m pytest -q` (worktree shadows the editable install).
+- Commits end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. PRs are drafts. Testing-repo branch must be cut from a fresh `origin/main`.
+
+## Why this is safe now (context for reviewer)
+
+- kbc-stacks `update-image-tag.yaml` (post-#20151, verified on origin/main) resolves `DEPLOY_STRATEGY=standard` for **every** non-override run with no promoter-* label; production rollout via promoter verified live (kai-agent #20164/#20165). The legacy no-strategy production path is **unreachable from kbc-stacks** except via `cloud_multi_stage` label mapping (dead — multi-stage users already migrated) and `OVERRIDE_STACK` runs (kept).
+- `_should_auto_merge` on the branch already never merges to prod stacks; this plan removes the *other* legacy consumers of the knobs (grouping, titles) so the knobs can be deleted wholesale.
+
+---
+
+# Phase 1 — helm-image-updater (extend PR #43)
+
+### Task 1: `environment.py` — delete AUTOMERGE/MULTI_STAGE parsing, cloud_multi_stage, promoter flags
+
+**Files:**
+- Modify: `helm_image_updater/environment.py`
+- Test: `tests/test_legacy_knobs_removed.py` (new)
+
+**Interfaces:**
+- Produces: `EnvironmentConfig` WITHOUT fields `automerge`, `multi_stage`, `promoter_managed_standard`, `promoter_managed_manual_per_stack`. `deploy_strategy: DeployStrategy = DeployStrategy.STANDARD` (empty env → STANDARD, now meaning promoter-standard). Everything else unchanged.
+
+- [ ] **Step 1: Write the failing tests** (`tests/test_legacy_knobs_removed.py`):
+
+```python
+"""ST-4159: legacy knobs are gone — AUTOMERGE/MULTI_STAGE env ignored,
+cloud_multi_stage invalid, empty strategy resolves to standard."""
+import pytest
+from helm_image_updater.environment import EnvironmentConfig
+from helm_image_updater.models import DeployStrategy
+
+BASE = {"HELM_CHART": "x", "IMAGE_TAG": "production-abc",
+        "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a"}
+
+
+def test_automerge_env_not_parsed():
+    cfg = EnvironmentConfig.from_env({**BASE, "AUTOMERGE": "false"})
+    assert not hasattr(cfg, "automerge")
+
+
+def test_multi_stage_env_ignored_with_warning(capsys):
+    cfg = EnvironmentConfig.from_env({**BASE, "MULTI_STAGE": "true"})
+    assert not hasattr(cfg, "multi_stage")
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+    assert "MULTI_STAGE is deprecated" in capsys.readouterr().out
+
+
+def test_empty_strategy_is_standard():
+    cfg = EnvironmentConfig.from_env(BASE)
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+    assert not hasattr(cfg, "promoter_managed_standard")
+
+
+def test_cloud_multi_stage_is_invalid_strategy():
+    cfg = EnvironmentConfig.from_env({**BASE, "DEPLOY_STRATEGY": "cloud_multi_stage"})
+    assert any("Invalid DEPLOY_STRATEGY" in e for e in cfg.validate())
+```
+
+- [ ] **Step 2: Run to verify failure** — `pytest tests/test_legacy_knobs_removed.py -q` → FAIL (`automerge` attr exists, etc.)
+
+- [ ] **Step 3: Implement.** In `environment.py`:
+  - Delete dataclass fields + docstrings: `automerge` (l.21), `multi_stage` (l.23), `promoter_managed_standard` (l.24-29), `promoter_managed_manual_per_stack` (l.30-32) — the last two have **zero** consumers after Task 3.
+  - Replace the parse block (l.75-114) with:
+
+```python
+        # Parse DEPLOY_STRATEGY. Empty -> standard, the universal default (ST-4131/ST-4159):
+        # a PRODUCTION deploy is ALWAYS promoter-managed; there is no legacy fallback.
+        # AUTOMERGE is dead (auto-merge is decided by tag class + target stacks, ST-4169)
+        # and MULTI_STAGE/cloud_multi_stage was removed (ST-4159) -- old dispatchers still
+        # send both, so tolerate-and-ignore (warn for MULTI_STAGE so stragglers surface).
+        raw_strategy = env.get("DEPLOY_STRATEGY", "").strip().lower()
+        deploy_strategy = DeployStrategy.STANDARD
+        deploy_strategy_error = None
+        if raw_strategy:
+            try:
+                deploy_strategy = DeployStrategy(raw_strategy)
+            except ValueError:
+                deploy_strategy_error = (
+                    f"Invalid DEPLOY_STRATEGY: '{raw_strategy}'. "
+                    "Must be one of: standard, gradual, critical, "
+                    "critical-manual-gate, manual-per-stack"
+                )
+        if env.get("MULTI_STAGE", "false").lower() == "true":
+            print(
+                "WARNING: MULTI_STAGE is deprecated and ignored "
+                "(cloud_multi_stage was removed in ST-4159; production deploys are promoter-managed)"
+            )
+```
+
+  - Remove `automerge=…`, `multi_stage=…`, `promoter_managed_standard=…`, `promoter_managed_manual_per_stack=…` from the `cls(...)` call. Keep everything else EXPLICITLY, in particular `config._deploy_strategy_error = deploy_strategy_error` after construction — the `cloud_multi_stage`-is-invalid test depends on it (codex review).
+
+- [ ] **Step 4: Run** `pytest tests/test_legacy_knobs_removed.py -q` → 4 PASS. (Full suite is red until Task 6 — expected.)
+
+- [ ] **Step 5: Commit** `refactor(ST-4159): drop AUTOMERGE/MULTI_STAGE knobs and cloud_multi_stage from env config`
+
+### Task 2: `models.py` — remove `CLOUD_MULTI_STAGE` + `UpdatePlan.multi_stage`
+
+**Files:**
+- Modify: `helm_image_updater/models.py`
+
+**Interfaces:**
+- Produces: `DeployStrategy` = {STANDARD, GRADUAL, CRITICAL, CRITICAL_MANUAL_GATE, MANUAL_PER_STACK}; `is_wave` unchanged; `is_promoter_managed` now returns True for every member (keep the property — the E2E/kbc-stacks docs reference it — but rewrite its docstring: "every strategy is promoter-capable; DEV/CANARY/OVERRIDE runs are exempted at the plan level (`plan.strategy`), not the strategy level"). `UpdatePlan` loses `multi_stage`.
+
+- [ ] **Step 1:** Delete `CLOUD_MULTI_STAGE = "cloud_multi_stage"` (l.21); delete `UpdatePlan.multi_stage: bool = False` (l.110); rewrite the two docstrings (the `is_promoter_managed` one currently documents the legacy-default caveat — now stale).
+- [ ] **Step 2:** `pytest tests/test_models.py -q` → note failures (fixed in Task 6).
+- [ ] **Step 3: Commit** `refactor(ST-4159): remove cloud_multi_stage strategy and UpdatePlan.multi_stage`
+
+### Task 3: `plan_builder.py` — one production path: promoter-managed, always
+
+**Files:**
+- Modify: `helm_image_updater/plan_builder.py`
+
+**Interfaces:**
+- Consumes: Task 1's `EnvironmentConfig` (no knob fields).
+- Produces: `_is_promoter_managed_standard(config, plan)` keyed on enum only; `_group_changes_for_prs` with NO multi_stage branch and NO automerge grouping; `_create_pr_plan` without `multi_stage_*` pr_types.
+
+- [ ] **Step 1:** Replace `_is_promoter_managed_standard` (l.33-44) body/docstring:
+
+```python
+def _is_promoter_managed_standard(config: EnvironmentConfig, plan: UpdatePlan) -> bool:
+    """True iff this run is the promoter-managed `standard` 2-wave release (ST-4126):
+    DEPLOY_STRATEGY resolves to standard -- which since ST-4159 includes the EMPTY
+    default -- AND a PRODUCTION deploy. ONLY production is staged: DEV, CANARY and
+    OVERRIDE are orthogonal UpdateStrategy axes that keep their own single-PR handling
+    and are never promoter-managed (a dev push stays a fast auto-merged deploy)."""
+    return (
+        config.deploy_strategy == DeployStrategy.STANDARD
+        and plan.strategy == UpdateStrategy.PRODUCTION
+    )
+```
+
+- [ ] **Step 2:** In `prepare_plan` remove `multi_stage=config.multi_stage,` from the `UpdatePlan(...)` construction (l.90).
+- [ ] **Step 3:** In `_group_changes_for_prs`, delete the whole multi-stage branch (l.500-541) and the legacy tail (l.543-572); replace the tail with:
+
+```python
+    # PRODUCTION is unreachable here by construction (standard 2-wave is the ST-4159
+    # default; wave / manual-per-stack are explicit) -- guard so no future regression
+    # can ever route a production deploy into an auto-mergeable single PR.
+    if plan.strategy == UpdateStrategy.PRODUCTION:
+        raise RuntimeError(
+            "PRODUCTION deploys must be promoter-managed "
+            "(standard/gradual/critical/critical-manual-gate/manual-per-stack); "
+            "the legacy grouping was removed in ST-4159."
+        )
+
+    # DEV / OVERRIDE (and any defensive single-change case): one auto-mergeable PR.
+    return [{
+        'stacks': [sc['stack'] for sc in stack_changes],
+        'changes': stack_changes,
+        'base_branch': 'main',
+        'pr_type': 'standard'
+    }]
+```
+
+- [ ] **Step 4:** In `_create_pr_plan`: delete the `pr_type.startswith('multi_stage_')` branch-name branch (l.728-732); in the final `else` title branch call:
+
+```python
+        pr_title_prefix = generate_pr_title_prefix(
+            strategy=plan.strategy,
+            target_stacks=pr_group['stacks'],
+        )
+```
+
+  (drop `is_multi_stage`, `user_requested_automerge`, `cloud_provider` args). Also grep the file for any remaining `plan.multi_stage` / `config.automerge` / `cloud_provider` and delete leftovers (l.776-777 are inside this call; `cloud_provider` local at l.726 becomes unused — remove).
+- [ ] **Step 5:** `grep -n 'multi_stage\|automerge\|cloud_multi' helm_image_updater/plan_builder.py` → expect ONLY the `_should_auto_merge` docstring mentions (fine) — no live code refs.
+- [ ] **Step 6: Commit** `refactor(ST-4159): single production path — promoter-managed grouping only`
+
+### Task 4: `message_generation.py` — simplify PR title prefix
+
+**Files:**
+- Modify: `helm_image_updater/message_generation.py:59-107`
+
+**Interfaces:**
+- Produces: `generate_pr_title_prefix(strategy: UpdateStrategy, target_stacks: List[str]) -> str` → `[canary sync]` | `[test sync]` | `[prod sync]` (multi-stage prefixes gone). Sole caller updated in Task 3.
+
+- [ ] **Step 1:** Replace the function:
+
+```python
+def generate_pr_title_prefix(
+    strategy: UpdateStrategy,
+    target_stacks: List[str],
+) -> str:
+    """[canary sync] for canary; [test sync] when every target stack is a dev stack;
+    [prod sync] otherwise (incl. e2e/override targets, matching historical titles)."""
+    if strategy == UpdateStrategy.CANARY:
+        return "[canary sync]"
+    is_dev_update = bool(target_stacks) and all(
+        classify_stack(stack).is_dev for stack in target_stacks
+    )
+    return "[test sync]" if is_dev_update else "[prod sync]"
+```
+
+- [ ] **Step 2:** Grep `message_generation.py` for other `multi_stage`/`automerge` refs (PR body text at ~l.313 mentions overrides — unrelated, keep) and remove any leftovers.
+- [ ] **Step 3: Commit** `refactor(ST-4159): drop multi-stage PR title prefixes`
+
+### Task 5: delete `UpdateConfig`; clean `cli.py`
+
+**Files:**
+- Modify: `helm_image_updater/config.py` (delete class l.45-58 + docstring ref l.17), `helm_image_updater/cli.py` (delete prints l.43 `Automerge:` and l.45 `Multi-stage deployment:`)
+
+`UpdateConfig` has **zero** source consumers (verified) — tests referencing it get fixed/deleted in Task 6.
+
+- [ ] **Step 1:** Make both edits; `grep -rn 'UpdateConfig' helm_image_updater/` → no hits.
+- [ ] **Step 2: Commit** `refactor(ST-4159): delete dead UpdateConfig; drop legacy CLI prints`
+
+### Task 6: test sweep — delete legacy tests, port the rest, add invariants
+
+**Files:**
+- Modify/Delete tests across: `test_core.py`, `test_cli_functional.py`, `test_deploy_strategy.py`, `test_standard_2wave.py`, `test_plan_builder.py`, `test_wave_grouping.py`, `test_manual_per_stack.py`, `test_models.py`, `test_auto_merge.py`
+- Create: (already) `tests/test_legacy_knobs_removed.py`
+
+Rules for the sweep (run `pytest -q`, fix every failure by exactly one of):
+1. **Delete** tests whose *subject* was removed: cloud_multi_stage grouping/strategy tests, MULTI_STAGE-alias parsing tests, AUTOMERGE parsing tests, `promoter_managed_standard`-flag tests, multi-stage 6-PR grouping tests, legacy "production single combined PR (automerge=true)" / "per-stack PRs (automerge=false)" grouping tests, `UpdateConfig` construction tests, the `@pytest.mark.skip` `test_multi_cloud_multi_stage_automerge_true`, and multi-stage title-prefix tests.
+2. **Port** tests whose subject survives: remove `automerge=`/`multi_stage=`/`promoter_managed_standard=` kwargs from `EnvironmentConfig(...)`/Mock constructions; update `generate_pr_title_prefix` call sites to the 2-arg signature; update `UpdatePlan(...)` constructions dropping `multi_stage=`.
+3. **CLI-output assertions** (codex review): `tests/test_cli_functional.py` asserts the deleted stdout lines (`"Automerge: False"`, `"Multi-stage deployment: True"`, ~l.189) — delete those specific assertions (or the whole test when the print was its only subject); production-run functional tests get re-pointed at the 2-wave outcome per rule 4.
+4. **Repurpose** the legacy happy-path: production tag + EMPTY strategy must now produce the 2-wave promoter release. Add to `test_standard_2wave.py`:
+
+```python
+def test_empty_strategy_production_is_promoter_standard(monkeypatch):
+    """ST-4159: the empty-strategy default IS promoter standard -- a production tag
+    with no DEPLOY_STRATEGY produces the 2-wave dev->prod release, PRs unmerged."""
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "IMAGE_TAG": "production-abc",
+        "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+    })
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    assert _is_promoter_managed_standard(cfg, plan) is True
+```
+
+   and its override counterpart:
+
+```python
+def test_override_stack_never_promoter_standard():
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "IMAGE_TAG": "production-abc",
+        "OVERRIDE_STACK": "kbc-us-east-1",
+        "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+    })
+    plan = Mock()
+    plan.strategy = UpdateStrategy.OVERRIDE  # _determine_strategy: override wins first
+    assert _is_promoter_managed_standard(cfg, plan) is False
+```
+
+- [ ] **Step 1:** Run full suite; apply rules 1-3 file by file; re-run until green.
+- [ ] **Step 2:** Grep tests for stragglers: `grep -rn 'automerge\|multi_stage\|MULTI_STAGE\|AUTOMERGE\|cloud_multi_stage\|UpdateConfig\|promoter_managed' tests/` → remaining hits must be only (a) `test_legacy_knobs_removed.py`, (b) `_should_auto_merge` tests (the function name contains "auto_merge" — fine), (c) the MULTI_STAGE deprecation-warning test.
+- [ ] **Step 3:** Full suite green. Record the count.
+- [ ] **Step 4: Commit** `test(ST-4159): drop legacy deploy-path tests, add promoter-default invariants`
+
+### Task 7: `action.yaml` + README + version 0.23.0
+
+**Files:**
+- Modify: `action.yaml` (delete `automerge:` input l.10-13, `multi-stage:` input l.18-21, and their env-mapping lines `AUTOMERGE:`/`MULTI_STAGE:` in the `runs:` block), `README.md` (rewrite strategy/inputs docs: no automerge/multi-stage/cloud_multi_stage; document "production ⇒ promoter-managed, always; empty strategy = standard; merge decided by tag class + target stacks"), `CLAUDE.md` (drops its `AUTOMERGE`/`MULTI_STAGE` env-var documentation — codex review), `setup.py` (`version="0.22.0"` → `"0.23.0"`).
+
+Note: callers still passing the deleted action inputs get a GH *warning*, not an error; the only live caller at HEAD is kbc-stacks (updated in Task 15) — old pins are unaffected.
+
+- [ ] **Step 1:** Make the three edits; `grep -n 'AUTOMERGE\|MULTI_STAGE\|automerge\|multi-stage\|cloud_multi_stage' action.yaml README.md` → no hits.
+- [ ] **Step 2:** Full suite still green.
+- [ ] **Step 3: Commit** `chore(ST-4159): drop knob inputs from action.yaml, update README, bump to 0.23.0`
+
+### Task 8: push + retitle PR #43
+
+- [ ] Push branch; update PR #43 title to `ST-4169 + ST-4159: tag/stack-based auto-merge + legacy deploy-path removal` and body (Changes += Tasks 1-7; "closes ST-4159" Linear link; release = v0.23.0; keep the do-not-merge gate = E2E). Reply on the PR threads only if new review comments appeared.
+
+---
+
+# Phase 2 — helm-image-updater-testing PR
+
+Branch: `tomaskacur-st-4159-drop-legacy-scenarios` cut from fresh `origin/main`.
+
+### Task 9: drop legacy scenarios
+
+**Files:**
+- Modify: `.github/workflows/test-suite.yaml`
+
+- [ ] **Step 1:** Delete matrix entries: `happy-path` (l.78-105), `multi-stage` (l.107-145), `dont-merge` (l.147-180), `multi-stage-extra-tags` (l.182-226), `multi-stage-one-cloud` (l.345-383). (`non-existent-service` stays; `override-stack` stays as-is — its `[prod sync] … in dev-keboola-gcp-us-east1-e2e` + `merged: true` assertions remain correct under the tag/stack rule.)
+- [ ] **Step 2:** Update the `summary` job's hardcoded list (l.1058-1066) to the new scenario set (all names from Tasks 9-11).
+- [ ] **Step 3 (codex review):** Tighten `run-assertions.js` merge semantics — today `merged: false` passes when *not all* matching PRs are merged, so 1-merged-of-2 slips through; our new unmerged-wave assertions need "NONE merged". In BOTH `pr_created` (l.102-108) and `pr_created_group` (l.181-187) replace the `actualMerged` comparison:
+
+```js
+          if (assertion.merged !== undefined && matchingPrs.length > 0) {
+            const mergedPrs = matchingPrs.filter(pr => pr.merged_at !== null);
+            // merged: true -> ALL matching PRs merged; merged: false -> NONE merged.
+            // (Previously false meant "not all merged", letting a partial merge pass.)
+            mergeMatch = assertion.merged
+              ? mergedPrs.length === matchingPrs.length
+              : mergedPrs.length === 0;
+            mergeDetails = ` Merge status: ${mergedPrs.length}/${matchingPrs.length} merged (expected: ${assertion.merged ? 'all merged' : 'none merged'}).`;
+          }
+```
+
+  (mirror the same change with the `Group`-suffixed variables in `pr_created_group`). Safe for the surviving scenarios: after Task 9 the only `merged:` consumers are this PR's scenarios and `override-stack`/`non-existent-service` (merged:true / count:0).
+- [ ] **Step 4: Commit** `test(ST-4159): drop legacy direct-automerge scenarios; strict none-merged assertion semantics`
+
+### Task 10: rework `override-removal` + `override-removal-with-values` for the 2-wave world
+
+These two keep e2e coverage of the `appManifestsRevision` removal feature, which now ships inside the standard release's **wave 1** (prod) PR. Wave titles are `[dummy-service standard wave N] dummy-service@{image_tag}`. dummy-service spans 3 dev + 6 prod stacks → wave 0 = 3 files, wave 1 = 6 tag.yaml (+1 values.yaml) = 7.
+
+- [ ] **Step 1:** Replace both scenarios' `assertions` (keep `inputs` but they now carry `deploy-strategy: ""` and the `automerge: true` value becomes explicitly-ignored documentation; keep `setup_files` unchanged). New assertions for `override-removal` (same shape for `-with-values`, which additionally keeps its `content_contains` check):
+
+```yaml
+            assertions:
+              - type: "workflow_success"
+                description: "Workflow completes successfully"
+              - type: "pr_created_group"
+                group_name: "waves"
+                count: 2
+                merged: false
+                title_pattern_regex: "\\[dummy-service standard wave [01]\\] dummy-service@{image_tag}"
+                description: "2 unmerged wave PRs (empty strategy = promoter standard)"
+              - type: "pr_created"
+                count: 1
+                merged: false
+                title_pattern_regex: "\\[dummy-service standard wave 1\\] dummy-service@{image_tag}"
+                description: "wave 1 (prod) PR — scope file assertions to it"
+              - type: "files_modified"
+                pattern: "*/dummy-service/*"
+                expected_count: 7
+                description: "wave 1: 6 prod tag.yaml + 1 values.yaml override removal"
+              - type: "yaml_content"
+                files: "*/dummy-service/tag.yaml"
+                path: "image.tag"
+                expected_value: "{image_tag}"
+                description: "prod tag.yaml files carry the new tag"
+              - type: "file_content_check"
+                files: "com-keboola-gcp-europe-west3/dummy-service/values.yaml"
+                check: "override_removed"
+                description: "values.yaml no longer contains argocdApplication.appManifestsRevision"
+```
+
+  (Ordering matters: the scoped `pr_created` runs *after* the group assert so `foundTestPrs` = wave 1 only — `file_content_check` fails on any foundTestPr lacking the file.)
+- [ ] **Step 2 (placement — codex review):** These scenarios leave 2 OPEN wave PRs each, including a `release:wave:0` anchor with a manifest — a live release for dummy-service. Any LATER promoter-drive scenario on the same app would discover it and FIFO-block. Therefore both scenarios go at the **END of the matrix, after every `promoter_drive` scenario** (order: …drives… → `override-removal` → `override-removal-with-values` → `non-existent-service`). `prod-override-unmerged` (label-free) stays early for the noop check. The next suite run's `cleanup.js` closes the leftover PRs + strips labels — no changes needed there.
+- [ ] **Step 3: Commit** `test(ST-4159): override-removal scenarios assert the wave-1 (prod) PR`
+
+### Task 11: add the tag/stack-rule scenarios
+
+**Files:**
+- Modify: `.github/workflows/test-suite.yaml` (matrix)
+
+- [ ] **Step 1:** Add FOUR scenarios (full YAML; `automerge`/`multi-stage` inputs deliberately set to values HIU must ignore):
+
+```yaml
+          - name: "default-standard-rollout"
+            description: "EMPTY deploy-strategy = promoter standard (ST-4159): production tag + extra tag, automerge=true IGNORED -> 2 unmerged wave PRs; promoter merges dev -> sync -> prod -> complete"
+            promoter_drive: true
+            promoter_drive_standard: true
+            promoter_expected_waves: "0,1"
+            promoter_with_uat: "false"
+            inputs:
+              helm-chart: "dummy-service"
+              image-tag-prefix: "production-default-standard"
+              automerge: true
+              multi-stage: false
+              dry-run: false
+              extra-tag1: "agent.tag:{agent_tag}"
+              extra-tag2: ""
+              override-stack: ""
+              deploy-strategy: ""
+            assertions:
+              - type: "workflow_success"
+                description: "Workflow completes successfully"
+              - type: "pr_created"
+                count: 2
+                merged: false
+                title_pattern_regex: "\\[dummy-service standard wave [01]\\] dummy-service@{image_tag} agent\\.tag@{agent_tag}"
+                description: "2 unmerged wave PRs carrying image + extra tag (HIU merged nothing)"
+              - type: "files_modified"
+                pattern: "*/dummy-service/tag.yaml"
+                expected_count: 9
+                description: "3 dev (wave 0) + 6 prod (wave 1) tag.yaml"
+              - type: "yaml_content"
+                files: "*/dummy-service/tag.yaml"
+                path: "image.tag"
+                expected_value: "{image_tag}"
+                description: "image.tag updated in both waves"
+              - type: "yaml_content"
+                files: "*/dummy-service/tag.yaml"
+                path: "agent.tag"
+                expected_value: "{agent_tag}"
+                description: "extra tag updated in both waves"
+              # promoter-drive-standard.js then drives dev->prod to promoter:complete
+              # (STRATEGY is hardcoded 'standard' in that harness; empty input is fine).
+
+          - name: "dev-tag-fast-path"
+            description: "dev- tag -> single [test sync] PR to the 3 central dev stacks, auto-merged by HIU (tag/stack rule; no promoter)"
+            inputs:
+              helm-chart: "dummy-service"
+              image-tag-prefix: "dev-fast-path"
+              automerge: false
+              multi-stage: false
+              dry-run: false
+              extra-tag1: ""
+              extra-tag2: ""
+              override-stack: ""
+              deploy-strategy: ""
+            assertions:
+              - type: "workflow_success"
+                description: "Workflow completes successfully"
+              - type: "pr_created"
+                count: 1
+                merged: true
+                title_pattern_regex: "\\[test sync\\] dummy-service@{image_tag}"
+                description: "1 PR auto-merged even with automerge=false input (input is dead)"
+              - type: "files_modified"
+                pattern: "*/dummy-service/tag.yaml"
+                expected_count: 3
+                description: "exactly the 3 dev stacks"
+              - type: "yaml_content"
+                files: "*/dummy-service/tag.yaml"
+                path: "image.tag"
+                expected_value: "{image_tag}"
+                description: "dev tag.yaml files updated"
+
+          - name: "pr-test-override-dev"
+            description: "pr-test-* (INVALID-class) tag + override-stack=dev central -> merged single-stack PR (the connection PR-test flow)"
+            inputs:
+              helm-chart: "dummy-service"
+              image-tag-prefix: "pr-test-7786"
+              automerge: true
+              multi-stage: false
+              dry-run: false
+              extra-tag1: ""
+              extra-tag2: ""
+              override-stack: "dev-keboola-gcp-us-central1"
+              deploy-strategy: ""
+            assertions:
+              - type: "workflow_success"
+                description: "Workflow completes successfully"
+              - type: "pr_created"
+                count: 1
+                merged: true
+                title_pattern_regex: "\\[test sync\\] dummy-service@{image_tag} in dev-keboola-gcp-us-central1"
+                description: "1 merged PR targeting only the override stack"
+              - type: "files_modified"
+                pattern: "*/dummy-service/tag.yaml"
+                expected_count: 1
+                description: "only the override stack's tag.yaml"
+
+          - name: "prod-override-unmerged"
+            description: "production tag + override-stack=<prod stack> -> single PR created UNMERGED (HIU never merges to a production stack); promoter no-op guard runs here (0 releases)"
+            promoter_noop_check: true
+            inputs:
+              helm-chart: "dummy-service"
+              image-tag-prefix: "production-prod-override"
+              automerge: true
+              multi-stage: false
+              dry-run: false
+              extra-tag1: ""
+              extra-tag2: ""
+              override-stack: "kbc-us-east-1"
+              deploy-strategy: ""
+            assertions:
+              - type: "workflow_success"
+                description: "Workflow completes successfully"
+              - type: "pr_created"
+                count: 1
+                merged: false
+                title_pattern_regex: "\\[prod sync\\] dummy-service@{image_tag} in kbc-us-east-1"
+                description: "1 PR, NOT merged despite automerge=true (prod stack in targets)"
+              - type: "files_modified"
+                pattern: "*/dummy-service/tag.yaml"
+                expected_count: 1
+                description: "only kbc-us-east-1 tag.yaml"
+```
+
+- [ ] **Step 2:** Matrix placement/order: `prod-override-unmerged` takes `dont-merge`'s old slot (before any wave-PR-producing scenario — the noop check must observe `0 release(s)` with no open wave anchors); `default-standard-rollout` goes next to `standard-rollout` (it completes its release, so no leftovers); `dev-tag-fast-path`/`pr-test-override-dev` anywhere before the drives; `override-removal`/`-with-values` LAST (Task 10 Step 2 — they leave open wave anchors).
+- [ ] **Step 3:** Note in the matrix comment why canary has no e2e scenario: the testing repo has no `canary-orion` branch (HIU's canary flow switches to it); canary auto-merge is unit-tested (`test_standard_2wave.py` canary cases + `test_auto_merge.py`).
+- [ ] **Step 4: Commit** `test(ST-4159): add tag/stack-rule scenarios (default-standard, dev fast path, pr-test override, prod-override unmerged)`
+
+### Task 12: wrapper + docs
+
+**Files:**
+- Modify: `.github/workflows/update-image-tag.yaml` (testing repo wrapper): keep the `automerge`/`multi-stage` inputs AND keep forwarding `AUTOMERGE`/`MULTI_STAGE` env to HIU — that *is* the back-compat test (HIU must ignore them). Update only the `deploy-strategy` input descriptions (2×, l.46+l.103): `"Release rollout strategy: standard | gradual | critical | critical-manual-gate | manual-per-stack (empty = standard)"`, and reword the knob descriptions to `"DEAD KNOB (ST-4159): forwarded to HIU, which ignores it — kept to prove back-compat"`.
+- Modify: `README.md` + `CLAUDE.md`: replace the scenario lists with the new set; state the promoter-owns-production model; drop multi-stage/automerge descriptions.
+
+- [ ] **Step 1:** Make edits.
+- [ ] **Step 2: Commit** `docs(ST-4159): document promoter-owned production + dead knobs in the harness`
+
+### Task 13: draft PR + release-gate run
+
+- [ ] **Step 1:** Push branch; open **draft** PR (title `ST-4159: drop legacy scenarios, add tag/stack-rule scenarios`, link ST-4159, note it must merge together with helm-image-updater#43 / v0.23.0).
+- [ ] **Step 2:** Dispatch the suite: `gh workflow run test-suite.yaml --repo keboola/helm-image-updater-testing --ref tomaskacur-st-4159-drop-legacy-scenarios -f helm-image-updater-branch=tomaskacur-st-4169-tag-type-automerge` → poll to completion.
+- [ ] **Step 3:** All jobs green = **release gate satisfied**. Fix + re-run otherwise.
+
+---
+
+# Phase 3 — release + kbc-stacks follow-up
+
+### Task 14: release v0.23.0
+
+- [ ] Merge HIU PR #43 (squash per repo convention — check `gh pr list --state merged -L3` for the pattern first); tag `v0.23.0` on the merge commit; merge the testing PR; re-dispatch the suite `main` × `main` as confirmation.
+
+### Task 15: kbc-stacks PR (pin + stop forwarding knobs)
+
+**Files:**
+- Modify: `.github/workflows/update-image-tag.yaml`:
+  1. Pin `keboola/helm-image-updater@v0.20.0` → `@v0.23.0`.
+  2. Delete `automerge:` + `multi-stage:` from the action's `with:` block (the action no longer declares them).
+  3. Delete the `promoter-cloud-multi-stage` label mapping (elif at l.318-319 area) and the `cloud_multi_stage` routing branch; a stray label now falls through to the universal standard default.
+  4. Simplify the routing block: `SHOULD_AUTOMERGE`/`SHOULD_MULTI_STAGE` outputs disappear entirely (nothing consumes them); keep resolving + logging `DEPLOY_STRATEGY` only. The e2e-override branch keeps clearing `DEPLOY_STRATEGY`.
+  5. **Keep the workflow `automerge`/`multi-stage` input declarations** with descriptions updated to `"DEPRECATED, ignored (ST-4159) — kept so existing dispatchers don't 422"`.
+- Modify: `README.md` deploy-strategy section (drop cloud_multi_stage + automerge semantics; production always promoter-managed).
+- Do NOT touch `.github/actions/trigger-image-tag-update/action.yaml` (it dispatches the workflow, whose inputs stay).
+
+- [ ] Draft PR named after ST-4159, from a fresh-fetched `origin/main` branch; template; link issue. **Re-verify the routing block on the fresh origin/main first** — the local worktree copy is stale (still shows `STANDARD_DEFAULT_APPS`); the line anchors above are from `git show origin/main:...` as of 2026-07-13 and kbc-stacks main moves ~100 commits/day (codex review).
+
+### Task 16: post-release verification
+
+- [ ] Watch the first few real deploys after the pin merge (any `production-*` app): expect 2 unmerged wave PRs + promoter merges; an e2e/`pr-test` override deploy: expect fast auto-merge. `gh pr list --repo keboola/kbc-stacks --search "wave in:title" -L 6` + spot-check one app's release to `promoter:complete`. Update the memory file + Linear (close ST-4169 + ST-4159).
+
+---
+
+# Codex review (gpt-5.5) — outcome
+
+Two passes (design pass against code; task-level pass against the plan doc + all three repos): **APPROVE-WITH-CHANGES**, all applied above:
+1. Keep the `_deploy_strategy_error` assignment explicit in Task 1 (invalid-strategy test depends on it).
+2. Test-sweep rule for CLI stdout assertions (`test_cli_functional.py` ~l.189) — added as rule 3.
+3. `merged: false` in run-assertions.js meant "not all merged" — tightened to "none merged" (Task 9 Step 3).
+4. `override-removal` scenarios leave a live open `release:wave:0` anchor → moved to END of matrix so they can't FIFO-block later same-app promoter drives (Task 10 Step 2).
+5. Defensive `PRODUCTION ⇒ raise` guard before the grouping tail (Task 3).
+6. HIU `CLAUDE.md` also documents the dead knobs → added to Task 7; wrapper line anchors corrected (l.46/103); Task 15 re-verify note (stale local kbc-stacks checkout).
+Confirmed correct as planned: empty-strategy pivot (override precedence, e2e-override clearing, wrapper), grouping-tail claim, validate() behavior for cloud_multi_stage/MULTI_STAGE, wave title regexes + file counts (3 / 6+1), foundTestPrs scoping order, noop-check relocation shape, action-input removal (warning-only), SHOULD_AUTOMERGE/SHOULD_MULTI_STAGE outputs have no consumers beyond the HIU `with:` block, release sequencing (prod pinned to v0.20.0 until the kbc-stacks PR).
+
+# Self-review notes / risks
+
+1. **Empty-strategy semantics change is the biggest behavioral pivot**: any *non-kbc-stacks* caller sending a production tag with no strategy now gets 2 unmerged wave PRs instead of a merged single PR. Known callers: kbc-stacks (sends `standard` explicitly — unaffected), the testing harness (updated here), kbc-stacks-playground (test sandbox, pinned to an old tag — unaffected until it bumps).
+2. **`promoter_noop_check` relocation**: `dont-merge` (9 unmerged PRs) → `prod-override-unmerged` (1 unmerged PR). Weaker corpus but same property ("promoter observes 0 releases, merges nothing"); the wave-drive scenarios cover the promoter's positive paths.
+3. **Extra-tags e2e coverage** previously lived in `multi-stage-extra-tags`; it moves into `default-standard-rollout` (extra tag asserted in both wave PRs + driven to complete).
+4. **Order sensitivity in run-assertions.js**: `pr_created` overwrites `foundTestPrs`; Task 10/11 assertions are ordered so file checks bind to the intended PR set.
+5. **`[prod sync]` prefix retained for e2e/override targets** (e2e stacks are not `is_dev`) — existing `override-stack` scenario regex stays valid; historical title format preserved.
+6. Wave-1 file count (7) depends on the 6-prod-stack fixture set; if a stack dir is added later the assertion needs a bump (same maintenance property as the old `expected_count: 9`).
+7. kbc-stacks Task 15 must NOT break the e2e-override dispatch path used by e2e pipelines (inputs preserved; only forwarding removed).

--- a/helm_image_updater/cli.py
+++ b/helm_image_updater/cli.py
@@ -40,10 +40,9 @@ def main():
             print("Extra tags to update:")
             for tag in config.extra_tags:
                 print(f"  - {tag['path']}: {tag['value']}")
-        print(f"Automerge: {config.automerge}")
+        print(f"Deploy strategy: {config.deploy_strategy.value}")
         print(f"Dry run: {config.dry_run}")
-        print(f"Multi-stage deployment: {config.multi_stage}")
-        
+
         # Handle target path change
         if config.target_path != ".":
             print(f"Changing to target directory: {config.target_path}")

--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -1,9 +1,8 @@
 """
 Configuration Module for Helm Image Updater
 
-This module contains configuration settings and data structures used throughout the application.
-It defines constants and configuration classes that control
-the behavior of the image updating process.
+This module contains configuration constants used throughout the application
+that control the behavior of the image updating process.
 
 Constants:
     DEV_STACK_MAPPING: Dictionary mapping cloud providers to development stack names
@@ -12,16 +11,9 @@ Constants:
     IGNORED_FOLDERS: Set of folder names to ignore during processing
     GITHUB_REPO: Name of the GitHub repository (from environment)
     GITHUB_BRANCH: Name of the GitHub branch (from environment)
-
-Classes:
-    UpdateConfig: Configuration class holding settings for update operations
 """
 
-from dataclasses import dataclass
-from typing import List, Optional
 import os
-from git import Repo
-from github.Repository import Repository
 
 # Constants
 DEV_STACK_MAPPING = {
@@ -40,19 +32,3 @@ CANARY_STACKS = {
 IGNORED_FOLDERS = {".venv", "aws", ".git", ".github", "utils", "docs", "apps"}
 GITHUB_REPO = os.getenv("GITHUB_REPOSITORY", "keboola/kbc-stacks")
 GITHUB_BRANCH = "main"
-
-
-@dataclass
-class UpdateConfig:
-    """Configuration class for update operations."""
-
-    repo: Repo
-    github_repo: Repository
-    helm_chart: str
-    image_tag: str
-    automerge: bool
-    dry_run: bool = False
-    multi_stage: bool = False
-    extra_tags: Optional[List[dict]] = None
-    commit_sha: bool = False
-    user_requested_automerge: Optional[bool] = None

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -179,17 +179,19 @@ class EnvironmentConfig:
             if tag_type == TagType.INVALID:
                 errors.append(f"Invalid IMAGE_TAG format: '{self.image_tag}'. Must start with 'dev-', 'production-', 'canary-' or be a valid semver (e.g., 1.2.3)")
         
-        # Check for dev tag on production stack (even with override)
-        if self.override_stack and self.image_tag:
+        # A production override target accepts ONLY production/semver tags. Block any
+        # dev-/canary- tag -- the main image OR an extra tag -- from landing on a prod
+        # stack (ST-4169 closes the gap: previously only a dev MAIN tag was caught, so a
+        # canary tag or a dev extra tag slipped through). Non-production override targets
+        # (incl. e2e, which is EXCLUDED_STACKS) are unrestricted.
+        if self.override_stack:
             import os
             from .stack_classification import classify_stack
-            
-            # Only validate if the stack actually exists on disk
-            if os.path.isdir(self.override_stack):
-                tag_type = detect_tag_type(self.image_tag)
-                stack_classification = classify_stack(self.override_stack)
-                # Check if it's a dev tag being applied to a production stack
-                if tag_type == TagType.DEV and stack_classification.is_production:
+
+            # Only validate if the stack actually exists on disk.
+            if os.path.isdir(self.override_stack) and classify_stack(self.override_stack).is_production:
+                candidate_tags = [self.image_tag] + [t.get("value", "") for t in self.extra_tags]
+                if any(detect_tag_type(v) in (TagType.DEV, TagType.CANARY) for v in candidate_tags if v):
                     errors.append("Cannot apply non-production tag to production stack")
         
         if not self.approve_token:

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -18,18 +18,11 @@ class EnvironmentConfig:
     helm_chart: str
     image_tag: str
     github_token: str
-    automerge: bool = True
     dry_run: bool = False
-    multi_stage: bool = False
+    # Empty DEPLOY_STRATEGY resolves to STANDARD — the universal default (ST-4131/ST-4159):
+    # a PRODUCTION deploy is ALWAYS promoter-managed. There is no legacy fallback and no
+    # AUTOMERGE/MULTI_STAGE knob (auto-merge is decided by tag class + target stacks, ST-4169).
     deploy_strategy: DeployStrategy = DeployStrategy.STANDARD
-    # True for an EXPLICIT DEPLOY_STRATEGY=standard run: the promoter-managed 2-wave
-    # dev→prod path (ST-4126). AUTOMERGE is IGNORED, exactly like the wave strategies. The
-    # legacy default (empty strategy → STANDARD) leaves this False so historical single-PR /
-    # per-stack behaviour is unchanged.
-    promoter_managed_standard: bool = False
-    # True for DEPLOY_STRATEGY=manual-per-stack (ST-4157): one PR per prod stack, no waves.
-    # Always promoter-managed when selected (never a legacy default), AUTOMERGE ignored.
-    promoter_managed_manual_per_stack: bool = False
     _deploy_strategy_error: Optional[str] = field(default=None, init=False, repr=False)
     target_path: str = "."
     commit_sha: bool = False
@@ -72,10 +65,12 @@ class EnvironmentConfig:
             except Exception:
                 pass  # Ignore invalid metadata
         
-        # Parse DEPLOY_STRATEGY (default standard). MULTI_STAGE=true is a deprecated
-        # alias for cloud_multi_stage when DEPLOY_STRATEGY is not explicitly set.
+        # Parse DEPLOY_STRATEGY. Empty -> standard, the universal default (ST-4131/ST-4159):
+        # a PRODUCTION deploy is ALWAYS promoter-managed; there is no legacy fallback.
+        # AUTOMERGE is dead (auto-merge is decided by tag class + target stacks, ST-4169)
+        # and MULTI_STAGE/cloud_multi_stage was removed (ST-4159) -- old dispatchers still
+        # send both, so tolerate-and-ignore (warn for MULTI_STAGE so stragglers surface).
         raw_strategy = env.get("DEPLOY_STRATEGY", "").strip().lower()
-        multi_stage_raw = env.get("MULTI_STAGE", "false").lower() == "true"
         deploy_strategy = DeployStrategy.STANDARD
         deploy_strategy_error = None
         if raw_strategy:
@@ -84,44 +79,20 @@ class EnvironmentConfig:
             except ValueError:
                 deploy_strategy_error = (
                     f"Invalid DEPLOY_STRATEGY: '{raw_strategy}'. "
-                    "Must be one of: standard, cloud_multi_stage, gradual, critical, "
+                    "Must be one of: standard, gradual, critical, "
                     "critical-manual-gate, manual-per-stack"
                 )
-            if multi_stage_raw and deploy_strategy != DeployStrategy.CLOUD_MULTI_STAGE:
-                print("WARNING: MULTI_STAGE=true is ignored because DEPLOY_STRATEGY is set explicitly")
-        elif multi_stage_raw:
-            deploy_strategy = DeployStrategy.CLOUD_MULTI_STAGE
-
-        # Keep the legacy `multi_stage` flag in sync so the existing cloud×stage grouping
-        # branch (which keys off plan.multi_stage) fires for DEPLOY_STRATEGY=cloud_multi_stage too.
-        multi_stage = deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
-
-        automerge = env.get("AUTOMERGE", "true").lower() == "true"
-
-        # Promoter-managed `standard` (ST-4126): an EXPLICIT DEPLOY_STRATEGY=standard always
-        # emits the 2-wave dev→prod release — AUTOMERGE is IGNORED, exactly like the wave
-        # strategies (gradual/critical/...). The wave PRs are created unmerged (auto_merge=False
-        # ⇒ HIU auto-approves them) and merged later by release-promoter. `raw_strategy` is the
-        # empty-string default for the action's unset deploy-strategy, so the legacy default
-        # (empty → STANDARD) never trips this — it stays the historical single-PR / per-stack flow.
-        promoter_managed_standard = (
-            raw_strategy == "standard"
-            and deploy_strategy == DeployStrategy.STANDARD
-        )
-
-        # manual-per-stack (ST-4157) is ALWAYS promoter-managed when selected (no legacy
-        # default — it is never the empty-string default), so a simple equality is enough.
-        promoter_managed_manual_per_stack = deploy_strategy == DeployStrategy.MANUAL_PER_STACK
+        if env.get("MULTI_STAGE", "false").lower() == "true":
+            print(
+                "WARNING: MULTI_STAGE is deprecated and ignored "
+                "(cloud_multi_stage was removed in ST-4159; production deploys are promoter-managed)"
+            )
 
         config = cls(
             helm_chart=env.get("HELM_CHART", ""),
             image_tag=env.get("IMAGE_TAG", "").strip(),
             github_token=env.get("GH_TOKEN", ""),
-            automerge=automerge,
             dry_run=env.get("DRY_RUN", "false").lower() == "true",
-            multi_stage=multi_stage,
-            promoter_managed_standard=promoter_managed_standard,
-            promoter_managed_manual_per_stack=promoter_managed_manual_per_stack,
             target_path=env.get("TARGET_PATH", "."),
             commit_sha=env.get("COMMIT_PIPELINE_SHA", "false").lower() == "true",
             override_stack=env.get("OVERRIDE_STACK", "").strip(),

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -180,10 +180,14 @@ class EnvironmentConfig:
                 errors.append(f"Invalid IMAGE_TAG format: '{self.image_tag}'. Must start with 'dev-', 'production-', 'canary-' or be a valid semver (e.g., 1.2.3)")
         
         # A production override target accepts ONLY production/semver tags. Block any
-        # dev-/canary- tag -- the main image OR an extra tag -- from landing on a prod
-        # stack (ST-4169 closes the gap: previously only a dev MAIN tag was caught, so a
-        # canary tag or a dev extra tag slipped through). Non-production override targets
-        # (incl. e2e, which is EXCLUDED_STACKS) are unrestricted.
+        # non-production tag -- dev-/canary- OR an unrecognized/`pr-test-*` (INVALID) tag,
+        # via the main image OR an extra tag -- from landing on a prod stack. Tag-format
+        # validation is SKIPPED in override mode, so INVALID tags reach here; keying on
+        # "not production/semver" (rather than a DEV/CANARY allowlist) rejects them too,
+        # matching this comment (ST-4169 closes the gap: previously only a dev MAIN tag was
+        # caught, so canary/dev-extra/pr-test tags slipped through). Non-production override
+        # targets (incl. e2e, which is EXCLUDED_STACKS) are unrestricted -- the pr-test-*/dev
+        # -> e2e test-deploy flow is preserved.
         if self.override_stack:
             import os
             from .stack_classification import classify_stack
@@ -191,7 +195,7 @@ class EnvironmentConfig:
             # Only validate if the stack actually exists on disk.
             if os.path.isdir(self.override_stack) and classify_stack(self.override_stack).is_production:
                 candidate_tags = [self.image_tag] + [t.get("value", "") for t in self.extra_tags]
-                if any(detect_tag_type(v) in (TagType.DEV, TagType.CANARY) for v in candidate_tags if v):
+                if any(detect_tag_type(v) not in (TagType.PRODUCTION, TagType.SEMVER) for v in candidate_tags if v):
                     errors.append("Cannot apply non-production tag to production stack")
         
         if not self.approve_token:

--- a/helm_image_updater/message_generation.py
+++ b/helm_image_updater/message_generation.py
@@ -58,53 +58,26 @@ def generate_commit_message(
 
 def generate_pr_title_prefix(
     strategy: UpdateStrategy,
-    is_multi_stage: bool,
-    user_requested_automerge: bool,
     target_stacks: List[str],
-    cloud_provider: Optional[str] = None
 ) -> str:
-    """
-    Generate the PR title prefix based on the update context.
-    
-    Pure function that determines PR title prefix.
-    
+    """PR title prefix: `[canary sync]` for canary; `[test sync]` when every target
+    stack is a dev stack; `[prod sync]` otherwise (incl. e2e/override targets, matching
+    the historical titles). Pure function.
+
     Args:
         strategy: The update strategy being used
-        is_multi_stage: Whether this is a multi-stage deployment
-        user_requested_automerge: Original user automerge preference
         target_stacks: List of stacks being updated
-        cloud_provider: Cloud provider for multi-cloud deployment (aws, azure, gcp)
-        
+
     Returns:
         PR title prefix string
     """
-    # Canary updates always use canary sync
     if strategy == UpdateStrategy.CANARY:
         return "[canary sync]"
-    
-    # Determine if this is a dev or production update
-    is_dev_update = False
-    if target_stacks:
-        classifications = [classify_stack(stack) for stack in target_stacks]
-        is_dev_update = all(c.is_dev for c in classifications)
-    
-    # Multi-stage mode has special prefixes
-    if is_multi_stage:
-        # Build cloud suffix
-        cloud_suffix = f" {cloud_provider}" if cloud_provider else ""
-        
-        if is_dev_update:
-            merge_suffix = "" if user_requested_automerge else " manual"
-            return f"[multi-stage] [test sync{cloud_suffix}{merge_suffix}]"
-        else:
-            # Production PRs never auto-merge in multi-stage, so no "manual" needed for requested automerge
-            return f"[multi-stage] [prod sync{cloud_suffix}]"
-    
-    # Regular mode
-    if is_dev_update:
-        return "[test sync]"
-    else:
-        return "[prod sync]"
+
+    is_dev_update = bool(target_stacks) and all(
+        classify_stack(stack).is_dev for stack in target_stacks
+    )
+    return "[test sync]" if is_dev_update else "[prod sync]"
 
 
 def build_tag_string(

--- a/helm_image_updater/models.py
+++ b/helm_image_updater/models.py
@@ -18,7 +18,6 @@ class DeployStrategy(Enum):
     """Deploy strategy (the DEPLOY_STRATEGY knob). Values double as the `deploy:*`
     label value for promoter-managed (wave) strategies."""
     STANDARD = "standard"
-    CLOUD_MULTI_STAGE = "cloud_multi_stage"
     GRADUAL = "gradual"
     CRITICAL = "critical"
     CRITICAL_MANUAL_GATE = "critical-manual-gate"
@@ -39,17 +38,16 @@ class DeployStrategy(Enum):
 
     @property
     def is_promoter_managed(self) -> bool:
-        """Strategy-level CAPABILITY: strategies that *can* be promoter-managed (PRs
-        created unmerged, labelled, carrying a manifest). Superset of `is_wave`: also
-        includes STANDARD (ST-4126, 2-wave dev→prod) and MANUAL_PER_STACK (ST-4157,
-        one PR per stack).
+        """Strategy-level CAPABILITY: EVERY strategy is promoter-capable (ST-4159 removed
+        the only non-promoter strategy, cloud_multi_stage). PRs are created unmerged,
+        labelled, carrying a manifest. Superset of `is_wave` (adds STANDARD 2-wave dev→prod
+        and MANUAL_PER_STACK one-PR-per-stack).
 
         NOTE: this is about the STRATEGY, not a given run. Whether a specific run is
-        actually promoter-managed depends on more than the strategy — for STANDARD it
-        also needs `EnvironmentConfig.promoter_managed_standard` (an explicit
-        DEPLOY_STRATEGY=standard) AND a PRODUCTION/DEV deploy. Do NOT use this predicate
-        as the run-time gate: it is True for STANDARD even for a legacy default single-PR
-        deploy. The run-time condition lives in `plan_builder._is_promoter_managed_standard`."""
+        actually promoter-managed is gated at the PLAN level, not the strategy level: only
+        a PRODUCTION deploy is staged — DEV/CANARY/OVERRIDE runs keep their own single-PR
+        auto-merged handling. The run-time condition lives in
+        `plan_builder._is_promoter_managed_standard` / `_is_promoter_managed_manual_per_stack`."""
         return self.is_wave or self in (DeployStrategy.STANDARD, DeployStrategy.MANUAL_PER_STACK)
 
 
@@ -107,7 +105,6 @@ class UpdatePlan:
     
     # Metadata
     dry_run: bool = False
-    multi_stage: bool = False
     override_stack: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
     manifest_context: Optional[Dict[str, Any]] = None  # {app, instance_id, display_name, source_sha, source_pr}; wave mode only

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -26,20 +26,19 @@ from .message_generation import (
     wave_release_search_link,
     manual_release_search_link,
 )
-from .config import CANARY_STACKS, IGNORED_FOLDERS, DEV_STACK_MAPPING, GITHUB_REPO
-from .cloud_detection import get_stack_cloud_provider
+from .config import CANARY_STACKS, IGNORED_FOLDERS, GITHUB_REPO
 
 
 def _is_promoter_managed_standard(config: EnvironmentConfig, plan: UpdatePlan) -> bool:
-    """True iff this run is a promoter-managed `standard` 2-wave release (ST-4126):
-    an explicit DEPLOY_STRATEGY=standard (`config.promoter_managed_standard`, AUTOMERGE
-    ignored) AND a `PRODUCTION` deploy. ONLY production is staged — a `dev-*` tag (DEV),
-    CANARY, and OVERRIDE are orthogonal UpdateStrategy axes that keep their own handling
-    and are NEVER promoter-managed (a dev push must stay a fast auto-merged deploy, not an
-    unmerged wave PR the promoter has to merge — Halama review). Keeping this gate in ONE
-    place stops the grouping and the manifest/idempotency-guard wiring from diverging."""
+    """True iff this run is the promoter-managed `standard` 2-wave release (ST-4126):
+    DEPLOY_STRATEGY resolves to standard -- which since ST-4159 includes the EMPTY
+    default -- AND a `PRODUCTION` deploy. ONLY production is staged: a `dev-*` tag (DEV),
+    CANARY, and OVERRIDE are orthogonal UpdateStrategy axes that keep their own single-PR
+    handling and are NEVER promoter-managed (a dev push must stay a fast auto-merged
+    deploy, not an unmerged wave PR the promoter has to merge -- Halama review). Keeping
+    this gate in ONE place stops the grouping and the manifest/guard wiring from diverging."""
     return (
-        getattr(config, "promoter_managed_standard", False)
+        config.deploy_strategy == DeployStrategy.STANDARD
         and plan.strategy == UpdateStrategy.PRODUCTION
     )
 
@@ -87,7 +86,6 @@ def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
         image_tag=config.image_tag,
         extra_tags=config.extra_tags,
         dry_run=config.dry_run,
-        multi_stage=config.multi_stage,
         override_stack=config.override_stack,
         metadata=config.metadata,
     )
@@ -497,79 +495,23 @@ def _group_changes_for_prs(
             'pr_type': 'canary'
         }]
     
-    if plan.multi_stage and plan.strategy == UpdateStrategy.PRODUCTION:
-        print("🔄 Multi-stage deployment detected - grouping by cloud and dev/prod")
-        # Multi-cloud multi-stage: group by (dev/prod) × (aws/azure/gcp)
-        # Creates up to 6 PRs (3 dev + 3 prod)
-        cloud_groups = {
-            "aws": {"dev": [], "prod": []}, 
-            "azure": {"dev": [], "prod": []}, 
-            "gcp": {"dev": [], "prod": []}
-        }
-        
-        # Group changes by cloud and dev/prod
-        print(f"📋 Analyzing {len(stack_changes)} stack changes:")
-        for sc in stack_changes:
-            stack = sc['stack']
-            cloud = get_stack_cloud_provider(stack, io_layer)
-            is_dev = stack in DEV_STACK_MAPPING.values()
-            
-            category = 'dev' if is_dev else 'prod'
-            cloud_groups[cloud][category].append(sc)
-            print(f"  - {stack} → {cloud} {category}")
-        
-        # Create PR plans for each non-empty (cloud, category) combination
-        # Production PRs first, then dev PRs to prevent race condition
-        groups = []
-        print("\n🎯 Creating PR groups (prod first, then dev):")
-        for category in ["prod", "dev"]:
-            for cloud in ["aws", "azure", "gcp"]:
-                changes = cloud_groups[cloud][category]
-                if changes:  # Only create PR if there are changes
-                    stacks = [sc['stack'] for sc in changes]
-                    pr_type = f'multi_stage_{category}'
-                    print(f"  - {cloud} {category}: {len(changes)} changes in stacks {stacks} (pr_type: {pr_type})")
-                    groups.append({
-                        'stacks': stacks,
-                        'changes': changes,
-                        'base_branch': 'main',
-                        'pr_type': pr_type,
-                        'cloud_provider': cloud
-                    })
-        
-        print(f"📊 Total PR groups created: {len(groups)}")
-        return groups
-    
-    # Default: one PR per stack or all in one
-    if len(stack_changes) == 1 or plan.strategy in (UpdateStrategy.DEV, UpdateStrategy.OVERRIDE):
-        # Single stack or dev or override: one PR
-        return [{
-            'stacks': [sc['stack'] for sc in stack_changes],
-            'changes': stack_changes,
-            'base_branch': 'main',
-            'pr_type': 'standard'
-        }]
+    # PRODUCTION is unreachable here by construction (standard 2-wave is the ST-4159
+    # default; wave / manual-per-stack are explicit) -- guard so no future regression
+    # can ever route a production deploy into an auto-mergeable single PR.
+    if plan.strategy == UpdateStrategy.PRODUCTION:
+        raise RuntimeError(
+            "PRODUCTION deploys must be promoter-managed "
+            "(standard/gradual/critical/critical-manual-gate/manual-per-stack); "
+            "the legacy grouping was removed in ST-4159."
+        )
 
-    # Production without multi-stage: based on automerge
-    if config.automerge:
-        # One PR for all
-        return [{
-            'stacks': [sc['stack'] for sc in stack_changes],
-            'changes': stack_changes,
-            'base_branch': 'main',
-            'pr_type': 'standard'
-        }]
-    else:
-        # One PR per stack
-        return [
-            {
-                'stacks': [sc['stack']],
-                'changes': [sc],
-                'base_branch': 'main',
-                'pr_type': 'standard'
-            }
-            for sc in stack_changes
-        ]
+    # DEV / OVERRIDE (and any defensive single-change case): one auto-mergeable PR.
+    return [{
+        'stacks': [sc['stack'] for sc in stack_changes],
+        'changes': stack_changes,
+        'base_branch': 'main',
+        'pr_type': 'standard'
+    }]
 
 
 def _build_manifest_context(plan: UpdatePlan) -> Dict[str, Any]:
@@ -723,14 +665,8 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
     
     # Create descriptive but short branch name based on PR type
     pr_type = pr_group['pr_type']
-    cloud_provider = pr_group.get('cloud_provider', '')
-    
-    if pr_type.startswith('multi_stage_'):
-        # Multi-stage: dummy-service-prod-sync-gcp-production-tag-abc1
-        stage = pr_type.replace('multi_stage_', '')  # 'dev' or 'prod'
-        cloud_suffix = f"-{cloud_provider}" if cloud_provider else ""
-        branch_name = f"{plan.helm_chart}-{stage}-sync{cloud_suffix}-{plan.image_tag}-{suffix}"
-    elif pr_type == 'canary':
+
+    if pr_type == 'canary':
         # Canary: dummy-service-canary-canary-tag-abc1
         branch_name = f"{plan.helm_chart}-canary-{plan.image_tag}-{suffix}"
     elif pr_type == 'wave':
@@ -773,10 +709,7 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
     else:
         pr_title_prefix = generate_pr_title_prefix(
             strategy=plan.strategy,
-            is_multi_stage=plan.multi_stage,
-            user_requested_automerge=config.automerge,
             target_stacks=pr_group['stacks'],
-            cloud_provider=pr_group.get('cloud_provider')
         )
         pr_title = generate_pr_title(
             pr_title_prefix=pr_title_prefix,

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -821,13 +821,12 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         pr_body += f"\n\n### Release\n[All member PRs of this manual-per-stack release]({search_link})"
 
 
-    # Determine auto-merge
-    auto_merge = _should_auto_merge(plan, pr_group['pr_type'], config.automerge)
-    
+    # Determine auto-merge (ST-4169: by tag class + target stacks, not the automerge flag)
+    auto_merge = _should_auto_merge(plan, pr_group['pr_type'], pr_group['stacks'])
+
     print(f"🔀 Auto-merge decision for {pr_group['pr_type']}:")
     print(f"   - pr_type: {pr_group['pr_type']}")
-    print(f"   - user_requested: {config.automerge}")
-    print(f"   - strategy: {plan.strategy}")
+    print(f"   - stacks: {pr_group['stacks']}")
     print(f"   - decision: {'AUTO-MERGE' if auto_merge else 'MANUAL ONLY'}")
     
     # Get files to commit (tag.yaml + any override values.yaml changes)
@@ -861,28 +860,31 @@ def _get_canary_base_branch(config: EnvironmentConfig) -> str:
     return "main"
 
 
-def _should_auto_merge(plan: UpdatePlan, pr_type: str, user_requested: bool) -> bool:
-    """Determine if a PR should be auto-merged."""
-    print(f"    🧠 Auto-merge logic:")
-    print(f"       - strategy: {plan.strategy}")
-    print(f"       - pr_type: {pr_type}")
-    print(f"       - user_requested: {user_requested}")
-    
-    if pr_type == 'wave':
-        print(f"       - result: FALSE (wave PRs are merged by release-promoter)")
+def _should_auto_merge(plan: UpdatePlan, pr_type: str, stacks: List[str]) -> bool:
+    """Auto-merge a non-production deploy that targets only non-production stacks (ST-4169).
+
+    release-promoter owns wave + manual-per-stack PRs. A production-class image
+    (production-/semver, or a mixed deploy carrying one) is promoter-managed and never
+    auto-merged here. Everything else -- dev-/canary- tags AND unrecognized tags such as
+    the `pr-test-*` images used for `override-stack` test deploys -- auto-merges, provided
+    no stack in the PR is production.
+
+    The stack check is defense-in-depth: validate() rejects a dev/canary tag on a prod
+    stack, but if one ever slips through we still must not auto-merge it. `not is_production`
+    covers dev + e2e + canary and fails safe for a new/unknown stack name.
+    """
+    if pr_type in ('wave', 'manual'):
+        print(f"    🧠 Auto-merge: FALSE (pr_type={pr_type}; release-promoter / human merges)")
         return False
 
-    if pr_type == 'manual':
-        print(f"       - result: FALSE (manual-per-stack members are merged by a human)")
+    if _effective_tag_type(plan) == TagType.PRODUCTION:
+        print(f"    🧠 Auto-merge: FALSE (production-class image; promoter-managed)")
         return False
 
-    if plan.strategy == UpdateStrategy.CANARY:
-        print(f"       - result: TRUE (canary always auto-merges)")
-        return True  # Always auto-merge canary
+    prod_stacks = [s for s in stacks if classify_stack(s).is_production]
+    if prod_stacks:
+        print(f"    🧠 Auto-merge: FALSE (PR touches production stack(s): {prod_stacks})")
+        return False
 
-    if pr_type == 'multi_stage_prod':
-        print(f"       - result: FALSE (multi-stage prod never auto-merges)")
-        return False  # Never auto-merge multi-stage production
-    
-    print(f"       - result: {user_requested} (using user preference)")
-    return user_requested
+    print(f"    🧠 Auto-merge: TRUE (non-production deploy to non-production stacks: {stacks})")
+    return True

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -186,6 +186,27 @@ def _determine_strategy(config: EnvironmentConfig) -> UpdateStrategy:
     return UpdateStrategy.DEV  # Default
 
 
+def _effective_tag_type(plan: UpdatePlan) -> TagType:
+    """Most-cautious tag class across image_tag + extra tags (ST-4169).
+
+    PRODUCTION/SEMVER dominate CANARY/DEV, so a mixed deploy (e.g. a dev image tag
+    plus a production extra tag) is treated as production and is NOT auto-merged.
+    SEMVER collapses into PRODUCTION (a semver tag is a production release).
+    Returns INVALID when no usable tag is present (e.g. a `pr-test-*` override
+    build) -- which is non-production-class and so eligible to auto-merge onto a
+    non-prod stack.
+    """
+    values = [plan.image_tag] + [t.get("value", "") for t in (plan.extra_tags or [])]
+    types = [detect_tag_type(v) for v in values if v and v.strip()]
+    if any(t in (TagType.PRODUCTION, TagType.SEMVER) for t in types):
+        return TagType.PRODUCTION
+    if any(t == TagType.CANARY for t in types):
+        return TagType.CANARY
+    if any(t == TagType.DEV for t in types):
+        return TagType.DEV
+    return TagType.INVALID
+
+
 def _discover_stacks(io_layer: IOLayer) -> List[str]:
     """Discover all available stacks."""
     stacks = []

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -473,11 +473,11 @@ def _group_changes_for_prs(
         return _group_changes_by_wave(stack_changes, plan, config, io_layer)
 
     # Promoter-managed `standard`: 2-wave dev→prod release (ST-4126). See
-    # `_is_promoter_managed_standard` — an explicit DEPLOY_STRATEGY=standard for a full
-    # PRODUCTION/DEV deploy (AUTOMERGE ignored). CANARY and OVERRIDE are orthogonal
-    # UpdateStrategy axes and MUST keep their own handling below (the same predicate gates
-    # the manifest/guard wiring in prepare_plan, so the two can't diverge). The legacy
-    # default standard (empty strategy) falls through to the historical grouping below.
+    # `_is_promoter_managed_standard` — DEPLOY_STRATEGY=standard (the ST-4159 universal
+    # default, so this covers the EMPTY strategy too) on a PRODUCTION deploy. CANARY and
+    # OVERRIDE are orthogonal UpdateStrategy axes and keep their own handling below (the
+    # same predicate gates the manifest/guard wiring in prepare_plan, so the two can't
+    # diverge); a DEV tag also falls through to the single-PR tail (never staged).
     if _is_promoter_managed_standard(config, plan):
         return _group_changes_standard_2wave(stack_changes, plan, config, io_layer)
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.22.0",
+    version="0.23.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -1,6 +1,6 @@
 """Tests for the tag-type / stack-based auto-merge decision (ST-4169)."""
 
-from helm_image_updater.plan_builder import _effective_tag_type
+from helm_image_updater.plan_builder import _effective_tag_type, _should_auto_merge
 from helm_image_updater.models import UpdatePlan, UpdateStrategy
 from helm_image_updater.tag_classification import TagType
 
@@ -39,3 +39,60 @@ def test_effective_tag_type_pr_test_is_invalid():
     # unrecognized tags (pr-test-*) are not production-class -> eligible to auto-merge
     # on a non-prod stack via the override flow.
     assert _effective_tag_type(_plan("pr-test-7786-deadbeef")) == TagType.INVALID
+
+
+# --- Task 2: _should_auto_merge (non-production deploy -> non-prod stacks only) ---
+
+DEV = ["dev-keboola-gcp-us-central1"]      # is_dev
+E2E = ["dev-keboola-gcp-us-east1-e2e"]     # is_excluded (e2e)
+PROD = ["cloud-keboola-acme"]              # unknown name -> is_production
+
+
+def test_dev_tag_dev_stack_auto_merges():
+    assert _should_auto_merge(_plan("dev-abc"), "standard", DEV) is True
+
+
+def test_canary_auto_merges():
+    assert _should_auto_merge(_plan("canary-orion-abc"), "canary",
+                              ["dev-keboola-canary-orion"]) is True
+
+
+def test_production_does_not_auto_merge():
+    assert _should_auto_merge(_plan("production-abc"), "standard", PROD) is False
+
+
+def test_semver_does_not_auto_merge():
+    assert _should_auto_merge(_plan("1.2.3"), "standard", PROD) is False
+
+
+def test_wave_and_manual_never_auto_merge():
+    assert _should_auto_merge(_plan("dev-abc"), "wave", DEV) is False
+    assert _should_auto_merge(_plan("dev-abc"), "manual", DEV) is False
+
+
+def test_dev_tag_on_prod_stack_does_not_auto_merge():
+    # Defense-in-depth: validate() should reject this run, but if a dev tag ever
+    # reaches a production stack, never auto-merge it.
+    assert _should_auto_merge(_plan("dev-abc"), "standard", PROD) is False
+
+
+def test_override_dev_to_e2e_auto_merges():
+    p = _plan("dev-abc"); p.strategy = UpdateStrategy.OVERRIDE
+    assert _should_auto_merge(p, "standard", E2E) is True
+
+
+def test_override_production_does_not_auto_merge():
+    p = _plan("production-abc"); p.strategy = UpdateStrategy.OVERRIDE
+    assert _should_auto_merge(p, "standard", PROD) is False
+
+
+def test_override_pr_test_tag_to_dev_auto_merges():
+    # connection PR-test deploy: an unrecognized `pr-test-*` image on a dev stack via
+    # override-stack must still auto-merge (regression guard for ST-4169).
+    p = _plan("pr-test-7786-deadbeef"); p.strategy = UpdateStrategy.OVERRIDE
+    assert _should_auto_merge(p, "standard", DEV) is True
+
+
+def test_semver_on_dev_stack_does_not_auto_merge():
+    # production-class (semver) image is never auto-merged, even onto a dev stack.
+    assert _should_auto_merge(_plan("1.2.3"), "standard", DEV) is False

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -1,0 +1,41 @@
+"""Tests for the tag-type / stack-based auto-merge decision (ST-4169)."""
+
+from helm_image_updater.plan_builder import _effective_tag_type
+from helm_image_updater.models import UpdatePlan, UpdateStrategy
+from helm_image_updater.tag_classification import TagType
+
+
+def _plan(image_tag="", extra=None):
+    return UpdatePlan(
+        strategy=UpdateStrategy.DEV,
+        helm_chart="x",
+        image_tag=image_tag,
+        extra_tags=extra or [],
+    )
+
+
+# --- Task 1: _effective_tag_type (most-cautious tag class) ---
+
+def test_effective_tag_type_dev():
+    assert _effective_tag_type(_plan("dev-abc")) == TagType.DEV
+
+
+def test_effective_tag_type_canary():
+    assert _effective_tag_type(_plan("canary-orion-abc")) == TagType.CANARY
+
+
+def test_effective_tag_type_mixed_dev_image_prod_extra_is_production():
+    # most-cautious: a production extra tag dominates a dev image tag
+    p = _plan("dev-abc", [{"path": "x.tag", "value": "production-def"}])
+    assert _effective_tag_type(p) == TagType.PRODUCTION
+
+
+def test_effective_tag_type_semver_is_production_class():
+    # semver collapses to PRODUCTION (most-cautious) -- it is a production release.
+    assert _effective_tag_type(_plan("1.2.3")) == TagType.PRODUCTION
+
+
+def test_effective_tag_type_pr_test_is_invalid():
+    # unrecognized tags (pr-test-*) are not production-class -> eligible to auto-merge
+    # on a non-prod stack via the override flow.
+    assert _effective_tag_type(_plan("pr-test-7786-deadbeef")) == TagType.INVALID

--- a/tests/test_cli_functional.py
+++ b/tests/test_cli_functional.py
@@ -705,6 +705,7 @@ def test_nonexistent_stack_override(cli_test_env, capsys):
     assert len(created_prs) == 0
 
 
+@pytest.mark.skip(reason="ST-4169: cloud_multi_stage dev PRs no longer auto-merge (a production-class image is promoter-managed). The cloud_multi_stage strategy + this test are removed in ST-4159.")
 def test_multi_cloud_multi_stage_automerge_true(cli_test_env, capsys):
     """Test multi-cloud multi-stage deployment with automerge=true.
 
@@ -1102,9 +1103,10 @@ def test_happy_path_production_update(cli_test_env, mock_git_operations, capsys)
     assert mock_git_operations['commit'].called, "git commit should be called"
     assert mock_git_operations['create_pull_request'].called, "create PR should be called"
 
-    # Verify our tracking shows PR was created with automerge enabled
+    # ST-4169: a production-class image is promoter-managed, so HIU creates the PR but
+    # does NOT auto-merge it (it was auto-merged under the legacy automerge flag).
     assert len(created_prs) == 1
-    assert created_prs[0]["automerge"] is True
+    assert created_prs[0]["automerge"] is False
     assert "test-chart" in created_prs[0]["title"]
 
 

--- a/tests/test_cli_functional.py
+++ b/tests/test_cli_functional.py
@@ -176,7 +176,7 @@ def test_cli_environment_variables(cli_test_env, capsys):
     # Set environment variables
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
-    os.environ["AUTOMERGE"] = "false"
+    os.environ["AUTOMERGE"] = "false"  # dead knob (ST-4159) — set to prove HIU ignores it
     os.environ["DRY_RUN"] = "true"
 
     # Run CLI
@@ -186,7 +186,9 @@ def test_cli_environment_variables(cli_test_env, capsys):
     captured = capsys.readouterr()
     assert "Processing Helm chart: test-chart" in captured.out
     assert "New image tag: dev-1.2.3" in captured.out
-    assert "Automerge: False" in captured.out
+    # ST-4159: the CLI prints the resolved deploy strategy (empty -> standard); the
+    # legacy "Automerge:"/"Multi-stage deployment:" lines are gone (AUTOMERGE is ignored).
+    assert "Deploy strategy: standard" in captured.out
     assert "Dry run: True" in captured.out
 
 
@@ -208,7 +210,6 @@ def test_dev_tag_update(cli_test_env, mock_git_operations, capsys):
     # Set environment variables for dev tag update
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "dev-1.2.3"
-    os.environ["AUTOMERGE"] = "true"
 
     # Track PR creation calls
     created_prs = []
@@ -265,73 +266,12 @@ def test_dev_tag_update(cli_test_env, mock_git_operations, capsys):
     assert "test-chart" in created_prs[0]["title"]
 
 
-def test_production_tag_update(cli_test_env, mock_git_operations, capsys):
-    """Test updating all stacks with a production tag.
-
-    This test verifies that:
-    1. All stacks are updated with production tags
-    2. The tag.yaml files are correctly modified
-    3. Console output correctly reports the updates
-    4. Git operations are performed correctly
-    """
-    base_dir, mock_repo, mock_github_repo = cli_test_env
-
-    # Set environment variables for production tag update
-    os.environ["HELM_CHART"] = "test-chart"
-    os.environ["IMAGE_TAG"] = "production-1.2.3"
-    os.environ["AUTOMERGE"] = "true"
-
-    # Track PR creation calls
-    created_prs = []
-
-    def track_pr_creation(*args, **kwargs):
-        """Track GitHub PR creation details."""
-        # Extract arguments (self, title, body, branch_name, base_branch="main", auto_merge=False)
-        if len(args) >= 4:
-            title, body, branch_name = args[1], args[2], args[3]
-            base_branch = args[4] if len(args) > 4 else kwargs.get("base_branch", "main")
-        else:
-            title = kwargs.get("title", "Unknown")
-            body = kwargs.get("body", "")
-            branch_name = kwargs.get("branch_name", "unknown-branch")
-            base_branch = kwargs.get("base_branch", "main")
-        
-        created_prs.append({"branch": branch_name, "title": title, "base": base_branch})
-        print(f"Created PR: {title} (branch: {branch_name}, base: {base_branch})")
-        return "https://github.com/mock-org/mock-repo/pull/123"
-
-    # Customize the PR creation mock to track calls
-    mock_git_operations['create_pull_request'].side_effect = track_pr_creation
-    
-    # Run CLI - files will be written, Git/GitHub operations mocked
-    cli.main()
-
-    # Check console output
-    captured = capsys.readouterr()
-    assert "Processing Helm chart: test-chart" in captured.out
-    assert "Updating all stacks (production- tag)" in captured.out
-    assert "New image tag:" in captured.out
-
-    # Verify tag.yaml was updated in both dev and prod stacks
-    dev_tag_yaml = read_tag_yaml(
-        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
-    )
-    assert dev_tag_yaml["image"]["tag"] == "production-1.2.3"
-
-    prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
-    )
-    assert prod_tag_yaml["image"]["tag"] == "production-1.2.3"
-
-    # Verify Git operations were performed
-    assert mock_git_operations['checkout_branch'].called, "git checkout should be called"
-    assert mock_git_operations['add_files'].called, "git add should be called"
-    assert mock_git_operations['commit'].called, "git commit should be called"
-    assert mock_git_operations['create_pull_request'].called, "create PR should be called"
-
-    # Verify PR was created
-    assert len(created_prs) == 1
-    assert "test-chart" in created_prs[0]["title"]
+# NOTE (ST-4159): the legacy CLI-level production tests (test_production_tag_update,
+# test_happy_path_production_update, test_semver_main_image_tag, and the two
+# test_multi_cloud_multi_stage_* tests) were removed. A production/semver tag is now the
+# promoter-managed `standard` 2-wave release (no single combined PR, no cloud_multi_stage
+# 6-PR grouping); that path is covered by tests/test_standard_2wave.py at the plan level
+# and by the helm-image-updater-testing E2E suite end-to-end. cloud_multi_stage is gone.
 
 
 def test_canary_tag_update(cli_test_env, capsys):
@@ -372,7 +312,6 @@ def test_canary_tag_update(cli_test_env, capsys):
     # Test Case 1: Regular service that exists in multiple environments
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["IMAGE_TAG"] = "canary-orion-1.2.3"
-    os.environ["AUTOMERGE"] = "true"
 
     with patch("helm_image_updater.io_layer.IOLayer.create_branch_commit_and_pr", mock_create_branch_commit_and_pr):
         cli.main()
@@ -423,7 +362,6 @@ def test_canary_tag_update(cli_test_env, capsys):
     os.environ["GH_APPROVE_TOKEN"] = "fake-approve-token"
     os.environ["HELM_CHART"] = "metastore"  # Chart that only exists in canary
     os.environ["IMAGE_TAG"] = "canary-orion-metastore-0.0.5"
-    os.environ["AUTOMERGE"] = "true"
 
     # Create metastore chart only in canary stack (simulating canary-only service)
     metastore_canary_dir = base_dir / "dev-keboola-canary-orion" / "metastore"
@@ -637,12 +575,15 @@ def test_valid_extra_tag_formats(cli_test_env, capsys):
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
 
-    # Run another test with v-prefixed semver
+    # Run another test with a v-prefixed semver EXTRA tag. The main IMAGE_TAG stays dev-
+    # (ST-4159: a production main tag is now the promoter-managed 2-wave path, exercised by
+    # test_standard_2wave.py, not this single-PR CLI smoke) so we still validate that a
+    # v-prefixed semver EXTRA tag value is accepted end-to-end.
     os.environ.clear()
     os.environ["GH_TOKEN"] = "fake-token"
     os.environ["GH_APPROVE_TOKEN"] = "fake-approve-token"
     os.environ["HELM_CHART"] = "test-chart"
-    os.environ["IMAGE_TAG"] = "production-1.2.3"
+    os.environ["IMAGE_TAG"] = "dev-1.2.3"
     os.environ["EXTRA_TAG1"] = "path1:v1.2.3"  # Semver format with v prefix
 
     created_prs.clear()
@@ -658,7 +599,7 @@ def test_valid_extra_tag_formats(cli_test_env, capsys):
     assert "Extra tags to update:" in captured.out
     assert "  - path1: v1.2.3" in captured.out
 
-    # Verify PR was created (production tag should trigger a PR for all stacks)
+    # Verify PR was created (dev tag -> single dev PR; the v-semver extra tag is accepted)
     assert len(created_prs) == 1
     assert "test-chart" in created_prs[0]["title"]
 
@@ -703,192 +644,6 @@ def test_nonexistent_stack_override(cli_test_env, capsys):
 
     # Verify PR was not created
     assert len(created_prs) == 0
-
-
-@pytest.mark.skip(reason="ST-4169: cloud_multi_stage dev PRs no longer auto-merge (a production-class image is promoter-managed). The cloud_multi_stage strategy + this test are removed in ST-4159.")
-def test_multi_cloud_multi_stage_automerge_true(cli_test_env, capsys):
-    """Test multi-cloud multi-stage deployment with automerge=true.
-
-    This test verifies that:
-    1. With multi-stage=true and automerge=true
-    2. For production tags, it creates 6 PRs:
-       - 3 Dev PRs with [multi-stage] [test sync {cloud}] that have automerge=true
-       - 3 Prod PRs with [multi-stage] [prod sync {cloud}] that have automerge=false
-    3. Each cloud (aws, azure, gcp) gets both dev and prod PRs
-    4. The automerge setting for dev stacks is true, prod stacks is false
-    """
-    base_dir, mock_repo, mock_github_repo = cli_test_env
-
-    # Set environment variables for multi-cloud multi-stage deployment
-    os.environ["HELM_CHART"] = "test-chart"
-    os.environ["IMAGE_TAG"] = "production-1.2.3"
-    os.environ["MULTI_STAGE"] = "true"
-    os.environ["AUTOMERGE"] = "true"
-
-    # Track PRs with their automerge setting
-    created_prs = []
-
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
-        created_prs.append(
-            {
-                "branch": branch_name,
-                "title": pr_title,
-                "base": base_branch,
-                "automerge": auto_merge,
-            }
-        )
-        print(
-            f"Created PR: {pr_title} (branch: {branch_name}, base: {base_branch}, automerge: {auto_merge})"
-        )
-
-    # Mock create_pr but use real config to capture automerge setting
-    with patch("helm_image_updater.io_layer.IOLayer.create_branch_commit_and_pr", mock_create_branch_commit_and_pr):
-        # Run CLI
-        cli.main()
-
-    # Check console output
-    captured = capsys.readouterr()
-    assert "Multi-stage deployment: True" in captured.out
-    assert "Automerge: True" in captured.out
-
-    # Verify 6 PRs were created (3 dev + 3 prod)
-    assert len(created_prs) == 6, f"Should create exactly 6 PRs, got {len(created_prs)}"
-
-    # Debug: Print all PR titles for inspection
-    print("DEBUG: All PR titles:")
-    for pr in created_prs:
-        print(f"  - '{pr['title']}' (automerge: {pr['automerge']})")
-
-    # Find dev and prod PRs by cloud
-    dev_prs = {}
-    prod_prs = {}
-    
-    for pr in created_prs:
-        if "[multi-stage] [test sync" in pr["title"]:
-            # Extract cloud from title like "[multi-stage] [test sync aws]"
-            for cloud in ["aws", "azure", "gcp"]:
-                if f"[test sync {cloud}]" in pr["title"]:
-                    dev_prs[cloud] = pr
-                    break
-        elif "[multi-stage] [prod sync" in pr["title"]:
-            # Extract cloud from title like "[multi-stage] [prod sync aws]"
-            for cloud in ["aws", "azure", "gcp"]:
-                if f"[prod sync {cloud}]" in pr["title"]:
-                    prod_prs[cloud] = pr
-                    break
-
-    # Verify all cloud PRs exist
-    expected_clouds = ["aws", "azure", "gcp"]
-    for cloud in expected_clouds:
-        assert cloud in dev_prs, f"Should create dev PR for {cloud}"
-        assert cloud in prod_prs, f"Should create prod PR for {cloud}"
-
-    # Verify automerge settings for all clouds
-    for cloud in expected_clouds:
-        assert dev_prs[cloud]["automerge"] is True, f"Dev {cloud} PR should have automerge=True"
-        assert prod_prs[cloud]["automerge"] is False, f"Prod {cloud} PR should have automerge=False"
-
-    # Verify PR title patterns
-    for cloud in expected_clouds:
-        assert dev_prs[cloud]["title"].startswith(f"[multi-stage] [test sync {cloud}]"), (
-            f"Dev {cloud} PR should start with [multi-stage] [test sync {cloud}]"
-        )
-        assert prod_prs[cloud]["title"].startswith(f"[multi-stage] [prod sync {cloud}]"), (
-            f"Prod {cloud} PR should start with [multi-stage] [prod sync {cloud}]"
-        )
-
-
-def test_multi_cloud_multi_stage_automerge_false(cli_test_env, capsys):
-    """Test multi-cloud multi-stage deployment with automerge=false.
-
-    This test verifies that:
-    1. With multi-stage=true and automerge=false
-    2. For production tags, it creates 6 PRs:
-       - 3 Dev PRs with [multi-stage] [test sync {cloud} manual] that respect automerge=false
-       - 3 Prod PRs with [multi-stage] [prod sync {cloud}] that are NOT auto-merged
-    3. Each cloud (aws, azure, gcp) gets both dev and prod PRs
-    4. All PRs have automerge=false due to user preference and multi-stage prod rule
-    """
-    base_dir, mock_repo, mock_github_repo = cli_test_env
-
-    # Set environment variables for multi-cloud multi-stage deployment with automerge=false
-    os.environ["HELM_CHART"] = "test-chart"
-    os.environ["IMAGE_TAG"] = "production-1.2.3"
-    os.environ["MULTI_STAGE"] = "true"
-    os.environ["AUTOMERGE"] = "false"
-
-    # Track PRs with their automerge setting
-    created_prs = []
-
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
-        created_prs.append(
-            {
-                "branch": branch_name,
-                "title": pr_title,
-                "base": base_branch,
-                "automerge": auto_merge,
-            }
-        )
-        print(
-            f"Created PR: {pr_title} (branch: {branch_name}, base: {base_branch}, automerge: {auto_merge})"
-        )
-
-    # Mock create_pr but use real config to capture automerge setting
-    with patch("helm_image_updater.io_layer.IOLayer.create_branch_commit_and_pr", mock_create_branch_commit_and_pr):
-        # Run CLI
-        cli.main()
-
-    # Check console output
-    captured = capsys.readouterr()
-    assert "Multi-stage deployment: True" in captured.out
-    assert "Automerge: False" in captured.out
-
-    # Verify 6 PRs were created (3 dev + 3 prod)
-    assert len(created_prs) == 6, f"Should create exactly 6 PRs, got {len(created_prs)}"
-
-    # Debug: Print all PR titles for inspection
-    print("DEBUG: All PR titles:")
-    for pr in created_prs:
-        print(f"  - '{pr['title']}' (automerge: {pr['automerge']})")
-
-    # Find dev and prod PRs by cloud
-    dev_prs = {}
-    prod_prs = {}
-    
-    for pr in created_prs:
-        if "[multi-stage] [test sync" in pr["title"]:
-            # Extract cloud from title like "[multi-stage] [test sync aws manual]"
-            for cloud in ["aws", "azure", "gcp"]:
-                if f"[test sync {cloud} manual]" in pr["title"]:
-                    dev_prs[cloud] = pr
-                    break
-        elif "[multi-stage] [prod sync" in pr["title"]:
-            # Extract cloud from title like "[multi-stage] [prod sync aws]"
-            for cloud in ["aws", "azure", "gcp"]:
-                if f"[prod sync {cloud}]" in pr["title"]:
-                    prod_prs[cloud] = pr
-                    break
-
-    # Verify all cloud PRs exist
-    expected_clouds = ["aws", "azure", "gcp"]
-    for cloud in expected_clouds:
-        assert cloud in dev_prs, f"Should create dev PR for {cloud}"
-        assert cloud in prod_prs, f"Should create prod PR for {cloud}"
-
-    # Verify automerge settings for all clouds (all should be False)
-    for cloud in expected_clouds:
-        assert dev_prs[cloud]["automerge"] is False, f"Dev {cloud} PR should have automerge=False"
-        assert prod_prs[cloud]["automerge"] is False, f"Prod {cloud} PR should have automerge=False"
-
-    # Verify PR title patterns
-    for cloud in expected_clouds:
-        assert dev_prs[cloud]["title"].startswith(f"[multi-stage] [test sync {cloud} manual]"), (
-            f"Dev {cloud} PR should start with [multi-stage] [test sync {cloud} manual]"
-        )
-        assert prod_prs[cloud]["title"].startswith(f"[multi-stage] [prod sync {cloud}]"), (
-            f"Prod {cloud} PR should start with [multi-stage] [prod sync {cloud}]"
-        )
-
 
 
 def test_dry_run(cli_test_env, capsys):
@@ -1031,169 +786,6 @@ def test_dev_tag_with_production_override_stack(cli_test_env, capsys):
     assert len(created_prs) == 0
 
 
-def test_happy_path_production_update(cli_test_env, mock_git_operations, capsys):
-    """Test the most common happy path - production tag with automerge.
-
-    This test verifies the complete flow for the most common production scenario:
-    1. Production tag is applied to all stacks
-    2. Automerge is enabled (default)
-    3. Dry run is disabled (default)
-    4. Git operations are performed correctly
-    5. PR is created and auto-merged
-    """
-    base_dir, mock_repo, mock_github_repo = cli_test_env
-
-    # Set environment variables for production update
-    os.environ["HELM_CHART"] = "test-chart"
-    os.environ["IMAGE_TAG"] = "production-2.0.0"
-    os.environ["AUTOMERGE"] = "true"  # this is default, but being explicit
-    # DRY_RUN is not set, which defaults to false
-
-    # Track PR creation calls
-    created_prs = []
-
-    def track_pr_creation(*args, **kwargs):
-        """Track GitHub PR creation details."""
-        # Extract arguments (self, title, body, branch_name, base_branch="main", auto_merge=False)
-        if len(args) >= 4:
-            title, body, branch_name = args[1], args[2], args[3]
-            base_branch = args[4] if len(args) > 4 else kwargs.get("base_branch", "main")
-            auto_merge = args[5] if len(args) > 5 else kwargs.get("auto_merge", False)
-        else:
-            title = kwargs.get("title", "Unknown")
-            body = kwargs.get("body", "")
-            branch_name = kwargs.get("branch_name", "unknown-branch")
-            base_branch = kwargs.get("base_branch", "main")
-            auto_merge = kwargs.get("auto_merge", False)
-        
-        created_prs.append({
-            "branch": branch_name,
-            "title": title,
-            "base": base_branch,
-            "automerge": auto_merge,
-        })
-
-        # Simulate the non-dry-run behavior that would occur in create_pr
-        if auto_merge:
-            print(f"Created and auto-merged PR: {title} (branch: {branch_name}, base: {base_branch})")
-        else:
-            print(f"Created PR: {title} (branch: {branch_name}, base: {base_branch})")
-
-        return "https://github.com/mock-org/mock-repo/pull/123"
-
-    # Customize the PR creation mock to track calls
-    mock_git_operations['create_pull_request'].side_effect = track_pr_creation
-    
-    # Run CLI - files will be written, Git/GitHub operations mocked
-    cli.main()
-
-    # Check console output
-    captured = capsys.readouterr()
-    assert "Processing Helm chart: test-chart" in captured.out
-    assert "New image tag: production-2.0.0" in captured.out
-    assert "New image tag:" in captured.out
-
-    # Verify console output shows updates for both dev and prod stacks
-    assert "Updated dev-keboola-gcp-us-central1/test-chart/tag.yaml: image.tag from old-tag to production-2.0.0" in captured.out
-    assert "Updated com-keboola-gcp-prod/test-chart/tag.yaml: image.tag from old-tag to production-2.0.0" in captured.out
-
-    # Verify Git operations were performed
-    assert mock_git_operations['checkout_branch'].called, "git checkout should be called"
-    assert mock_git_operations['add_files'].called, "git add should be called"
-    assert mock_git_operations['commit'].called, "git commit should be called"
-    assert mock_git_operations['create_pull_request'].called, "create PR should be called"
-
-    # ST-4169: a production-class image is promoter-managed, so HIU creates the PR but
-    # does NOT auto-merge it (it was auto-merged under the legacy automerge flag).
-    assert len(created_prs) == 1
-    assert created_prs[0]["automerge"] is False
-    assert "test-chart" in created_prs[0]["title"]
-
-
-def test_semver_main_image_tag(cli_test_env, capsys):
-    """Test that semver formats are accepted for the main IMAGE_TAG.
-
-    This test verifies that:
-    1. IMAGE_TAG can be a semver with or without v prefix (0.1.2 or v0.1.2)
-    2. Semver tags are treated like production tags and update all stacks
-    3. PRs are created with the correct information
-    """
-    base_dir, mock_repo, mock_github_repo = cli_test_env
-
-    # Set environment variables with semver image tag (no v prefix)
-    os.environ["HELM_CHART"] = "test-chart"
-    os.environ["IMAGE_TAG"] = "1.2.3"  # Semver without v prefix
-
-    # Track PRs
-    created_prs = []
-
-    def mock_create_branch_commit_and_pr(self, branch_name, files_to_commit, commit_message, pr_title, pr_body, base_branch="main", auto_merge=False, labels=None):
-        """Mock PR creation to track PR details."""
-        created_prs.append({"branch": branch_name, "title": pr_title, "base": base_branch})
-        print(f"Created PR: {pr_title} (branch: {branch_name}, base: {base_branch})")
-        return "https://github.com/mock-org/mock-repo/pull/123"
-
-    # Mock create_pr but use real config
-    with patch("helm_image_updater.io_layer.IOLayer.create_branch_commit_and_pr", mock_create_branch_commit_and_pr):
-        # Run CLI
-        cli.main()
-
-    # Check console output
-    captured = capsys.readouterr()
-    assert "Processing Helm chart: test-chart" in captured.out
-    assert "New image tag: 1.2.3" in captured.out
-
-    # Verify tag.yaml was updated in both dev and prod stacks (like production tag)
-    dev_tag_yaml = read_tag_yaml(
-        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
-    )
-    assert dev_tag_yaml["image"]["tag"] == "1.2.3"
-
-    prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
-    )
-    assert prod_tag_yaml["image"]["tag"] == "1.2.3"
-
-    # Verify PR was created
-    assert len(created_prs) == 1
-    assert "test-chart" in created_prs[0]["title"]
-
-    # Test with v-prefixed semver
-    os.environ.clear()
-    os.environ["GH_TOKEN"] = "fake-token"
-    os.environ["GH_APPROVE_TOKEN"] = "fake-approve-token"
-    os.environ["HELM_CHART"] = "test-chart"
-    os.environ["IMAGE_TAG"] = "v2.3.4"  # Semver with v prefix
-
-    # Reset mocks and stacks
-    created_prs.clear()
-
-    # Mock create_pr but use real config
-    with patch("helm_image_updater.io_layer.IOLayer.create_branch_commit_and_pr", mock_create_branch_commit_and_pr):
-        # Run CLI
-        cli.main()
-
-    # Check console output
-    captured = capsys.readouterr()
-    assert "Processing Helm chart: test-chart" in captured.out
-    assert "New image tag: v2.3.4" in captured.out
-
-    # Verify tag.yaml was updated in both dev and prod stacks (like production tag)
-    dev_tag_yaml = read_tag_yaml(
-        base_dir / "dev-keboola-gcp-us-central1" / "test-chart" / "tag.yaml"
-    )
-    assert dev_tag_yaml["image"]["tag"] == "v2.3.4"
-
-    prod_tag_yaml = read_tag_yaml(
-        base_dir / "com-keboola-gcp-prod" / "test-chart" / "tag.yaml"
-    )
-    assert prod_tag_yaml["image"]["tag"] == "v2.3.4"
-
-    # Verify PR was created
-    assert len(created_prs) == 1
-    assert "test-chart" in created_prs[0]["title"]
-
-
 def test_canary_tag_in_extra_tag_should_update_canary_stack(cli_test_env, mock_git_operations, capsys):
     """Test that canary tag in EXTRA_TAG properly updates canary stack.
 
@@ -1235,7 +827,6 @@ def test_canary_tag_in_extra_tag_should_update_canary_stack(cli_test_env, mock_g
     # Test scenario: canary tag in EXTRA_TAG1 only (no IMAGE_TAG)
     os.environ["HELM_CHART"] = "test-chart"
     os.environ["EXTRA_TAG1"] = "image.tag:canary-orion-xyz789"  # Canary tag in extra tag
-    os.environ["AUTOMERGE"] = "true"
 
     with patch("helm_image_updater.io_layer.IOLayer.create_branch_commit_and_pr", mock_create_branch_commit_and_pr):
         cli.main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -122,74 +122,17 @@ class TestPRTitleGeneration:
         """Test canary PR title generation."""
         prefix = generate_pr_title_prefix(
             strategy=UpdateStrategy.CANARY,
-            is_multi_stage=False,
-            user_requested_automerge=True,
             target_stacks=["dev-keboola-canary-orion"]
         )
         assert prefix == "[canary sync]"
-        
+
     def test_dev_pr_title(self):
         """Test dev PR title generation."""
         prefix = generate_pr_title_prefix(
             strategy=UpdateStrategy.DEV,
-            is_multi_stage=False,
-            user_requested_automerge=True,
             target_stacks=["dev-keboola-gcp-us-central1"]
         )
         assert prefix == "[test sync]"
-        
-    def test_multi_stage_dev_pr_title(self):
-        """Test multi-stage dev PR title generation."""
-        # With automerge
-        prefix = generate_pr_title_prefix(
-            strategy=UpdateStrategy.DEV,
-            is_multi_stage=True,
-            user_requested_automerge=True,
-            target_stacks=["dev-keboola-gcp-us-central1"]
-        )
-        assert prefix == "[multi-stage] [test sync]"
-        
-        # Without automerge
-        prefix = generate_pr_title_prefix(
-            strategy=UpdateStrategy.DEV,
-            is_multi_stage=True,
-            user_requested_automerge=False,
-            target_stacks=["dev-keboola-gcp-us-central1"]
-        )
-        assert prefix == "[multi-stage] [test sync manual]"
-        
-    def test_multi_cloud_dev_pr_title_with_cloud_provider(self):
-        """Test multi-cloud dev PR title generation with cloud provider."""
-        # With automerge and cloud provider
-        prefix = generate_pr_title_prefix(
-            strategy=UpdateStrategy.DEV,
-            is_multi_stage=True,
-            user_requested_automerge=True,
-            target_stacks=["dev-keboola-gcp-us-central1"],
-            cloud_provider="gcp"
-        )
-        assert prefix == "[multi-stage] [test sync gcp]"
-        
-        # Without automerge and cloud provider
-        prefix = generate_pr_title_prefix(
-            strategy=UpdateStrategy.DEV,
-            is_multi_stage=True,
-            user_requested_automerge=False,
-            target_stacks=["kbc-testing-azure-east-us-2"],
-            cloud_provider="azure"
-        )
-        assert prefix == "[multi-stage] [test sync azure manual]"
-        
-    def test_multi_cloud_prod_pr_title_with_cloud_provider(self):
-        """Test multi-cloud production PR title generation with cloud provider."""
-        prefix = generate_pr_title_prefix(
-            strategy=UpdateStrategy.PRODUCTION,
-            is_multi_stage=True,
-            user_requested_automerge=True,
-            target_stacks=["com-keboola-aws-prod"],
-            cloud_provider="aws"
-        )
-        assert prefix == "[multi-stage] [prod sync aws]"
 
 
 class TestCloudDetection:

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -23,7 +23,6 @@ def test_deploy_strategy_defaults_to_standard():
 def test_deploy_strategy_parses_known_values():
     for raw, expected in [
         ("standard", DeployStrategy.STANDARD),
-        ("cloud_multi_stage", DeployStrategy.CLOUD_MULTI_STAGE),
         ("gradual", DeployStrategy.GRADUAL),
         ("critical", DeployStrategy.CRITICAL),
         ("critical-manual-gate", DeployStrategy.CRITICAL_MANUAL_GATE),
@@ -32,22 +31,10 @@ def test_deploy_strategy_parses_known_values():
         assert cfg.deploy_strategy == expected
 
 
-def test_multi_stage_true_aliases_to_cloud_multi_stage_when_unset():
-    cfg = EnvironmentConfig.from_env(_base_env(MULTI_STAGE="true"))
-    assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
-
-
 def test_unknown_deploy_strategy_does_not_silently_become_standard():
     cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="gradul"))
     # Parsed value stays unset/standard, but an error is recorded for validate() (Task 2).
     assert cfg._deploy_strategy_error is not None
-
-
-def test_cloud_multi_stage_sets_multi_stage_flag():
-    # DEPLOY_STRATEGY=cloud_multi_stage must drive the legacy multi_stage grouping branch.
-    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="cloud_multi_stage"))
-    assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
-    assert cfg.multi_stage is True
 
 
 def test_unknown_deploy_strategy_is_a_validation_error():
@@ -93,13 +80,6 @@ def test_prplan_labels_can_be_set():
         labels=["release:wave:0"],
     )
     assert p.labels == ["release:wave:0"]
-
-
-def test_explicit_standard_overrides_multi_stage_flag():
-    # DEPLOY_STRATEGY=standard wins over MULTI_STAGE=true: multi_stage must be False.
-    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="standard", MULTI_STAGE="true"))
-    assert cfg.deploy_strategy == DeployStrategy.STANDARD
-    assert cfg.multi_stage is False
 
 
 def test_wave_strategy_ok_with_production_extra_tag_only():
@@ -176,38 +156,3 @@ def test_resolve_wave_rejects_non_integer():
         resolve_wave("kbc-us-east-1", {"rollout_wave": True})
 
 
-def test_promoter_managed_standard_requires_explicit_standard_and_automerge_false():
-    # Explicit DEPLOY_STRATEGY=standard + automerge=false → promoter-managed 2-wave.
-    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="standard", AUTOMERGE="false"))
-    assert cfg.promoter_managed_standard is True
-    assert cfg.deploy_strategy == DeployStrategy.STANDARD
-    assert cfg.multi_stage is False
-
-
-def test_promoter_managed_standard_ignores_automerge_for_explicit_standard():
-    # Explicit standard → promoter-managed 2-wave regardless of AUTOMERGE (ST-4126):
-    # AUTOMERGE is ignored, exactly like the wave strategies.
-    for automerge in ("true", "false"):
-        cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="standard", AUTOMERGE=automerge))
-        assert cfg.promoter_managed_standard is True, f"automerge={automerge}"
-
-
-def test_promoter_managed_standard_off_for_default_empty_strategy():
-    # Empty DEPLOY_STRATEGY (the action default) collapses to STANDARD but is NOT explicit;
-    # even with automerge=false it must stay the legacy per-stack path.
-    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="", AUTOMERGE="false"))
-    assert cfg.deploy_strategy == DeployStrategy.STANDARD
-    assert cfg.promoter_managed_standard is False
-
-
-def test_promoter_managed_standard_off_for_wave_strategies():
-    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="gradual", AUTOMERGE="false"))
-    assert cfg.promoter_managed_standard is False
-
-
-def test_empty_deploy_strategy_with_multi_stage_aliases_to_cloud_multi_stage():
-    # The action passes deploy-strategy='' by default; empty must behave as unset
-    # so MULTI_STAGE=true still aliases to cloud_multi_stage (legacy action callers).
-    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="", MULTI_STAGE="true"))
-    assert cfg.deploy_strategy == DeployStrategy.CLOUD_MULTI_STAGE
-    assert cfg.multi_stage is True

--- a/tests/test_legacy_knobs_removed.py
+++ b/tests/test_legacy_knobs_removed.py
@@ -1,0 +1,30 @@
+"""ST-4159: legacy knobs are gone — AUTOMERGE/MULTI_STAGE env ignored,
+cloud_multi_stage invalid, empty strategy resolves to standard."""
+from helm_image_updater.environment import EnvironmentConfig
+from helm_image_updater.models import DeployStrategy
+
+BASE = {"HELM_CHART": "x", "IMAGE_TAG": "production-abc",
+        "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a"}
+
+
+def test_automerge_env_not_parsed():
+    cfg = EnvironmentConfig.from_env({**BASE, "AUTOMERGE": "false"})
+    assert not hasattr(cfg, "automerge")
+
+
+def test_multi_stage_env_ignored_with_warning(capsys):
+    cfg = EnvironmentConfig.from_env({**BASE, "MULTI_STAGE": "true"})
+    assert not hasattr(cfg, "multi_stage")
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+    assert "MULTI_STAGE is deprecated" in capsys.readouterr().out
+
+
+def test_empty_strategy_is_standard():
+    cfg = EnvironmentConfig.from_env(BASE)
+    assert cfg.deploy_strategy == DeployStrategy.STANDARD
+    assert not hasattr(cfg, "promoter_managed_standard")
+
+
+def test_cloud_multi_stage_is_invalid_strategy():
+    cfg = EnvironmentConfig.from_env({**BASE, "DEPLOY_STRATEGY": "cloud_multi_stage"})
+    assert any("Invalid DEPLOY_STRATEGY" in e for e in cfg.validate())

--- a/tests/test_manual_per_stack.py
+++ b/tests/test_manual_per_stack.py
@@ -47,17 +47,12 @@ def _stack_change(stack):
 def _manual_config():
     config = Mock()
     config.deploy_strategy = DeployStrategy.MANUAL_PER_STACK
-    config.automerge = False
-    # Mock auto-creates truthy attrs; pin the OTHER promoter gates off so routing
-    # exercises the manual branch (a real manual EnvironmentConfig has these False).
-    config.promoter_managed_standard = False
     return config
 
 
 def _manual_plan():
     plan = Mock()
     plan.strategy = UpdateStrategy.PRODUCTION
-    plan.multi_stage = False
     plan.helm_chart = "dummy-service"
     plan.image_tag = "production-abc123"
     return plan
@@ -231,14 +226,13 @@ def manual_stacks(tmp_path):
     return tmp_path
 
 
-def _manual_env(base_dir, dry_run="true", automerge="false"):
+def _manual_env(base_dir, dry_run="true"):
     return {
         "HELM_CHART": "test-chart",
         "IMAGE_TAG": "production-abc123",
         "GH_TOKEN": "t",
         "GH_APPROVE_TOKEN": "a",
         "DEPLOY_STRATEGY": "manual-per-stack",
-        "AUTOMERGE": automerge,
         "DRY_RUN": dry_run,
         "TARGET_PATH": str(base_dir),
     }
@@ -247,7 +241,6 @@ def _manual_env(base_dir, dry_run="true", automerge="false"):
 def test_env_recognises_manual_per_stack():
     config = EnvironmentConfig.from_env(_manual_env("/tmp"))
     assert config.deploy_strategy == DeployStrategy.MANUAL_PER_STACK
-    assert config.promoter_managed_manual_per_stack is True
     assert config.validate() == []
 
 

--- a/tests/test_manual_per_stack.py
+++ b/tests/test_manual_per_stack.py
@@ -138,8 +138,8 @@ def test_group_changes_for_prs_routes_manual_per_stack():
 
 def test_should_auto_merge_manual_is_false():
     plan = _manual_plan()
-    assert _should_auto_merge(plan, "manual", user_requested=True) is False
-    assert _should_auto_merge(plan, "manual", user_requested=False) is False
+    # manual-per-stack members are merged by a human, never by HIU (pr_type short-circuit)
+    assert _should_auto_merge(plan, "manual", ["dev-keboola-gcp-us-central1"]) is False
 
 
 def test_is_promoter_managed_manual_per_stack_production_only():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,8 +9,8 @@ def test_is_promoter_managed_includes_wave_strategies_and_standard():
     assert DeployStrategy.CRITICAL_MANUAL_GATE.is_promoter_managed is True
     # STANDARD is promoter-managed too (ST-4126: 2-wave dev→prod when unmerged).
     assert DeployStrategy.STANDARD.is_promoter_managed is True
-    # cloud_multi_stage stays legacy, NOT promoter-managed.
-    assert DeployStrategy.CLOUD_MULTI_STAGE.is_promoter_managed is False
+    # MANUAL_PER_STACK is promoter-managed as well.
+    assert DeployStrategy.MANUAL_PER_STACK.is_promoter_managed is True
 
 
 def test_standard_is_not_is_wave():

--- a/tests/test_plan_builder.py
+++ b/tests/test_plan_builder.py
@@ -74,9 +74,7 @@ def test_plan_with_dry_run(test_stacks):
         "HELM_CHART": "test-chart",
         "IMAGE_TAG": "dev-1.2.3",
         "GH_TOKEN": "fake-token",
-        "AUTOMERGE": "true",
         "DRY_RUN": "true",  # Dry run to avoid actual Git operations
-        "MULTI_STAGE": "false",
         "TARGET_PATH": str(test_stacks["base_dir"]),
         "GH_APPROVE_TOKEN": "fake-approve-token",
     }
@@ -161,145 +159,22 @@ def test_extra_tags_calculation(test_stacks):
 
 
 # Multi-cloud grouping tests
-def test_multi_cloud_multi_stage_grouping_production_tag(test_stacks):
-    """Test multi-cloud multi-stage grouping logic for production tags."""
-    from helm_image_updater.plan_builder import _group_changes_for_prs
-    
-    os.chdir(test_stacks["base_dir"])
-    
-    # Create mock I/O layer that can read shared-values.yaml
-    mock_io_layer = Mock()
-    def mock_shared_values(stack):
-        cloud_mapping = {
-            "dev-keboola-gcp-us-central1": {"cloudProvider": "gcp"},
-            "kbc-testing-azure-east-us-2": {"cloudProvider": "azure"},
-            "dev-keboola-aws-eu-west-1": {"cloudProvider": "aws"},
-            "com-keboola-gcp-prod": {"cloudProvider": "gcp"},
-            "com-keboola-azure-prod": {"cloudProvider": "azure"},
-            "com-keboola-aws-prod": {"cloudProvider": "aws"},
-        }
-        return cloud_mapping.get(stack)
-    mock_io_layer.read_shared_values_yaml.side_effect = mock_shared_values
-
-    # Create mock environment config
-    mock_config = Mock()
-    mock_config.automerge = True
-    from helm_image_updater.models import DeployStrategy
-    mock_config.deploy_strategy = DeployStrategy.STANDARD
-    mock_config.promoter_managed_standard = False
-
-    # Create mock plan
-    mock_plan = Mock()
-    mock_plan.multi_stage = True
-    mock_plan.strategy = UpdateStrategy.PRODUCTION
-    
-    # Create mock stack changes for all 6 stacks
-    stack_changes = []
-    all_stacks = [
-        "dev-keboola-gcp-us-central1", "kbc-testing-azure-east-us-2", "dev-keboola-aws-eu-west-1",
-        "com-keboola-gcp-prod", "com-keboola-azure-prod", "com-keboola-aws-prod"
-    ]
-    
-    for stack in all_stacks:
-        stack_changes.append({
-            'stack': stack,
-            'file_change': Mock(),
-            'changes': []
-        })
-    
-    # Test the grouping
-    groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
-    
-    # Verify 6 groups were created (3 dev + 3 prod)
-    assert len(groups) == 6, f"Expected 6 groups, got {len(groups)}"
-    
-    # Verify each group has correct properties
-    dev_groups = [g for g in groups if g['pr_type'] == 'multi_stage_dev']
-    prod_groups = [g for g in groups if g['pr_type'] == 'multi_stage_prod']
-    
-    assert len(dev_groups) == 3, f"Expected 3 dev groups, got {len(dev_groups)}"
-    assert len(prod_groups) == 3, f"Expected 3 prod groups, got {len(prod_groups)}"
-    
-    # Verify cloud providers are correctly assigned
-    dev_clouds = {g['cloud_provider'] for g in dev_groups}
-    prod_clouds = {g['cloud_provider'] for g in prod_groups}
-    
-    expected_clouds = {"aws", "azure", "gcp"}
-    assert dev_clouds == expected_clouds, f"Dev clouds {dev_clouds} != expected {expected_clouds}"
-    assert prod_clouds == expected_clouds, f"Prod clouds {prod_clouds} != expected {expected_clouds}"
-    
-    # Verify each group has exactly one stack (one per cloud)
-    for group in groups:
-        assert len(group['stacks']) == 1, f"Each group should have exactly 1 stack, got {len(group['stacks'])}"
-        assert len(group['changes']) == 1, f"Each group should have exactly 1 change, got {len(group['changes'])}"
-        assert group['base_branch'] == 'main', f"All groups should target main branch"
-
-
-def test_multi_cloud_grouping_non_multi_stage(test_stacks):
-    """Test that non-multi-stage deployments still work correctly."""
-    from helm_image_updater.plan_builder import _group_changes_for_prs
-    
-    os.chdir(test_stacks["base_dir"])
-    
-    # Create mock I/O layer
-    mock_io_layer = Mock()
-    
-    # Create mock environment config
-    mock_config = Mock()
-    mock_config.automerge = True
-    from helm_image_updater.models import DeployStrategy
-    mock_config.deploy_strategy = DeployStrategy.STANDARD
-    mock_config.promoter_managed_standard = False
-
-    # Create mock plan (non-multi-stage)
-    mock_plan = Mock()
-    mock_plan.multi_stage = False  # Non-multi-stage
-    mock_plan.strategy = UpdateStrategy.PRODUCTION
-    
-    # Create mock stack changes for all 6 stacks
-    stack_changes = []
-    all_stacks = [
-        "dev-keboola-gcp-us-central1", "kbc-testing-azure-east-us-2", "dev-keboola-aws-eu-west-1",
-        "com-keboola-gcp-prod", "com-keboola-azure-prod", "com-keboola-aws-prod"
-    ]
-    
-    for stack in all_stacks:
-        stack_changes.append({
-            'stack': stack,
-            'file_change': Mock(),
-            'changes': []
-        })
-    
-    # Test the grouping
-    groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
-    
-    # Verify only 1 group was created (normal behavior for non-multi-stage)
-    assert len(groups) == 1, f"Non-multi-stage should create 1 group, got {len(groups)}"
-    
-    # Verify the group contains all stacks
-    assert len(groups[0]['stacks']) == 6, f"Group should contain all 6 stacks"
-    assert groups[0]['pr_type'] == 'standard', f"PR type should be 'standard'"
-
-
 def test_multi_cloud_grouping_dev_strategy(test_stacks):
     """Test multi-cloud grouping with dev strategy (should not use multi-stage logic)."""
     from helm_image_updater.plan_builder import _group_changes_for_prs
-    
+
     os.chdir(test_stacks["base_dir"])
-    
+
     # Create mock I/O layer
     mock_io_layer = Mock()
-    
+
     # Create mock environment config
     mock_config = Mock()
-    mock_config.automerge = True
     from helm_image_updater.models import DeployStrategy
     mock_config.deploy_strategy = DeployStrategy.STANDARD
-    mock_config.promoter_managed_standard = False
 
-    # Create mock plan (dev strategy, even with multi_stage=True)
+    # Create mock plan (dev strategy)
     mock_plan = Mock()
-    mock_plan.multi_stage = True
     mock_plan.strategy = UpdateStrategy.DEV  # Dev strategy
     
     # Create mock stack changes for dev stacks only
@@ -316,44 +191,15 @@ def test_multi_cloud_grouping_dev_strategy(test_stacks):
     # Test the grouping
     groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
     
-    # Verify only 1 group was created (dev strategy doesn't use multi-cloud logic)
-    assert len(groups) == 1, f"Dev strategy should create 1 group regardless of multi-stage, got {len(groups)}"
-    
+    # Verify only 1 group was created (dev strategy uses the single-PR path)
+    assert len(groups) == 1, f"Dev strategy should create 1 group, got {len(groups)}"
+
     # Verify the group contains all dev stacks
     assert len(groups[0]['stacks']) == 3, f"Group should contain all 3 dev stacks"
     assert groups[0]['pr_type'] == 'standard', f"PR type should be 'standard'"
 
 
 # Override removal tests
-
-def test_standard_production_automerge_false_is_one_pr_per_stack():
-    """standard production + automerge=false → ONE PR PER STACK (matches main).
-
-    (automerge=true stays a single PR for all stacks — see
-    test_multi_cloud_grouping_non_multi_stage.)
-    """
-    from helm_image_updater.plan_builder import _group_changes_for_prs
-    from helm_image_updater.models import DeployStrategy
-
-    mock_io_layer = Mock()
-    mock_config = Mock()
-    mock_config.automerge = False
-    mock_config.deploy_strategy = DeployStrategy.STANDARD
-    mock_config.promoter_managed_standard = False
-
-    mock_plan = Mock()
-    mock_plan.multi_stage = False
-    mock_plan.strategy = UpdateStrategy.PRODUCTION
-
-    stacks = ["com-keboola-gcp-prod", "com-keboola-azure-prod", "com-keboola-aws-prod"]
-    stack_changes = [{"stack": s, "file_change": Mock(), "changes": []} for s in stacks]
-
-    groups = _group_changes_for_prs(stack_changes, mock_plan, mock_config, mock_io_layer)
-
-    assert len(groups) == 3, f"expected one PR per stack, got {len(groups)}"
-    assert all(len(g["stacks"]) == 1 for g in groups)
-    assert {g["stacks"][0] for g in groups} == set(stacks)
-    assert all(g["pr_type"] == "standard" for g in groups)
 
 
 class TestCheckAndRemoveOverride:
@@ -504,9 +350,7 @@ class TestOverrideIntegration:
             "HELM_CHART": "test-chart",
             "IMAGE_TAG": "production-new-tag",
             "GH_TOKEN": "fake-token",
-            "AUTOMERGE": "true",
             "DRY_RUN": "true",
-            "MULTI_STAGE": "false",
             "TARGET_PATH": str(tmp_path),
         }
 
@@ -552,9 +396,7 @@ class TestOverrideIntegration:
             "HELM_CHART": "test-chart",
             "IMAGE_TAG": "dev-new-tag",
             "GH_TOKEN": "fake-token",
-            "AUTOMERGE": "true",
             "DRY_RUN": "true",
-            "MULTI_STAGE": "false",
             "TARGET_PATH": str(tmp_path),
         }
 
@@ -588,9 +430,7 @@ class TestOverrideIntegration:
             "HELM_CHART": "test-chart",
             "IMAGE_TAG": "dev-new-tag",
             "GH_TOKEN": "fake-token",
-            "AUTOMERGE": "true",
             "DRY_RUN": "true",
-            "MULTI_STAGE": "false",
             "TARGET_PATH": str(tmp_path),
         }
 

--- a/tests/test_standard_2wave.py
+++ b/tests/test_standard_2wave.py
@@ -1,8 +1,8 @@
-"""ST-4126: promoter-managed `standard` deploy = 2-wave dev→prod release.
+"""ST-4126/ST-4159: promoter-managed `standard` deploy = 2-wave dev→prod release.
 
 Wave 0 = all dev stacks (anchor, carries the manifest), wave 1 = all prod stacks.
-The cloud dimension is collapsed (no per-cloud split). Activation: explicit
-DEPLOY_STRATEGY=standard + automerge=false on a production/semver tag.
+The cloud dimension is collapsed (no per-cloud split). Activation: DEPLOY_STRATEGY
+resolves to standard (empty is the universal default, ST-4159) on a PRODUCTION deploy.
 """
 
 import os
@@ -41,15 +41,12 @@ def _stack_change(stack):
 def _std_config():
     config = Mock()
     config.deploy_strategy = DeployStrategy.STANDARD
-    config.automerge = False
-    config.promoter_managed_standard = True
     return config
 
 
 def _std_plan():
     plan = Mock()
     plan.strategy = UpdateStrategy.PRODUCTION
-    plan.multi_stage = False
     plan.helm_chart = "dummy-service"
     plan.image_tag = "production-abc123"
     return plan
@@ -136,47 +133,19 @@ def test_group_changes_for_prs_routes_explicit_standard_unmerged_to_2wave():
     assert by_wave[0]["labels"] == ["release:wave:0", "deploy:standard"]
 
 
-def test_group_changes_for_prs_legacy_default_standard_automerge_unchanged():
-    # Default standard + automerge=true (production tag, multiple stacks) → ONE legacy PR,
-    # NOT the 2-wave promoter path.
-    config = Mock()
-    config.deploy_strategy = DeployStrategy.STANDARD
-    config.automerge = True
-    config.promoter_managed_standard = False  # default standard, not opted in
-    plan = _std_plan()
-    changes = [_stack_change(s) for s in PROD_STACKS]
-
-    groups = _group_changes_for_prs(changes, plan, config, Mock())
-    assert len(groups) == 1
-    assert groups[0]["pr_type"] == "standard"
-    assert groups[0].get("wave_number") is None
-    assert groups[0].get("labels", []) == []
-
-
-def test_group_changes_for_prs_legacy_standard_automerge_false_per_stack_unchanged():
-    # Default standard + automerge=false on a multi-stack production deploy → one PR
-    # per stack (legacy), NOT a 2-wave release. Gated off because deploy_strategy is the
-    # DEFAULT (no explicit standard signal) — see plan_builder routing.
-    config = Mock()
-    config.deploy_strategy = DeployStrategy.STANDARD
-    config.automerge = False
-    config.promoter_managed_standard = False  # not explicitly opted in
-    plan = _std_plan()
-    changes = [_stack_change(s) for s in PROD_STACKS]
-
-    groups = _group_changes_for_prs(changes, plan, config, Mock())
-    # Legacy per-stack PRs: one per stack, no wave labels.
-    assert len(groups) == len(PROD_STACKS)
-    for g in groups:
-        assert g["pr_type"] == "standard"
-        assert g.get("wave_number") is None
+# NOTE (ST-4159): the two "legacy default standard" grouping tests were removed. There is
+# no legacy production grouping anymore — a PRODUCTION deploy with DEPLOY_STRATEGY resolving
+# to standard (empty included) is ALWAYS the 2-wave promoter release; a production deploy can
+# never fall through to the single-PR / per-stack tail (plan_builder raises if it does). The
+# empty-strategy-is-promoter-standard invariant is asserted by
+# test_empty_strategy_production_is_promoter_standard below.
 
 
 def test_group_changes_for_prs_override_not_hijacked_by_standard():
     # ST-4126 routing guard: explicit standard + automerge=false but an OVERRIDE
     # deploy must stay the override single-PR — the 2-wave standard path is for
     # full PRODUCTION/DEV deploys only, never override.
-    config = _std_config()  # promoter_managed_standard=True
+    config = _std_config()  # deploy_strategy=STANDARD
     plan = _std_plan()
     plan.strategy = UpdateStrategy.OVERRIDE
     changes = [_stack_change("kbc-us-east-1")]
@@ -257,7 +226,7 @@ def test_prepare_plan_standard_sets_manifest_context_and_two_waves(std_stacks):
     }
     config = EnvironmentConfig.from_env(env)
     assert config.validate() == []
-    assert config.promoter_managed_standard is True
+    assert config.deploy_strategy == DeployStrategy.STANDARD
 
     plan = prepare_plan(config, _io_layer())
 
@@ -276,11 +245,11 @@ def test_prepare_plan_standard_sets_manifest_context_and_two_waves(std_stacks):
     assert by_wave[1].labels == ["release:wave:1", "deploy:standard"]
 
 
-def test_prepare_plan_explicit_standard_ignores_automerge_true(std_stacks):
-    # ST-4126: AUTOMERGE is IGNORED for an EXPLICIT DEPLOY_STRATEGY=standard (same as the
-    # wave strategies). AUTOMERGE=true must NOT revert it to a legacy single-PR deploy — it
-    # still emits the promoter-managed 2-wave release with unmerged wave PRs (which HIU
-    # auto-approves because auto_merge=False, so release-promoter can merge them).
+def test_prepare_plan_stray_automerge_true_still_two_waves(std_stacks):
+    # ST-4159: AUTOMERGE is a dead env var, but an old dispatcher may still send it. A stray
+    # AUTOMERGE=true must NOT revert a production standard deploy to a single merged PR — it
+    # is ignored, and the promoter-managed 2-wave release is emitted unchanged (unmerged wave
+    # PRs that HIU auto-approves so release-promoter can merge them).
     os.chdir(std_stacks["base_dir"])
     env = {
         "HELM_CHART": "test-chart",
@@ -288,12 +257,12 @@ def test_prepare_plan_explicit_standard_ignores_automerge_true(std_stacks):
         "GH_TOKEN": "t",
         "GH_APPROVE_TOKEN": "a",
         "DEPLOY_STRATEGY": "standard",
-        "AUTOMERGE": "true",  # explicitly true — must be ignored for explicit standard
+        "AUTOMERGE": "true",  # dead knob — must be ignored
         "DRY_RUN": "true",
         "TARGET_PATH": str(std_stacks["base_dir"]),
     }
     config = EnvironmentConfig.from_env(env)
-    assert config.promoter_managed_standard is True
+    assert not hasattr(config, "automerge")
 
     plan = prepare_plan(config, _io_layer())
     assert plan.manifest_context is not None
@@ -321,7 +290,7 @@ def test_prepare_plan_standard_invokes_idempotency_guard(std_stacks):
         ).decode(),
     }
     config = EnvironmentConfig.from_env(env)
-    assert config.promoter_managed_standard is True
+    assert config.deploy_strategy == DeployStrategy.STANDARD
 
     from helm_image_updater.manifest import build_manifest, manifest_block, compute_instance_id
 
@@ -338,27 +307,45 @@ def test_prepare_plan_standard_invokes_idempotency_guard(std_stacks):
         prepare_plan(config, io)
 
 
-def test_prepare_plan_legacy_standard_no_manifest_context(std_stacks):
-    # Default (empty) standard + automerge=true → legacy single PR, NO manifest context.
+def test_empty_strategy_production_is_promoter_standard(std_stacks):
+    # ST-4159: the empty-strategy default IS promoter standard. A production tag with NO
+    # DEPLOY_STRATEGY now produces the promoter-managed 2-wave release (manifest + unmerged
+    # wave PRs), NOT the old legacy single merged PR.
     os.chdir(std_stacks["base_dir"])
     env = {
         "HELM_CHART": "test-chart",
         "IMAGE_TAG": "production-abc123",
         "GH_TOKEN": "t",
         "GH_APPROVE_TOKEN": "a",
-        "DEPLOY_STRATEGY": "",
-        "AUTOMERGE": "true",
+        # DEPLOY_STRATEGY unset -> resolves to standard
         "DRY_RUN": "true",
         "TARGET_PATH": str(std_stacks["base_dir"]),
     }
     config = EnvironmentConfig.from_env(env)
-    assert config.promoter_managed_standard is False
+    assert config.deploy_strategy == DeployStrategy.STANDARD
 
     plan = prepare_plan(config, _io_layer())
-    assert plan.manifest_context is None
-    # legacy single PR for all stacks
-    assert len(plan.pr_plans) == 1
-    assert plan.pr_plans[0].wave_number is None
+    assert plan.strategy == UpdateStrategy.PRODUCTION
+    assert plan.manifest_context is not None
+    assert len(plan.pr_plans) == 2
+    by_wave = {p.wave_number: p for p in plan.pr_plans}
+    assert set(by_wave) == {0, 1}
+    assert by_wave[0].auto_merge is False
+    assert by_wave[1].auto_merge is False
+
+
+def test_override_stack_never_promoter_standard(std_stacks):
+    # ST-4159 invariant (unit level): OVERRIDE wins in _determine_strategy, so an
+    # override deploy is never the promoter-managed 2-wave path regardless of strategy.
+    from helm_image_updater.plan_builder import _is_promoter_managed_standard
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "IMAGE_TAG": "production-abc",
+        "OVERRIDE_STACK": "kbc-us-east-1",
+        "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+    })
+    plan = Mock()
+    plan.strategy = UpdateStrategy.OVERRIDE
+    assert _is_promoter_managed_standard(cfg, plan) is False
 
 
 def test_prepare_plan_explicit_standard_override_stack_not_managed(std_stacks):

--- a/tests/test_standard_2wave.py
+++ b/tests/test_standard_2wave.py
@@ -212,8 +212,11 @@ def test_canary_auto_merges_regardless_of_automerge_flag():
     # standard rollout (ST-4131) makes automerge=false the default.
     plan = Mock()
     plan.strategy = UpdateStrategy.CANARY
-    assert _should_auto_merge(plan, "canary", user_requested=False) is True
-    assert _should_auto_merge(plan, "canary", user_requested=True) is True
+    plan.image_tag = "canary-orion-abc"
+    plan.extra_tags = []
+    # canary tag (non-production-class) onto the canary stack (non-prod) -> auto-merges,
+    # no longer gated on any automerge flag (ST-4169).
+    assert _should_auto_merge(plan, "canary", ["dev-keboola-canary-orion"]) is True
 
 
 # --- prepare_plan: manifest-context + idempotency-guard wiring (integration) -------

--- a/tests/test_validate_override_guard.py
+++ b/tests/test_validate_override_guard.py
@@ -1,5 +1,6 @@
-"""validate() guard (ST-4169): a PRODUCTION override stack rejects dev-/canary- tags,
-including via extra tags. Non-production override targets (e.g. e2e) stay unrestricted."""
+"""validate() guard (ST-4169): a PRODUCTION override stack rejects any non-production
+tag -- dev-/canary- and unrecognized/`pr-test-*` (INVALID) -- including via extra tags.
+Non-production override targets (e.g. e2e) stay unrestricted."""
 
 from helm_image_updater.environment import EnvironmentConfig
 
@@ -25,6 +26,15 @@ def test_dev_extra_tag_blocked_on_prod_override(tmp_path, monkeypatch):
         override_stack="prod-stack",
         extra_tags=[{"path": "a.tag", "value": "dev-xyz"}],
     )
+    assert any("non-production" in e for e in cfg.validate())
+
+
+def test_pr_test_invalid_tag_blocked_on_prod_override(tmp_path, monkeypatch):
+    # Tag-format validation is skipped in override mode, so a pr-test-* (INVALID) tag
+    # reaches the guard; a production override target must still reject it (Copilot #43).
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prod-stack").mkdir()
+    cfg = _cfg(image_tag="pr-test-7786-abc", override_stack="prod-stack")
     assert any("non-production" in e for e in cfg.validate())
 
 

--- a/tests/test_validate_override_guard.py
+++ b/tests/test_validate_override_guard.py
@@ -1,0 +1,36 @@
+"""validate() guard (ST-4169): a PRODUCTION override stack rejects dev-/canary- tags,
+including via extra tags. Non-production override targets (e.g. e2e) stay unrestricted."""
+
+from helm_image_updater.environment import EnvironmentConfig
+
+
+def _cfg(**kw):
+    base = dict(helm_chart="x", github_token="t", approve_token="a")
+    base.update(kw)
+    return EnvironmentConfig(**base)
+
+
+def test_canary_tag_blocked_on_prod_override(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prod-stack").mkdir()  # unknown name -> classify_stack -> is_production
+    cfg = _cfg(image_tag="canary-orion-abc", override_stack="prod-stack")
+    assert any("non-production" in e for e in cfg.validate())
+
+
+def test_dev_extra_tag_blocked_on_prod_override(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prod-stack").mkdir()
+    cfg = _cfg(
+        image_tag="production-abc",
+        override_stack="prod-stack",
+        extra_tags=[{"path": "a.tag", "value": "dev-xyz"}],
+    )
+    assert any("non-production" in e for e in cfg.validate())
+
+
+def test_dev_tag_allowed_on_e2e_override(tmp_path, monkeypatch):
+    # e2e stacks are EXCLUDED_STACKS (not production) -> dev/pr-test deploys are allowed.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "dev-keboola-gcp-us-east1-e2e").mkdir()
+    cfg = _cfg(image_tag="dev-abc", override_stack="dev-keboola-gcp-us-east1-e2e")
+    assert not any("non-production" in e for e in cfg.validate())

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -34,7 +34,6 @@ def test_wave_grouping_one_pr_per_wave_with_labels():
 
     plan = Mock()
     plan.strategy = UpdateStrategy.PRODUCTION
-    plan.multi_stage = False
     plan.helm_chart = "dummy-service"
     plan.image_tag = "production-abc123"
 
@@ -66,7 +65,7 @@ def test_wave_grouping_requires_all_waves_0_to_3():
     io = Mock()
     io.read_yaml.side_effect = _wave_metadata(waves)
     config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
-    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION
     plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
 
     with pytest.raises(RuntimeError, match="wave"):
@@ -93,7 +92,7 @@ def test_wave_grouping_rejects_gap():
     io = Mock()
     io.read_yaml.side_effect = _wave_metadata(waves)
     config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
-    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION
     plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
 
     with pytest.raises(RuntimeError, match="wave"):
@@ -111,7 +110,7 @@ def test_wave_grouping_rejects_missing_last():
     io = Mock()
     io.read_yaml.side_effect = _wave_metadata(waves)
     config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
-    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION
     plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
 
     with pytest.raises(RuntimeError, match="wave"):
@@ -137,7 +136,7 @@ def test_wave_grouping_missing_metadata_uses_defaults():
     io = Mock()
     io.read_yaml.side_effect = _read
     config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
-    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION
     plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc123"
 
     all_stacks = [dev_stack] + list(waves_explicit.keys())
@@ -154,11 +153,10 @@ from helm_image_updater.plan_builder import _create_pr_plan
 
 
 def test_create_pr_plan_wave_sets_labels_and_branch_title():
-    config = Mock(); config.automerge = False
+    config = Mock()
     config.deploy_strategy = DeployStrategy.GRADUAL
     plan = Mock()
     plan.strategy = UpdateStrategy.PRODUCTION
-    plan.multi_stage = False
     plan.helm_chart = "dummy-service"
     plan.image_tag = "production-abc123"
     plan.extra_tags = []
@@ -186,11 +184,10 @@ def test_create_pr_plan_wave_sets_labels_and_branch_title():
 def test_create_pr_plan_wave_title_includes_extra_tags():
     """Wave titles must carry the SAME chart+tags string the release search link quotes —
     with extra tags, otherwise the quoted-phrase search matches nothing (ST-4035)."""
-    config = Mock(); config.automerge = False
+    config = Mock()
     config.deploy_strategy = DeployStrategy.GRADUAL
     plan = Mock()
     plan.strategy = UpdateStrategy.PRODUCTION
-    plan.multi_stage = False
     plan.helm_chart = "dummy-service"
     plan.image_tag = "production-abc123"
     plan.extra_tags = [{"path": "agent.tag", "value": "production-agent-xyz"}]
@@ -383,7 +380,7 @@ def test_wave_grouping_excludes_e2e_stacks():
     }
     io = Mock(); io.read_yaml.side_effect = _wave_metadata(waves)
     config = Mock(); config.deploy_strategy = DeployStrategy.GRADUAL
-    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION; plan.multi_stage = False
+    plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION
     plan.helm_chart = "dummy-service"; plan.image_tag = "production-abc"
     # an unlisted e2e stack must be dropped from waves, not placed in wave 3
     changes = [_stack_change(s) for s in waves] + [_stack_change("foo-bar-e2e")]
@@ -400,11 +397,10 @@ from helm_image_updater.message_generation import wave_release_search_link
 
 
 def _pr_plan_mocks(pr_type, wave_number=None):
-    config = Mock(); config.automerge = False
+    config = Mock()
     config.deploy_strategy = DeployStrategy.GRADUAL
     plan = Mock()
     plan.strategy = UpdateStrategy.PRODUCTION
-    plan.multi_stage = False
     plan.helm_chart = "dummy-service"
     plan.image_tag = "production-abc123"
     plan.extra_tags = [{"path": "agent.tag", "value": "production-xyz"}]

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -78,8 +78,8 @@ from helm_image_updater.plan_builder import _should_auto_merge
 
 def test_wave_pr_type_never_auto_merges():
     plan = Mock(); plan.strategy = UpdateStrategy.PRODUCTION
-    assert _should_auto_merge(plan, "wave", user_requested=True) is False
-    assert _should_auto_merge(plan, "wave", user_requested=False) is False
+    # wave PRs are merged by release-promoter, never by HIU (pr_type short-circuit)
+    assert _should_auto_merge(plan, "wave", ["dev-keboola-gcp-us-central1"]) is False
 
 
 def test_wave_grouping_rejects_gap():
@@ -218,7 +218,7 @@ def test_create_pr_plan_wave_title_includes_extra_tags():
 
 def test_wave_never_auto_merges_even_for_canary_strategy():
     plan = Mock(); plan.strategy = UpdateStrategy.CANARY
-    assert _should_auto_merge(plan, "wave", user_requested=True) is False
+    assert _should_auto_merge(plan, "wave", ["dev-keboola-gcp-us-central1"]) is False
 
 
 from helm_image_updater.io_layer import IOLayer


### PR DESCRIPTION
## What
Two folded issues that together make **release-promoter own every production merge** and let HIU auto-merge only non-production deploys:

- **ST-4169** — decide PR auto-merge by the image **tag class + target stacks** instead of the `AUTOMERGE` input.
- **ST-4159** — remove ALL remaining legacy deploy paths from HIU (`cloud_multi_stage`, `AUTOMERGE`/`MULTI_STAGE` parsing, the legacy no-strategy production grouping, multi-stage PR titles, dead `UpdateConfig`) and make an **empty `DEPLOY_STRATEGY` resolve to `standard`** (promoter-managed) inside HIU.

Linear: [ST-4169](https://linear.app/keboola/issue/ST-4169) · [ST-4159](https://linear.app/keboola/issue/ST-4159)

Full plan committed in `docs/superpowers/plans/2026-07-13-st4159-legacy-removal-plan.md` (Codex-reviewed, gpt-5.5).

## End state
- **Production/semver deploy** (any strategy, incl. empty→standard) → PRs created **unmerged** + auto-approved; release-promoter (or a human, for `manual-per-stack`) merges. HIU has **no code path** that merges a PR whose targets include a production stack (a defensive `RuntimeError` guards the DEV/OVERRIDE single-PR tail against a production deploy).
- **Dev / canary / `pr-test-*`** deploy to non-production stacks (dev, e2e, canary, override) → **auto-merged** by HIU, fast.
- **Non-production tag on a production `override-stack`** → `validate()` error (dev/canary/INVALID all rejected).
- **Stray `AUTOMERGE`/`MULTI_STAGE`** env from old dispatchers is ignored (deprecation warning for `MULTI_STAGE=true`); `DEPLOY_STRATEGY=cloud_multi_stage` is now an invalid-strategy error.

## Changes
**ST-4169 (auto-merge by tag/stack):**
- `_effective_tag_type(plan)` — most-cautious tag class across image tag + extra tags. (`64d546d`)
- `_should_auto_merge(plan, pr_type, stacks)` — drops the `automerge` arg; `wave`/`manual` → False, production-class → False, else True iff no target stack is production. (`5710e00`)
- `validate()` override guard — rejects any non-production tag (dev/canary AND unrecognized/`pr-test-*`) on a production override stack. (`f37bec1`, `34cb1a3` — the INVALID case addresses Copilot review)

**ST-4159 (legacy removal):**
- `environment.py` — delete `AUTOMERGE`/`MULTI_STAGE`/`cloud_multi_stage` parsing + the `automerge`/`multi_stage`/`promoter_managed_*` fields; empty `DEPLOY_STRATEGY` → standard. (`ef72cf6`)
- `models.py` — remove `DeployStrategy.CLOUD_MULTI_STAGE` and `UpdatePlan.multi_stage`. (`afae487`)
- `plan_builder.py` — one production path: promoter-managed grouping only; drop the multi-stage 6-PR branch and the legacy automerge grouping; `_is_promoter_managed_standard` keys on the enum (empty=standard). (`f7e69d9`)
- `message_generation.py` — `generate_pr_title_prefix(strategy, target_stacks)`; drop `[multi-stage]` prefixes. (`65f7436`)
- delete dead `UpdateConfig`; CLI prints the resolved strategy, not the removed knobs. (`cbd9bd7`)
- `action.yaml` — drop the `automerge`/`multi-stage` inputs + env forwarding; README + CLAUDE.md rewritten; `setup.py` → **0.23.0**. (`2d7465a`)

## Tests
New `tests/test_legacy_knobs_removed.py` + `tests/test_auto_merge.py` + `tests/test_validate_override_guard.py`; ported survivors to the new signatures; deleted the legacy cloud_multi_stage / legacy-production-grouping / multi-stage-title / CLI-single-PR-production tests; added invariants (empty-strategy production IS promoter-standard; OVERRIDE never promoter-managed). **264 passed, 0 skipped.**

## E2E tests ✅ 
https://github.com/keboola/helm-image-updater-testing/actions/runs/29270470603
run on https://github.com/keboola/helm-image-updater-testing/pull/5456

## Rebased on v0.22.0
Rebased onto `main` @ `c9e0c12` (v0.22.0), picking up #44 (ST-4190 payload-based `instanceId`) and #45 (ST-4198 extra-tags-only production validation). Clean rebase.

## ⚠️ Do not merge until
1. **E2E green** — `helm-image-updater-testing` PR (separate) updated to the tag/stack-rule scenarios (drop the legacy direct-automerge + `multi-stage*` scenarios; add production→unmerged, `pr-test-*`+override→merged, dev→merged, canary→merged, dev/canary+prod-override→rejected; keep the promoter/wave scenarios). Run green against this branch.
2. Merge **together with** that testing PR, then release **v0.23.0** (tag).

## kbc-stacks side (separate follow-up PR)
Bump the pin `@v0.20.0 → @v0.23.0`, stop forwarding `automerge`/`multi-stage` to the action, and drop the `promoter-cloud-multi-stage` label mapping. The workflow **input declarations stay** — ~15 repos dispatch the workflow passing them directly (Azure DevOps `create_dispatch` silently swallows a 422), so removing the declarations is a separate org-wide migration. Once the pin lands, those inputs are harmless no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
