### PR TITLE
fix: accept production tag via EXTRA_TAG for wave/manual-per-stack strategies

### DIFF
--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -134,14 +134,33 @@ class EnvironmentConfig:
         config._deploy_strategy_error = deploy_strategy_error
         return config
     
+    def _production_rollout_tag(self) -> str:
+        """The tag that decides whether a production rollout (wave / manual-per-stack)
+        is valid.
+
+        Mirrors ``plan_builder._determine_strategy`` precedence: ``IMAGE_TAG`` when set,
+        otherwise the first non-empty ``EXTRA_TAG`` value. This lets an extra-tags-only
+        production deploy (empty ``IMAGE_TAG`` + a production/semver ``EXTRA_TAG``, e.g.
+        ``jobQueueRunnerImage.tag:production-…``) drive these strategies, since the
+        manifest identity (``compute_instance_id``) and stack selection already support it.
+        Returns ``""`` when no tag is carried.
+        """
+        if self.image_tag:
+            return self.image_tag
+        for tag in self.extra_tags:
+            value = tag.get("value", "")
+            if value:
+                return value
+        return ""
+
     def validate(self) -> List[str]:
         """Validate the configuration.
-        
+
         Returns:
             List of error messages (empty if valid)
         """
         from .tag_classification import detect_tag_type, TagType
-        
+
         errors = []
         
         # Required fields
@@ -197,34 +216,40 @@ class EnvironmentConfig:
             errors.append(self._deploy_strategy_error)
 
         if self.deploy_strategy.is_wave:
+            rollout_tag = self._production_rollout_tag()
             if self.override_stack:
                 errors.append("DEPLOY_STRATEGY wave modes are incompatible with OVERRIDE_STACK")
-            elif not self.image_tag:
+            elif not rollout_tag:
                 errors.append(
-                    f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver IMAGE_TAG"
+                    f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver "
+                    f"IMAGE_TAG or EXTRA_TAG"
                 )
             else:
-                tag_type = detect_tag_type(self.image_tag)
+                tag_type = detect_tag_type(rollout_tag)
                 if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
                     errors.append(
                         f"DEPLOY_STRATEGY '{self.deploy_strategy.value}' requires a production/semver "
-                        f"IMAGE_TAG, got '{self.image_tag}'"
+                        f"IMAGE_TAG or EXTRA_TAG, got '{rollout_tag}'"
                     )
 
         # manual-per-stack (ST-4157): a production rollout (one PR per prod stack), so it
-        # requires a production/semver tag and is incompatible with OVERRIDE_STACK — same
-        # as the wave strategies (kept separate so the wave error strings stay unchanged).
+        # requires a production/semver tag (via IMAGE_TAG or an EXTRA_TAG) and is
+        # incompatible with OVERRIDE_STACK — same as the wave strategies (kept separate so
+        # its error strings can name the strategy explicitly).
         if self.deploy_strategy == DeployStrategy.MANUAL_PER_STACK:
+            rollout_tag = self._production_rollout_tag()
             if self.override_stack:
                 errors.append("DEPLOY_STRATEGY manual-per-stack is incompatible with OVERRIDE_STACK")
-            elif not self.image_tag:
-                errors.append("DEPLOY_STRATEGY 'manual-per-stack' requires a production/semver IMAGE_TAG")
+            elif not rollout_tag:
+                errors.append(
+                    "DEPLOY_STRATEGY 'manual-per-stack' requires a production/semver IMAGE_TAG or EXTRA_TAG"
+                )
             else:
-                tag_type = detect_tag_type(self.image_tag)
+                tag_type = detect_tag_type(rollout_tag)
                 if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
                     errors.append(
                         f"DEPLOY_STRATEGY 'manual-per-stack' requires a production/semver "
-                        f"IMAGE_TAG, got '{self.image_tag}'"
+                        f"IMAGE_TAG or EXTRA_TAG, got '{rollout_tag}'"
                     )
 
         return errors

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.21.0",
+    version="0.22.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/tests/test_deploy_strategy.py
+++ b/tests/test_deploy_strategy.py
@@ -102,13 +102,42 @@ def test_explicit_standard_overrides_multi_stage_flag():
     assert cfg.multi_stage is False
 
 
-def test_wave_strategy_requires_image_tag_not_just_extra_tag():
+def test_wave_strategy_ok_with_production_extra_tag_only():
+    # Extra-tags-only production rollout (empty IMAGE_TAG, production EXTRA_TAG) is valid:
+    # the manifest identity and stack selection already support it. Regression for the
+    # job-queue-daemon jobQueueRunnerImage.tag production deploy that failed validation.
     cfg = EnvironmentConfig.from_env({
         "HELM_CHART": "dummy-service", "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
-        "EXTRA_TAG1": "image.tag:production-abc", "DEPLOY_STRATEGY": "gradual",
+        "EXTRA_TAG1": "jobQueueRunnerImage.tag:production-abc", "DEPLOY_STRATEGY": "critical-manual-gate",
+    })
+    assert cfg.validate() == []
+
+
+def test_wave_strategy_rejects_dev_extra_tag_only():
+    # A dev tag (even via EXTRA_TAG) cannot drive a production wave rollout.
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+        "EXTRA_TAG1": "image.tag:dev-abc", "DEPLOY_STRATEGY": "gradual",
     })
     errors = cfg.validate()
-    assert any("IMAGE_TAG" in e for e in errors)
+    assert any("requires a production" in e for e in errors)
+
+
+def test_manual_per_stack_ok_with_production_extra_tag_only():
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+        "EXTRA_TAG1": "image.tag:production-abc", "DEPLOY_STRATEGY": "manual-per-stack",
+    })
+    assert cfg.validate() == []
+
+
+def test_manual_per_stack_rejects_dev_extra_tag_only():
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+        "EXTRA_TAG1": "image.tag:dev-abc", "DEPLOY_STRATEGY": "manual-per-stack",
+    })
+    errors = cfg.validate()
+    assert any("requires a production" in e for e in errors)
 
 
 # Task 5: resolve_wave


### PR DESCRIPTION
Fixes [ST-4198](https://linear.app/keboola/issue/ST-4198/fix-failed-deployment-of-job-queue-daemon-image-tag-update)

## Release Notes
Wave strategies (`gradual`, `critical`, `critical-manual-gate`) and `manual-per-stack` now accept an **extra-tags-only** production rollout — a deploy that carries a production/semver tag in an `EXTRA_TAG*` with an empty `IMAGE_TAG` (e.g. `jobQueueRunnerImage.tag:production-…`). Previously such a deploy was rejected at validation with `DEPLOY_STRATEGY '…' requires a production/semver IMAGE_TAG`.

## Plans for customer communication
None.

## Impact analysis
Fixes a real failed production upgrade: [kbc-stacks run 28869736747](https://github.com/keboola/kbc-stacks/actions/runs/28869736747/job/85629016064) — `job-queue-daemon` with `DEPLOY_STRATEGY=critical-manual-gate`, empty `IMAGE_TAG`, and `EXTRA_TAG1=jobQueueRunnerImage.tag:production-c9852530…` — died at input validation before doing any work.

Root cause: the wave and `manual-per-stack` validation branches in `environment.py` checked only `self.image_tag` and ignored `extra_tags`. The downstream logic already supports the extra-tags-only payload — `plan_builder._determine_strategy` resolves the production strategy from `extra_tags`, and `manifest.compute_instance_id` (ST-4190) derives a payload-based identity for it — so only the validation gate was blocking it.

Change: added `EnvironmentConfig._production_rollout_tag()` which resolves the rollout tag as `IMAGE_TAG` when set, otherwise the first non-empty `EXTRA_TAG` value (mirroring `_determine_strategy` precedence), and validate that instead of `image_tag`. A dev/canary tag (via `IMAGE_TAG` or `EXTRA_TAG`) is still correctly rejected for these production strategies.

## Change type
Bug fix (validation gate); no behavior change for existing `IMAGE_TAG`-based deploys.

## Justification
Extra-tags-only production deploys are a supported payload everywhere except this validation gate, which caused a legitimate production upgrade to fail.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.

## Tests
- `pytest tests/` — 261 passed.
- New/updated cases in `tests/test_deploy_strategy.py`: wave ok with production-only `EXTRA_TAG`, wave rejects dev-only `EXTRA_TAG`, and the same pair for `manual-per-stack`.
- Reproduced the exact failed-run env locally: validation now returns no errors.

## E2E tests
Full suite green — **all jobs passed** against this branch: [helm-image-updater-testing run 28888130462](https://github.com/keboola/helm-image-updater-testing/actions/runs/28888130462). Covers all scenarios including the ones relevant to this fix (`multi-stage-extra-tags`, `critical-manual-gate-rollout`, `manual-per-stack-rollout`, `gradual`/`critical`/`standard-rollout`) plus the promoter-drive scenarios (`gradual-same-app-serialize`/`-rebase`/`-parallel`, `failed-uat-wave2`, `dont-merge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMMkKDUAosTYfzmEcdsdcx)_