### PR TITLE
ST-4230: manifest sourcePrAuthor passthrough

### DIFF
--- a/helm_image_updater/manifest.py
+++ b/helm_image_updater/manifest.py
@@ -78,6 +78,7 @@ def build_manifest(
     waves: Dict[int, int],
     source_sha: Optional[str] = None,
     source_pr: Optional[str] = None,
+    source_pr_author: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the v1 manifest object. `waves` maps wave number -> PR number."""
     manifest: Dict[str, Any] = {
@@ -92,6 +93,8 @@ def build_manifest(
         manifest["sourceSha"] = source_sha
     if source_pr:
         manifest["sourcePr"] = source_pr
+    if source_pr_author:
+        manifest["sourcePrAuthor"] = source_pr_author
     return manifest
 
 
@@ -103,6 +106,7 @@ def build_manual_manifest(
     members,
     source_sha: Optional[str] = None,
     source_pr: Optional[str] = None,
+    source_pr_author: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the manual-per-stack (ST-4157) v1 manifest: a flat member set, NO waves.
     `members` are the member PR numbers (sorted for determinism; anchor = min)."""
@@ -118,6 +122,8 @@ def build_manual_manifest(
         manifest["sourceSha"] = source_sha
     if source_pr:
         manifest["sourcePr"] = source_pr
+    if source_pr_author:
+        manifest["sourcePrAuthor"] = source_pr_author
     return manifest
 
 
@@ -157,7 +163,7 @@ def is_manifest_v1(x: Any) -> bool:
     app = x.get("app")
     if not isinstance(app, str) or not app:
         return False
-    for opt in ("sourceSha", "sourcePr"):
+    for opt in ("sourceSha", "sourcePr", "sourcePrAuthor"):
         if opt in x and not isinstance(x[opt], str):
             return False
     # mode discriminator (ST-4157): "manual-per-stack" ⇒ flat members set, NO waves.

--- a/helm_image_updater/models.py
+++ b/helm_image_updater/models.py
@@ -107,7 +107,7 @@ class UpdatePlan:
     dry_run: bool = False
     override_stack: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
-    manifest_context: Optional[Dict[str, Any]] = None  # {app, instance_id, display_name, source_sha, source_pr}; wave mode only
+    manifest_context: Optional[Dict[str, Any]] = None  # {app, instance_id, display_name, source_sha, source_pr, source_pr_author}; wave mode only
 
     def has_changes(self) -> bool:
         """Check if there are any changes to make."""

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -519,12 +519,14 @@ def _build_manifest_context(plan: UpdatePlan) -> Dict[str, Any]:
     source = (plan.metadata or {}).get("source", {})
     source_sha = source.get("sha")
     source_pr = source.get("pr_url")
+    source_pr_author = source.get("pr_author")
     return {
         "app": plan.helm_chart,
         "instance_id": compute_instance_id(plan.helm_chart, source_sha, plan.image_tag, plan.extra_tags),
         "display_name": f"{plan.helm_chart}@{plan.image_tag}",
         "source_sha": source_sha if (source_sha and str(source_sha).lower() != "unknown") else None,
         "source_pr": source_pr or None,
+        "source_pr_author": source_pr_author or None,
     }
 
 

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -225,6 +225,7 @@ def _patch_anchor_manifest(plan: UpdatePlan, io_layer: IOLayer, wave_pr_numbers:
     manifest = build_manifest(
         app=ctx["app"], instance_id=ctx["instance_id"], display_name=ctx["display_name"],
         waves=wave_pr_numbers, source_sha=ctx.get("source_sha"), source_pr=ctx.get("source_pr"),
+        source_pr_author=ctx.get("source_pr_author"),
     )
     links_md = _wave_links_md(wave_pr_numbers)
     new_body = f"{wave0_body}\n\n{links_md}\n\n{manifest_block(manifest)}"
@@ -313,6 +314,7 @@ def _patch_manual_anchor(plan: UpdatePlan, io_layer: IOLayer, manual_pr_numbers:
     manifest = build_manual_manifest(
         app=ctx["app"], instance_id=ctx["instance_id"], display_name=ctx["display_name"],
         members=members, source_sha=ctx.get("source_sha"), source_pr=ctx.get("source_pr"),
+        source_pr_author=ctx.get("source_pr_author"),
     )
     links_md = _manual_members_md(members, anchor)
     new_body = f"{anchor_body}\n\n{links_md}\n\n{manifest_block(manifest)}"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.23.0",
+    version="0.24.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -3,8 +3,8 @@ import json
 import re
 import pytest
 from helm_image_updater.manifest import (
-    compute_instance_id, build_manifest, manifest_block, extract_instance_id,
-    is_manifest_v1, MANIFEST_HEADING,
+    compute_instance_id, build_manifest, build_manual_manifest, manifest_block,
+    extract_instance_id, is_manifest_v1, MANIFEST_HEADING,
 )
 
 # Mirror the promoter's regexes with exact-JS semantics.
@@ -121,6 +121,32 @@ def test_build_manifest_shape():
 def test_build_manifest_omits_absent_optional_source_fields():
     m = build_manifest(app="a", instance_id="a-1", display_name="d", waves={0: 1})
     assert "sourceSha" not in m and "sourcePr" not in m
+
+
+def test_build_manifest_includes_source_pr_author():
+    m = build_manifest(app="a", instance_id="a-1", display_name="a@1",
+                       waves={0: 10}, source_pr="https://github.com/keboola/x/pull/1",
+                       source_pr_author="vojtabiberle")
+    assert m["sourcePrAuthor"] == "vojtabiberle"
+
+
+def test_build_manifest_omits_source_pr_author_when_absent():
+    m = build_manifest(app="a", instance_id="a-1", display_name="a@1", waves={0: 10})
+    assert "sourcePrAuthor" not in m
+
+
+def test_build_manual_manifest_includes_source_pr_author():
+    m = build_manual_manifest(app="a", instance_id="a-1", display_name="a@1",
+                              members=[10, 11], source_pr_author="odinuv")
+    assert m["sourcePrAuthor"] == "odinuv"
+
+
+def test_is_manifest_v1_accepts_and_rejects_source_pr_author():
+    base = build_manifest(app="a", instance_id="a-1", display_name="a@1", waves={0: 10})
+    ok = dict(base, sourcePrAuthor="odinuv")
+    bad = dict(base, sourcePrAuthor=42)
+    assert is_manifest_v1(ok) is True
+    assert is_manifest_v1(bad) is False
 
 
 def test_manifest_block_is_extractable_by_promoter_regex():
@@ -293,3 +319,6 @@ class TestIsManifestV1:
 
     def test_rejects_source_pr_int(self):
         assert is_manifest_v1(_valid_manifest(sourcePr=5)) is False
+
+    def test_rejects_source_pr_author_int(self):
+        assert is_manifest_v1(_valid_manifest(sourcePrAuthor=5)) is False

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -293,6 +293,31 @@ def test_build_manifest_context_with_real_sha():
     assert ctx["source_pr"] == "https://x/pull/1"
 
 
+def test_manifest_context_extracts_pr_author():
+    plan = Mock()
+    plan.helm_chart = "connection"
+    plan.image_tag = "production-abc"
+    plan.extra_tags = None
+    plan.metadata = {"source": {"sha": "deadbeef0123FULL", "pr_url": "https://x/pull/1",
+                                 "pr_author": "zajca"}}
+
+    ctx = _build_manifest_context(plan)
+
+    assert ctx["source_pr_author"] == "zajca"
+
+
+def test_manifest_context_pr_author_none_when_absent():
+    plan = Mock()
+    plan.helm_chart = "connection"
+    plan.image_tag = "production-abc"
+    plan.extra_tags = None
+    plan.metadata = {"source": {"sha": "deadbeef0123FULL", "pr_url": "https://x/pull/1"}}
+
+    ctx = _build_manifest_context(plan)
+
+    assert ctx["source_pr_author"] is None
+
+
 def test_build_manifest_context_with_unknown_sha():
     plan = Mock()
     plan.helm_chart = "connection"


### PR DESCRIPTION
Part 2 of ST-4230 (notify the source-PR author when a release fails). Pure passthrough: HIU forwards the `source.pr_author` metadata (set upstream by kbc-stacks) into the release manifest as `sourcePrAuthor`, mirroring the existing `sourcePr` handling exactly.

## What changed
- `build_manifest` and `build_manual_manifest`: new optional `source_pr_author` kwarg → conditional `manifest["sourcePrAuthor"]`.
- `is_manifest_v1`: `sourcePrAuthor` added to the optional-string validation loop (accepts string, rejects non-string) — kept in lockstep with release-promoter's `isManifestV1`.
- `_build_manifest_context`: extracts `source.get("pr_author")` (empty → None); threaded at both `build_manifest`/`build_manual_manifest` call sites in `plan_executor.py`.
- `models.py`: manifest_context comment updated.

Additive and backward-compatible: `manifestVersion` stays `v1`; absent input ⇒ key omitted; old manifests parse unchanged; older promoter versions ignore the field.

## Tests
Strict TDD. 271 passing (7 new): builder present/absent, validator accept/reject-non-string, and concrete `_build_manifest_context` present/absent cases.

## ✅  E2E tests
https://github.com/keboola/helm-image-updater-testing/actions/runs/29404634350

Linear: https://linear.app/keboola/issue/ST-4230/notify-author-of-the-source-pr-once-release-fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)