### PR TITLE
ST-4277: rollback deploy strategy (single-wave fleet-converging fan-out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Python tool for automating image tag updates across Helm charts in different K
 - Creates pull requests with detailed descriptions
 - Production deploys are always release-promoter-managed; dev/canary/override deploys are auto-merged fast by HIU
 - Dry-run mode for testing changes
-- Promoter rollout strategies (standard 2-wave, gradual/critical waves, manual-per-stack)
+- Promoter rollout strategies (standard 2-wave, gradual/critical waves, manual-per-stack, rollback)
 - Extra tag updates for complex configurations
 - Detailed logging and error handling
 - Automatically removes ArgoCD branch overrides (`appManifestsRevision`) from `values.yaml` in the same PR
@@ -53,7 +53,7 @@ Required:
 Optional:
 
 - `DRY_RUN`: Whether to perform a dry run (default: "false")
-- `DEPLOY_STRATEGY`: Rollout strategy (default/empty: `standard`): `standard`, `gradual`, `critical`, `critical-manual-gate`, or `manual-per-stack`. See [Deploy Strategies](#deploy-strategies). Whether a PR auto-merges is decided by tag class + target stacks (see [Auto-merge](#auto-merge-and-auto-approve)), not by a knob.
+- `DEPLOY_STRATEGY`: Rollout strategy (default/empty: `standard`): `standard`, `gradual`, `critical`, `critical-manual-gate`, `manual-per-stack`, or `rollback`. See [Deploy Strategies](#deploy-strategies). Whether a PR auto-merges is decided by tag class + target stacks (see [Auto-merge](#auto-merge-and-auto-approve)), not by a knob.
 - `TARGET_PATH`: Path to the directory containing the stacks (default: ".")
 - `OVERRIDE_STACK`: Stack ID to explicitly target for the update, bypassing automatic stack selection (default: None)
 - `EXTRA_TAG1`, `EXTRA_TAG2`: Additional tags to update (format: "path:value")
@@ -86,7 +86,7 @@ Minimal usage example (always pin to a released version — see [Releasing](#rel
     helm-chart: "dummy-service"
     image-tag: "dev-b10536c41180e420eaf083451a1ddee132f512c6"
     dry-run: "false"
-    deploy-strategy: ""  # empty = standard | gradual | critical | critical-manual-gate | manual-per-stack
+    deploy-strategy: ""  # empty = standard | gradual | critical | critical-manual-gate | manual-per-stack | rollback
     override-stack: "dev-keboola-gcp-us-central1"
     extra-tag1: "agent.image.tag:dev-2.0.0"
     extra-tag2: "messenger.image.tag:dev-2.0.0"
@@ -116,7 +116,7 @@ on:
         type: boolean
         default: false
       deploy-strategy:
-        description: "Rollout strategy (empty = standard): standard | gradual | critical | critical-manual-gate | manual-per-stack"
+        description: "Rollout strategy (empty = standard): standard | gradual | critical | critical-manual-gate | manual-per-stack | rollback"
         required: false
         type: string
         default: ''
@@ -263,6 +263,7 @@ If `argocdApplication` only contained `appManifestsRevision`, the entire block i
 | empty → `standard` | promoter-managed **2-wave dev→prod**: wave 0 = all dev stacks (anchor, carries the manifest), wave 1 = all prod stacks | release-promoter merges dev → prod |
 | `gradual` · `critical` · `critical-manual-gate` | 4 unmerged **wave** PRs (waves 0–3) | release-promoter merges wave-by-wave |
 | `manual-per-stack` | **one PR per stack (dev + prod), no waves** | a human merges each in any order; release-promoter completes |
+| `rollback` | **one PR, wave 0, over every stack (dev + prod) whose `tag.yaml` differs from the target** | release-promoter merges — never auto-merged by HIU |
 
 Non-production deploys (`dev-*` / `canary-*` tags and `override-stack` targets) ignore `DEPLOY_STRATEGY` — they stay single-PR deploys and are auto-merged by HIU (see [Auto-merge](#auto-merge-and-auto-approve)).
 
@@ -279,6 +280,10 @@ Only **`PRODUCTION`** deploys are staged: a `dev-*` tag (DEV), a `canary-*` tag,
 ### Manual-per-stack (one PR per stack)
 
 An **explicit** `DEPLOY_STRATEGY=manual-per-stack` on a **`production-`/semver tag** emits a deliberately **order-independent** release: **one unmerged PR per stack** (no waves), each labelled `deploy:manual-per-stack` and auto-approved. Members are **every stack the production tag lands on — dev AND prod** (a production tag deploys to dev stacks too; only prod stacks are tag-restricted), excluding canary/e2e. A human merges each member PR in **any order**; [release-promoter](https://github.com/keboola/release-promoter) completes the release once **all** members are merged + synced (no sequencing, soak, UAT, or out-of-order hole). The **anchor** = the **lowest-numbered member PR**: it carries the `release:anchor` discovery label and the JSON **release manifest** (`mode:"manual-per-stack"` + the flat `members` list). Only `PRODUCTION` deploys are managed (`override-stack`/`canary`/`dev-*` keep their own handling). Identity is `instanceId = <app>-<image_tag>` (derived from the deployed tag(s) — see the `standard` section); a duplicate fan-out for the same `instanceId` is refused while an anchor is still open (the rerun guard scans both `release:wave:0` and `release:anchor` anchors).
+
+### Rollback (fleet-converging recovery)
+
+An **explicit** `DEPLOY_STRATEGY=rollback` on a **production/semver** tag emits a **fleet-converging, single-wave recovery deploy**: **one unmerged PR, wave 0**, over **every stack (dev + prod together)** whose `tag.yaml` currently differs from the target — set via `IMAGE_TAG` and/or `EXTRA_TAG1`/`EXTRA_TAG2`, with an optional reason (`metadata.source.reason`) rendered as a `**Reason:**` line in the PR body. The title is marked `⏪ ROLLBACK` rather than "wave N" so it reads as a rollback at a glance. Verification is **sync-only** (no UAT, no soak): [release-promoter](https://github.com/keboola/release-promoter) preempts any older in-flight release of the same app and merges the rollback PR itself — HIU never auto-merges it. `rollback` is incompatible with `override-stack` and requires a production/semver target. **Zero-diff boundary:** if the target tag is already on every stack there is no diff to deploy, and HIU hard-fails rather than opening an empty PR — cancelling queued releases without deploying anything is what `promoter:abandon-release` is for, not `rollback`.
 
 > **Prerequisite (wave strategies):** the deploy token needs `Issues: write` (PR labels go through the Issues API), and release-promoter's merge identity needs `Contents: write` + `Pull requests: write` and must be a bypass actor on the target branch's ruleset.
 

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: 'false'
   deploy-strategy:
-    description: 'Promoter deploy strategy: standard | gradual | critical | critical-manual-gate | manual-per-stack (empty = standard). Production deploys are always promoter-managed; auto-merge is decided by tag class + target stacks.'
+    description: 'Promoter deploy strategy: standard | gradual | critical | critical-manual-gate | manual-per-stack | rollback (empty = standard). Production deploys are always promoter-managed; auto-merge is decided by tag class + target stacks.'
     required: false
     default: ''
   commit-sha:

--- a/helm_image_updater/environment.py
+++ b/helm_image_updater/environment.py
@@ -80,7 +80,7 @@ class EnvironmentConfig:
                 deploy_strategy_error = (
                     f"Invalid DEPLOY_STRATEGY: '{raw_strategy}'. "
                     "Must be one of: standard, gradual, critical, "
-                    "critical-manual-gate, manual-per-stack"
+                    "critical-manual-gate, manual-per-stack, rollback"
                 )
         if env.get("MULTI_STAGE", "false").lower() == "true":
             print(
@@ -226,6 +226,28 @@ class EnvironmentConfig:
                 if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
                     errors.append(
                         f"DEPLOY_STRATEGY 'manual-per-stack' requires a production/semver "
+                        f"IMAGE_TAG or EXTRA_TAG, got '{rollout_tag}'"
+                    )
+
+        # rollback (ST-4277): 1 PR / wave 0 / all changed stacks, never auto-merged —
+        # a production rollout like the wave strategies, so it is incompatible with
+        # OVERRIDE_STACK and requires a production/semver tag (via IMAGE_TAG or an
+        # EXTRA_TAG). This is LOAD-BEARING, not hygiene: a dev-/canary-classified
+        # target would otherwise route the plan as a DEV/CANARY deploy and silently
+        # skip preemption (single auto-merged PR) -- see RFC ST-4277 §3.2.
+        if self.deploy_strategy == DeployStrategy.ROLLBACK:
+            rollout_tag = self._production_rollout_tag()
+            if self.override_stack:
+                errors.append("DEPLOY_STRATEGY rollback is incompatible with OVERRIDE_STACK")
+            elif not rollout_tag:
+                errors.append(
+                    "DEPLOY_STRATEGY 'rollback' requires a production/semver IMAGE_TAG or EXTRA_TAG"
+                )
+            else:
+                tag_type = detect_tag_type(rollout_tag)
+                if tag_type not in (TagType.PRODUCTION, TagType.SEMVER):
+                    errors.append(
+                        f"DEPLOY_STRATEGY 'rollback' requires a production/semver "
                         f"IMAGE_TAG or EXTRA_TAG, got '{rollout_tag}'"
                     )
 

--- a/helm_image_updater/manifest.py
+++ b/helm_image_updater/manifest.py
@@ -70,6 +70,30 @@ def compute_instance_id(
     return f"{_machine_safe(app)}-{'-'.join(parts)}"
 
 
+def compute_rollback_instance_id(
+    app: str,
+    image_tag: str,
+    extra_tags: Optional[List[Dict[str, str]]],
+    run_id: str,
+) -> str:
+    """ST-4277: ``<app>-rollback-<payload signature>-<gha run id>``.
+
+    The ``rollback`` token and the run-id suffix keep this DISTINCT from the ST-4190
+    ``<app>-<signature>`` id of the ORIGINAL release (a duplicate instanceId would deadlock
+    the promoter's Conflicted guard) while staying unique per dispatch. A re-run of the SAME
+    workflow run (same ``run_id``) yields the SAME id (idempotent, per §3.1); a fresh
+    dispatch (new ``run_id``) gets a new one.
+
+    Reuses `compute_instance_id`'s signature-folding logic (tag + extras -> ``path=value``)
+    so the payload portion matches exactly; only the app prefix is stripped and replaced
+    with the ``-rollback-`` marker.
+    """
+    base = compute_instance_id(app, None, image_tag, extra_tags)  # "<machine_safe(app)>-<sig>"
+    safe_app = _machine_safe(app)
+    sig = base[len(safe_app) + 1:]
+    return f"{safe_app}-rollback-{sig}-{_machine_safe(str(run_id))}"
+
+
 def build_manifest(
     *,
     app: str,
@@ -79,6 +103,8 @@ def build_manifest(
     source_sha: Optional[str] = None,
     source_pr: Optional[str] = None,
     source_pr_author: Optional[str] = None,
+    image_tag: str = "",
+    extra_tags: Optional[List[Dict[str, str]]] = None,
 ) -> Dict[str, Any]:
     """Build the v1 manifest object. `waves` maps wave number -> PR number."""
     manifest: Dict[str, Any] = {
@@ -95,6 +121,10 @@ def build_manifest(
         manifest["sourcePr"] = source_pr
     if source_pr_author:
         manifest["sourcePrAuthor"] = source_pr_author
+    if image_tag:
+        manifest["imageTag"] = image_tag
+    if extra_tags:
+        manifest["extraTags"] = [f"{t['path']}={t['value']}" for t in extra_tags]
     return manifest
 
 
@@ -107,6 +137,8 @@ def build_manual_manifest(
     source_sha: Optional[str] = None,
     source_pr: Optional[str] = None,
     source_pr_author: Optional[str] = None,
+    image_tag: str = "",
+    extra_tags: Optional[List[Dict[str, str]]] = None,
 ) -> Dict[str, Any]:
     """Build the manual-per-stack (ST-4157) v1 manifest: a flat member set, NO waves.
     `members` are the member PR numbers (sorted for determinism; anchor = min)."""
@@ -124,6 +156,10 @@ def build_manual_manifest(
         manifest["sourcePr"] = source_pr
     if source_pr_author:
         manifest["sourcePrAuthor"] = source_pr_author
+    if image_tag:
+        manifest["imageTag"] = image_tag
+    if extra_tags:
+        manifest["extraTags"] = [f"{t['path']}={t['value']}" for t in extra_tags]
     return manifest
 
 

--- a/helm_image_updater/message_generation.py
+++ b/helm_image_updater/message_generation.py
@@ -106,6 +106,19 @@ def build_tag_string(
     return f"{helm_chart}{image_tag_str}"
 
 
+def generate_rollback_pr_title(helm_chart: str, image_tag: str) -> str:
+    """PR title for a rollback release (ST-4277): ``⏪ ROLLBACK {chart} → {tag}``.
+
+    The ⏪ marker + distinct shape (no "wave N" framing -- a rollback is always exactly
+    wave 0) make it read as a rollback at a glance, distinct from every other wave PR
+    title. Falls back to "(extra-tags)" for an extra-tags-only rollback (no plain
+    image_tag), mirroring `_build_manifest_context`'s display_name fallback.
+
+    Pure function.
+    """
+    return f"⏪ ROLLBACK {helm_chart} → {image_tag or '(extra-tags)'}"
+
+
 def wave_release_search_link(
     repo_full_name: str,
     helm_chart: str,

--- a/helm_image_updater/models.py
+++ b/helm_image_updater/models.py
@@ -22,6 +22,7 @@ class DeployStrategy(Enum):
     CRITICAL = "critical"
     CRITICAL_MANUAL_GATE = "critical-manual-gate"
     MANUAL_PER_STACK = "manual-per-stack"
+    ROLLBACK = "rollback"
 
     @property
     def is_wave(self) -> bool:
@@ -29,7 +30,8 @@ class DeployStrategy(Enum):
         (`_group_changes_by_wave`). MUST exclude STANDARD — its 2-wave dev→prod
         grouping is contiguous-from-0 by construction and must not hit the
         0..3-required guard. MUST also exclude MANUAL_PER_STACK (ST-4157) — it has
-        NO waves (one PR per stack, flat member set)."""
+        NO waves (one PR per stack, flat member set). MUST also exclude ROLLBACK
+        (ST-4277) — it is 1 PR / wave 0 / all changed stacks, no 0..3 grouping."""
         return self in (
             DeployStrategy.GRADUAL,
             DeployStrategy.CRITICAL,
@@ -40,15 +42,19 @@ class DeployStrategy(Enum):
     def is_promoter_managed(self) -> bool:
         """Strategy-level CAPABILITY: EVERY strategy is promoter-capable (ST-4159 removed
         the only non-promoter strategy, cloud_multi_stage). PRs are created unmerged,
-        labelled, carrying a manifest. Superset of `is_wave` (adds STANDARD 2-wave dev→prod
-        and MANUAL_PER_STACK one-PR-per-stack).
+        labelled, carrying a manifest. Superset of `is_wave` (adds STANDARD 2-wave dev→prod,
+        MANUAL_PER_STACK one-PR-per-stack, and ROLLBACK one-PR/wave-0/all-stacks).
 
         NOTE: this is about the STRATEGY, not a given run. Whether a specific run is
         actually promoter-managed is gated at the PLAN level, not the strategy level: only
         a PRODUCTION deploy is staged — DEV/CANARY/OVERRIDE runs keep their own single-PR
         auto-merged handling. The run-time condition lives in
         `plan_builder._is_promoter_managed_standard` / `_is_promoter_managed_manual_per_stack`."""
-        return self.is_wave or self in (DeployStrategy.STANDARD, DeployStrategy.MANUAL_PER_STACK)
+        return self.is_wave or self in (
+            DeployStrategy.STANDARD,
+            DeployStrategy.MANUAL_PER_STACK,
+            DeployStrategy.ROLLBACK,
+        )
 
 
 @dataclass

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -12,7 +12,7 @@ _ryaml.preserve_quotes = True
 
 from .models import UpdatePlan, FileChange, PRPlan, UpdateStrategy, TagChange, DeployStrategy
 from .wave_planning import wave_label, deploy_label, resolve_wave
-from .manifest import compute_instance_id, extract_instance_id
+from .manifest import compute_instance_id, extract_instance_id, compute_rollback_instance_id
 from .environment import EnvironmentConfig
 from .io_layer import IOLayer
 from .tag_classification import detect_tag_type, TagType
@@ -22,6 +22,7 @@ from .message_generation import (
     generate_commit_message,
     generate_pr_title,
     generate_pr_title_prefix,
+    generate_rollback_pr_title,
     format_pr_body_with_metadata,
     wave_release_search_link,
     manual_release_search_link,
@@ -50,6 +51,19 @@ def _is_promoter_managed_manual_per_stack(config: EnvironmentConfig, plan: Updat
     their own handling and are never promoter-managed. One PR per prod stack, no waves."""
     return (
         config.deploy_strategy == DeployStrategy.MANUAL_PER_STACK
+        and plan.strategy == UpdateStrategy.PRODUCTION
+    )
+
+
+def _is_promoter_managed_rollback(config: EnvironmentConfig, plan: UpdatePlan) -> bool:
+    """True iff this run is a promoter-managed `rollback` release (ST-4277): DEPLOY_STRATEGY=
+    rollback AND a PRODUCTION-classified target. Mirrors `_is_promoter_managed_standard` /
+    `_is_promoter_managed_manual_per_stack` so the manifest/guard wiring in `prepare_plan`
+    can never diverge from `_group_changes_for_prs`'s rollback branch, which independently
+    hard-raises on a non-production target (B1 already validates this at the env layer;
+    this is defense-in-depth, not the primary check)."""
+    return (
+        config.deploy_strategy == DeployStrategy.ROLLBACK
         and plan.strategy == UpdateStrategy.PRODUCTION
     )
 
@@ -102,6 +116,19 @@ def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
     stack_changes = _calculate_all_changes(plan, io_layer)
     
     if not stack_changes:
+        if config.deploy_strategy == DeployStrategy.ROLLBACK:
+            # ST-4277 §2 boundary: a rollback whose target tag is already on every stack
+            # has an EMPTY diff -- HIU cannot open a PR, so no rollback release exists and
+            # nothing preempts. That is by design: a rollback is a deploy, not a pure
+            # cancel. Cancelling queued releases without deploying anything is what
+            # `promoter:abandon-release` is for -- surface that guidance here rather than
+            # the generic noop message.
+            raise RuntimeError(
+                f"\nError: rollback found no stacks to update for chart {plan.helm_chart} -- "
+                f"the target tag is already on every stack (zero diff). Rollback is a deploy, "
+                f"not a pure cancel: to cancel queued releases without deploying anything, "
+                f"label their anchor PRs `promoter:abandon-release`."
+            )
         raise RuntimeError(
             f"\nError: tag.yaml for chart {plan.helm_chart} does not exist in any stack or all tags are already up to date (noop change)."
         )
@@ -116,15 +143,16 @@ def prepare_plan(config: EnvironmentConfig, io_layer: IOLayer) -> UpdatePlan:
     pr_groups = _group_changes_for_prs(stack_changes, plan, config, io_layer)
 
     # Promoter-managed modes (wave strategies + promoter-managed `standard` ST-4126 +
-    # `manual-per-stack` ST-4157): derive the manifest identity, then guard against a
-    # duplicate fan-out.
+    # `manual-per-stack` ST-4157 + `rollback` ST-4277): derive the manifest identity,
+    # then guard against a duplicate fan-out.
     promoter_managed = (
         config.deploy_strategy.is_wave
         or _is_promoter_managed_standard(config, plan)
         or _is_promoter_managed_manual_per_stack(config, plan)
+        or _is_promoter_managed_rollback(config, plan)
     )
     if promoter_managed and pr_groups:
-        plan.manifest_context = _build_manifest_context(plan)
+        plan.manifest_context = _build_manifest_context(plan, config)
         if not config.dry_run:
             _guard_release_not_already_open(plan.manifest_context["instance_id"], io_layer)
 
@@ -468,6 +496,26 @@ def _group_changes_for_prs(
 ) -> List[Dict[str, Any]]:
     """Group changes into pull requests based on strategy."""
 
+    # ST-4277 rollback: ONE wave-0 PR over every changed stack (fleet-converging),
+    # never auto-merged; the promoter preempts older releases then merges it. This
+    # branch is FIRST (before is_wave) and hard-raises on a non-production target --
+    # B1's env-layer validation already rejects a non-production rollback, but this guard
+    # makes a silent fall-through to the auto-merged DEV/OVERRIDE tail below IMPOSSIBLE
+    # (a rollback that skips preemption must never exist).
+    if config.deploy_strategy == DeployStrategy.ROLLBACK:
+        if plan.strategy != UpdateStrategy.PRODUCTION:
+            raise RuntimeError(
+                f"rollback requires a production/semver-classified target (got {plan.strategy.value})"
+            )
+        return [{
+            'stacks': [sc['stack'] for sc in stack_changes],
+            'changes': stack_changes,
+            'base_branch': 'main',
+            'pr_type': 'wave',
+            'wave_number': 0,
+            'labels': [wave_label(0), deploy_label(config.deploy_strategy)],
+        }]
+
     # Promoter-managed wave strategies: one PR per wave (0..3), unmerged, labeled.
     if config.deploy_strategy.is_wave:
         return _group_changes_by_wave(stack_changes, plan, config, io_layer)
@@ -514,19 +562,44 @@ def _group_changes_for_prs(
     }]
 
 
-def _build_manifest_context(plan: UpdatePlan) -> Dict[str, Any]:
-    """Compute the wave-0 manifest's identity fields from the plan + pipeline metadata."""
+def _build_manifest_context(plan: UpdatePlan, config: Optional[EnvironmentConfig] = None) -> Dict[str, Any]:
+    """Compute the wave-0 manifest's identity fields from the plan + pipeline metadata.
+
+    ST-4277: when `config.deploy_strategy == ROLLBACK`, the display_name/instance_id use
+    the rollback-specific shape (`compute_rollback_instance_id`), which is deliberately
+    DISTINCT from the ST-4190 `<app>-<signature>` id of the original release (a duplicate
+    instanceId would deadlock the promoter's Conflicted guard). `config` is optional and
+    defaults to the non-rollback shape so existing direct-`plan`-only callers/tests are
+    unaffected.
+
+    ALL strategies (rollback included) now also carry `image_tag`/`extra_tags` in the
+    returned context, so the executor can forward them into the live manifest.
+    """
     source = (plan.metadata or {}).get("source", {})
     source_sha = source.get("sha")
     source_pr = source.get("pr_url")
     source_pr_author = source.get("pr_author")
+
+    is_rollback = config is not None and config.deploy_strategy == DeployStrategy.ROLLBACK
+    if is_rollback:
+        display_name = f"ROLLBACK {plan.helm_chart} → {plan.image_tag or '(extra-tags)'}"
+        instance_id = compute_rollback_instance_id(
+            plan.helm_chart, plan.image_tag, plan.extra_tags,
+            os.getenv("GITHUB_RUN_ID", "local"),
+        )
+    else:
+        display_name = f"{plan.helm_chart}@{plan.image_tag}"
+        instance_id = compute_instance_id(plan.helm_chart, source_sha, plan.image_tag, plan.extra_tags)
+
     return {
         "app": plan.helm_chart,
-        "instance_id": compute_instance_id(plan.helm_chart, source_sha, plan.image_tag, plan.extra_tags),
-        "display_name": f"{plan.helm_chart}@{plan.image_tag}",
+        "instance_id": instance_id,
+        "display_name": display_name,
         "source_sha": source_sha if (source_sha and str(source_sha).lower() != "unknown") else None,
         "source_pr": source_pr or None,
         "source_pr_author": source_pr_author or None,
+        "image_tag": plan.image_tag,
+        "extra_tags": plan.extra_tags,
     }
 
 
@@ -696,12 +769,18 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
     # Generate PR title
     if pr_type == 'wave':
         wave = pr_group['wave_number']
-        # The suffix is the same chart+tags string (incl. extra tags) the release
-        # search link quotes — they must match or the search finds nothing (ST-4035).
-        pr_title = (
-            f"[{plan.helm_chart} {config.deploy_strategy.value} wave {wave}] "
-            f"{build_tag_string(plan.helm_chart, plan.image_tag, plan.extra_tags)}"
-        )
+        if config.deploy_strategy == DeployStrategy.ROLLBACK:
+            # ST-4277: a rollback gets its own title shape -- no "wave N" framing (a
+            # rollback is always exactly wave 0) and a ⏪ marker so it reads as a
+            # rollback at a glance, distinct from every other wave PR title.
+            pr_title = generate_rollback_pr_title(plan.helm_chart, plan.image_tag)
+        else:
+            # The suffix is the same chart+tags string (incl. extra tags) the release
+            # search link quotes — they must match or the search finds nothing (ST-4035).
+            pr_title = (
+                f"[{plan.helm_chart} {config.deploy_strategy.value} wave {wave}] "
+                f"{build_tag_string(plan.helm_chart, plan.image_tag, plan.extra_tags)}"
+            )
     elif pr_type == 'manual':
         stack = pr_group['stacks'][0]
         pr_title = (
@@ -737,6 +816,14 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
         metadata=plan.metadata,
         removed_overrides=removed_overrides,
     )
+
+    # ST-4277: rollback PR body gets an explicit reason line when the dispatcher supplied
+    # metadata.source.reason. This key is read ONLY by the rollback template (RFC §2) --
+    # a non-rollback PR must never render it even if present.
+    if config.deploy_strategy == DeployStrategy.ROLLBACK:
+        reason = (plan.metadata or {}).get("source", {}).get("reason")
+        if reason:
+            pr_body += f"\n\n**Reason:** {reason}"
 
     # Wave PRs: link a PR search that finds every wave PR of this release. The link
     # quotes the full chart+tags string (incl. extra tags), which every wave PR title
@@ -807,6 +894,10 @@ def _should_auto_merge(plan: UpdatePlan, pr_type: str, stacks: List[str]) -> boo
     The stack check is defense-in-depth: validate() rejects a dev/canary tag on a prod
     stack, but if one ever slips through we still must not auto-merge it. `not is_production`
     covers dev + e2e + canary and fails safe for a new/unknown stack name.
+
+    ST-4277: a `rollback` release ALSO hits this via `pr_type == 'wave'` (its grouping
+    always emits pr_type='wave', wave_number=0) -- it is a production-class path where
+    release-promoter (not HIU) owns the merge, exactly like every other wave/manual PR.
     """
     if pr_type in ('wave', 'manual'):
         print(f"    🧠 Auto-merge: FALSE (pr_type={pr_type}; release-promoter / human merges)")

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -588,7 +588,11 @@ def _build_manifest_context(plan: UpdatePlan, config: Optional[EnvironmentConfig
             os.getenv("GITHUB_RUN_ID", "local"),
         )
     else:
-        display_name = f"{plan.helm_chart}@{plan.image_tag}"
+        # ST-4277: use build_tag_string (the same chart+tags renderer the PR title +
+        # release-search link use) rather than a hand-built `<app>@<tag>` — the latter
+        # produced a truncated `<app>@` for an extra-tags-only deploy (empty image_tag),
+        # dropping the extra tags from the promoter's Slack notifications.
+        display_name = build_tag_string(plan.helm_chart, plan.image_tag, plan.extra_tags)
         instance_id = compute_instance_id(plan.helm_chart, source_sha, plan.image_tag, plan.extra_tags)
 
     return {

--- a/helm_image_updater/plan_builder.py
+++ b/helm_image_updater/plan_builder.py
@@ -832,7 +832,11 @@ def _create_pr_plan(pr_group: Dict[str, Any], plan: UpdatePlan, config: Environm
     # Wave PRs: link a PR search that finds every wave PR of this release. The link
     # quotes the full chart+tags string (incl. extra tags), which every wave PR title
     # embeds verbatim (see build_tag_string above); no PR numbers needed.
-    if pr_type == 'wave':
+    # ST-4277: NOT for rollback — its title is `⏪ ROLLBACK <chart> → <tag>`, which does
+    # NOT embed build_tag_string, so the quoted-phrase search would never match the
+    # rollback PR (and could match the ORIGINAL release's wave PRs). A rollback is a
+    # single wave-0 PR anyway, so an "all waves" link is meaningless.
+    if pr_type == 'wave' and config.deploy_strategy != DeployStrategy.ROLLBACK:
         search_link = wave_release_search_link(
             GITHUB_REPO, plan.helm_chart, plan.image_tag, plan.extra_tags
         )

--- a/helm_image_updater/plan_executor.py
+++ b/helm_image_updater/plan_executor.py
@@ -226,6 +226,7 @@ def _patch_anchor_manifest(plan: UpdatePlan, io_layer: IOLayer, wave_pr_numbers:
         app=ctx["app"], instance_id=ctx["instance_id"], display_name=ctx["display_name"],
         waves=wave_pr_numbers, source_sha=ctx.get("source_sha"), source_pr=ctx.get("source_pr"),
         source_pr_author=ctx.get("source_pr_author"),
+        image_tag=ctx.get("image_tag", ""), extra_tags=ctx.get("extra_tags"),
     )
     links_md = _wave_links_md(wave_pr_numbers)
     new_body = f"{wave0_body}\n\n{links_md}\n\n{manifest_block(manifest)}"
@@ -315,6 +316,7 @@ def _patch_manual_anchor(plan: UpdatePlan, io_layer: IOLayer, manual_pr_numbers:
         app=ctx["app"], instance_id=ctx["instance_id"], display_name=ctx["display_name"],
         members=members, source_sha=ctx.get("source_sha"), source_pr=ctx.get("source_pr"),
         source_pr_author=ctx.get("source_pr_author"),
+        image_tag=ctx.get("image_tag", ""), extra_tags=ctx.get("extra_tags"),
     )
     links_md = _manual_members_md(members, anchor)
     new_body = f"{anchor_body}\n\n{links_md}\n\n{manifest_block(manifest)}"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.25.0",
+    version="0.26.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -322,3 +322,40 @@ class TestIsManifestV1:
 
     def test_rejects_source_pr_author_int(self):
         assert is_manifest_v1(_valid_manifest(sourcePrAuthor=5)) is False
+
+
+# ---------------------------------------------------------------------------
+# imageTag / extraTags — additive optional fields on ALL strategies (ST-4277 §3.2)
+# ---------------------------------------------------------------------------
+
+def test_build_manifest_carries_image_tag_and_extra_tags():
+    m = build_manifest(app="c", instance_id="i", display_name="d", waves={0: 1},
+                       image_tag="production-1.2.3", extra_tags=[{"path": "a.b", "value": "1"}])
+    assert m["imageTag"] == "production-1.2.3"
+    assert m["extraTags"] == ["a.b=1"]
+
+
+def test_build_manifest_omits_absent_tags():
+    m = build_manifest(app="c", instance_id="i", display_name="d", waves={0: 1})
+    assert "imageTag" not in m
+    assert "extraTags" not in m
+
+
+def test_build_manifest_omits_empty_tags():
+    m = build_manifest(app="c", instance_id="i", display_name="d", waves={0: 1},
+                       image_tag="", extra_tags=[])
+    assert "imageTag" not in m
+    assert "extraTags" not in m
+
+
+def test_build_manual_manifest_carries_image_tag_and_extra_tags():
+    m = build_manual_manifest(app="c", instance_id="i", display_name="d", members=[10, 11],
+                              image_tag="production-1.2.3", extra_tags=[{"path": "a.b", "value": "1"}])
+    assert m["imageTag"] == "production-1.2.3"
+    assert m["extraTags"] == ["a.b=1"]
+
+
+def test_build_manual_manifest_omits_absent_tags():
+    m = build_manual_manifest(app="c", instance_id="i", display_name="d", members=[10, 11])
+    assert "imageTag" not in m
+    assert "extraTags" not in m

--- a/tests/test_plan_executor.py
+++ b/tests/test_plan_executor.py
@@ -120,6 +120,65 @@ def test_executor_standard_1wave_manifest_shape():
     assert manifest["anchorWave"] == 0
 
 
+def test_executor_wave_manifest_includes_image_tag_and_extra_tags():
+    """ST-4277 B3: the wave-0 build_manifest call site must forward manifest_context's
+    image_tag/extra_tags so they reach the live anchor PR body (imageTag/extraTags)."""
+    plan = _wave_plan()
+    plan.manifest_context["image_tag"] = "production-abc"
+    plan.manifest_context["extra_tags"] = [{"path": "foo.bar", "value": "baz"}]
+    io = MagicMock()
+    io.create_branch_commit_and_pr.side_effect = [
+        f"https://github.com/keboola/kbc-stacks/pull/{10 + w}" for w in range(4)
+    ]
+    execute_plan(plan, io)
+
+    io.update_pull_request_body.assert_called_once()
+    (_, new_body), _ = io.update_pull_request_body.call_args
+    manifest = json.loads(JSON_FENCE_RE.findall(new_body)[0])
+    assert manifest["imageTag"] == "production-abc"
+    assert manifest["extraTags"] == ["foo.bar=baz"]
+
+
+def _manual_manifest_plan():
+    """A manual-per-stack style plan (2 member PRs, no waves)."""
+    plan = UpdatePlan(strategy=UpdateStrategy.PRODUCTION, helm_chart="connection",
+                      image_tag="production-abc")
+    plan.manifest_context = {"app": "connection", "instance_id": "connection-manual-abc",
+                             "display_name": "connection@production-abc",
+                             "source_sha": "abc", "source_pr": None,
+                             "image_tag": "production-abc",
+                             "extra_tags": [{"path": "foo.bar", "value": "baz"}]}
+    for i, stack in enumerate(["s0", "s1"]):
+        fc = FileChange(file_path=f"{stack}/connection/tag.yaml", old_content="a",
+                        new_content="b", change_description="d")
+        plan.file_changes.append(fc)
+        plan.pr_plans.append(PRPlan(branch_name=f"connection-manual-{stack}-production-abc-xxxx",
+                                    pr_title=f"m{i}", pr_body=f"BODY{i}", base_branch="main",
+                                    auto_merge=False, files_to_commit=[fc.file_path],
+                                    commit_message="c", labels=["deploy:manual-per-stack"],
+                                    manual_member=True))
+    return plan
+
+
+def test_executor_manual_manifest_includes_image_tag_and_extra_tags():
+    """ST-4277 B3: the manual-per-stack build_manual_manifest call site must ALSO forward
+    manifest_context's image_tag/extra_tags -- both call sites, or the fields never reach
+    a live PR body depending on which grouping mode produced the release."""
+    plan = _manual_manifest_plan()
+    io = MagicMock()
+    io.create_branch_commit_and_pr.side_effect = [
+        "https://github.com/keboola/kbc-stacks/pull/30",
+        "https://github.com/keboola/kbc-stacks/pull/31",
+    ]
+    execute_plan(plan, io)
+
+    io.update_pull_request_body.assert_called_once()
+    (_, new_body), _ = io.update_pull_request_body.call_args
+    manifest = json.loads(JSON_FENCE_RE.findall(new_body)[0])
+    assert manifest["imageTag"] == "production-abc"
+    assert manifest["extraTags"] == ["foo.bar=baz"]
+
+
 def test_executor_no_patch_when_not_wave_mode():
     plan = UpdatePlan(strategy=UpdateStrategy.PRODUCTION, helm_chart="connection", image_tag="t")
     fc = FileChange(file_path="s/connection/tag.yaml", old_content="a", new_content="b", change_description="d")

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,0 +1,65 @@
+"""Tests for the `rollback` DEPLOY_STRATEGY (ST-4277, Task B1).
+
+Mirrors the fixtures/helpers used in tests/test_deploy_strategy.py.
+"""
+
+from helm_image_updater.environment import EnvironmentConfig
+from helm_image_updater.models import DeployStrategy
+
+
+def _base_env(**overrides):
+    env = {
+        "HELM_CHART": "dummy-service",
+        "IMAGE_TAG": "production-abc123",
+        "GH_TOKEN": "t",
+        "GH_APPROVE_TOKEN": "a",
+    }
+    env.update(overrides)
+    return env
+
+
+def test_rollback_enum_parses():
+    assert DeployStrategy("rollback") is DeployStrategy.ROLLBACK
+    assert not DeployStrategy.ROLLBACK.is_wave
+    assert DeployStrategy.ROLLBACK.is_promoter_managed
+
+
+def test_deploy_strategy_parses_rollback():
+    cfg = EnvironmentConfig.from_env(_base_env(DEPLOY_STRATEGY="rollback"))
+    assert cfg.deploy_strategy == DeployStrategy.ROLLBACK
+
+
+def test_rollback_ok_with_production_tag():
+    cfg = EnvironmentConfig.from_env(_base_env(IMAGE_TAG="production-abc", DEPLOY_STRATEGY="rollback"))
+    assert cfg.validate() == []
+
+
+def test_rollback_requires_production_tag():
+    cfg = EnvironmentConfig.from_env(_base_env(IMAGE_TAG="dev-abc", DEPLOY_STRATEGY="rollback"))
+    errors = cfg.validate()
+    assert any("requires a production" in e for e in errors)
+
+
+def test_rollback_rejects_override_stack():
+    cfg = EnvironmentConfig.from_env(
+        _base_env(DEPLOY_STRATEGY="rollback", OVERRIDE_STACK="kbc-us-east-1")
+    )
+    errors = cfg.validate()
+    assert any("OVERRIDE_STACK" in e for e in errors)
+
+
+def test_rollback_ok_with_production_extra_tag_only():
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+        "EXTRA_TAG1": "image.tag:production-abc", "DEPLOY_STRATEGY": "rollback",
+    })
+    assert cfg.validate() == []
+
+
+def test_rollback_rejects_dev_extra_tag_only():
+    cfg = EnvironmentConfig.from_env({
+        "HELM_CHART": "dummy-service", "GH_TOKEN": "t", "GH_APPROVE_TOKEN": "a",
+        "EXTRA_TAG1": "image.tag:dev-abc", "DEPLOY_STRATEGY": "rollback",
+    })
+    errors = cfg.validate()
+    assert any("requires a production" in e for e in errors)

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,9 +1,11 @@
-"""Tests for the `rollback` DEPLOY_STRATEGY (ST-4277, Task B1).
+"""Tests for the `rollback` DEPLOY_STRATEGY (ST-4277, Task B1)
+and the rollback instanceId computation (ST-4277, Task B2).
 
 Mirrors the fixtures/helpers used in tests/test_deploy_strategy.py.
 """
 
 from helm_image_updater.environment import EnvironmentConfig
+from helm_image_updater.manifest import compute_rollback_instance_id
 from helm_image_updater.models import DeployStrategy
 
 
@@ -63,3 +65,35 @@ def test_rollback_rejects_dev_extra_tag_only():
     })
     errors = cfg.validate()
     assert any("requires a production" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# compute_rollback_instance_id (ST-4277, Task B2)
+# ---------------------------------------------------------------------------
+
+def test_rollback_instance_id_shape():
+    # <app>-rollback-<sig>-<run_id>, sig = the ST-4190 compute_instance_id signature
+    # (tag/extras) minus the app prefix. Distinct from the plain <app>-<tag> id so the
+    # rollback release never collides with the original release's instanceId.
+    assert compute_rollback_instance_id("connection", "production-1.2.3", [], "16234567890") \
+        == "connection-rollback-production-1.2.3-16234567890"
+
+
+def test_rollback_instance_id_extras_only():
+    # Empty tag (extra-tags-only rollback) folds the extras exactly like compute_instance_id.
+    rid = compute_rollback_instance_id("connection", "", [{"path": "a.b", "value": "1"}], "99")
+    assert rid == "connection-rollback-a.b=1-99"
+
+
+def test_rollback_instance_id_idempotent_same_run_id():
+    # A re-run of the SAME workflow run (same run_id) keeps the same id.
+    a = compute_rollback_instance_id("connection", "production-1.2.3", [], "111")
+    b = compute_rollback_instance_id("connection", "production-1.2.3", [], "111")
+    assert a == b
+
+
+def test_rollback_instance_id_distinct_per_run_id():
+    # A fresh dispatch (different run_id) gets a new id, even for the same payload.
+    a = compute_rollback_instance_id("connection", "production-1.2.3", [], "111")
+    b = compute_rollback_instance_id("connection", "production-1.2.3", [], "222")
+    assert a != b

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -239,6 +239,28 @@ def test_rollback_pr_body_omits_reason_when_absent():
     assert "**Reason:**" not in pr_plan.pr_body
 
 
+def test_rollback_pr_body_omits_wave_search_link():
+    """ST-4277 (Copilot review r3613187991): the 'All wave PRs' search link quotes
+    build_tag_string, which the ⏪ ROLLBACK title does NOT embed — so the quoted-phrase
+    search would never match the rollback PR (and could match the ORIGINAL release's wave
+    PRs, which DO embed chart@tag). A rollback is a single wave-0 PR anyway, so an
+    'all waves' link is meaningless. Skip it for rollback."""
+    plan = _rollback_plan()
+    config = _rollback_config()
+    pr_group = {
+        "stacks": ["dev1", "prod1", "prod2"],
+        "changes": [_stack_change(s) for s in ["dev1", "prod1", "prod2"]],
+        "base_branch": "main",
+        "pr_type": "wave",
+        "wave_number": 0,
+        "labels": [wave_label(0), deploy_label(DeployStrategy.ROLLBACK)],
+    }
+    pr_plan = _create_pr_plan(pr_group, plan, config)
+
+    assert "All wave PRs of this release" not in pr_plan.pr_body
+    assert "/pulls?q=" not in pr_plan.pr_body
+
+
 # --- (c) manifest context: rollback display_name/instance_id + image_tag/extra_tags
 
 

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -287,7 +287,9 @@ def test_non_rollback_manifest_context_carries_image_tag_and_extra_tags():
 
     assert ctx["image_tag"] == "production-abc"
     assert ctx["extra_tags"] == [{"path": "a.b", "value": "1"}]
-    assert ctx["display_name"] == "connection@production-abc"  # unchanged non-rollback shape
+    # ST-4277: display_name now uses build_tag_string, so extra tags appear too
+    # (was "connection@production-abc", which dropped the extra tags — the bug fixed here).
+    assert ctx["display_name"] == "connection@production-abc a.b@1"
 
 
 # --- (d) zero-diff: rollback-specific error mentions promoter:abandon-release -----

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,12 +1,30 @@
-"""Tests for the `rollback` DEPLOY_STRATEGY (ST-4277, Task B1)
-and the rollback instanceId computation (ST-4277, Task B2).
+"""Tests for the `rollback` DEPLOY_STRATEGY (ST-4277, Task B1),
+the rollback instanceId computation (ST-4277, Task B2), and the rollback
+plan itself -- grouping, PR plan, manifest wiring, zero-diff guard (Task B3).
 
-Mirrors the fixtures/helpers used in tests/test_deploy_strategy.py.
+Mirrors the fixtures/helpers used in tests/test_deploy_strategy.py and the
+grouping/PR-plan style of tests/test_standard_2wave.py.
 """
+
+import base64
+import json
+import os
+from unittest.mock import Mock
+
+import pytest
 
 from helm_image_updater.environment import EnvironmentConfig
 from helm_image_updater.manifest import compute_rollback_instance_id
-from helm_image_updater.models import DeployStrategy
+from helm_image_updater.models import DeployStrategy, UpdateStrategy
+from helm_image_updater.io_layer import IOLayer
+from helm_image_updater.plan_builder import (
+    prepare_plan,
+    _group_changes_for_prs,
+    _build_manifest_context,
+    _create_pr_plan,
+    _guard_release_not_already_open,
+)
+from helm_image_updater.wave_planning import wave_label, deploy_label
 
 
 def _base_env(**overrides):
@@ -97,3 +115,313 @@ def test_rollback_instance_id_distinct_per_run_id():
     a = compute_rollback_instance_id("connection", "production-1.2.3", [], "111")
     b = compute_rollback_instance_id("connection", "production-1.2.3", [], "222")
     assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Task B3: the rollback plan -- grouping, PR plan, manifest wiring, guard,
+# zero-diff error.
+# ---------------------------------------------------------------------------
+
+
+def _stack_change(stack):
+    return {"stack": stack, "file_change": Mock(), "changes": []}
+
+
+def _rollback_config():
+    config = Mock()
+    config.deploy_strategy = DeployStrategy.ROLLBACK
+    return config
+
+
+def _rollback_plan(**overrides):
+    plan = Mock()
+    plan.strategy = UpdateStrategy.PRODUCTION
+    plan.helm_chart = "dummy-service"
+    plan.image_tag = "production-rollback-tag"
+    plan.extra_tags = []
+    plan.metadata = {}
+    for k, v in overrides.items():
+        setattr(plan, k, v)
+    return plan
+
+
+# --- (a) grouping: ONE wave-0 PR over every changed stack, labelled ----------------
+
+
+def test_rollback_grouping_is_one_pr_wave0_all_stacks():
+    stacks = ["dev1", "prod1", "prod2"]
+    changes = [_stack_change(s) for s in stacks]
+    groups = _group_changes_for_prs(changes, _rollback_plan(), _rollback_config(), Mock())
+
+    assert len(groups) == 1
+    group = groups[0]
+    assert group["pr_type"] == "wave"
+    assert group["wave_number"] == 0
+    assert group["labels"] == [wave_label(0), deploy_label(DeployStrategy.ROLLBACK)]
+    assert group["labels"] == ["release:wave:0", "deploy:rollback"]
+    assert sorted(group["stacks"]) == sorted(stacks)
+    assert group["base_branch"] == "main"
+
+
+def test_rollback_grouping_hard_raises_on_non_production_target():
+    # Defensive: B1 already rejects a non-production rollback at the env layer, but the
+    # grouping branch must ALSO hard-raise -- a silent fall-through to the auto-merged
+    # DEV/OVERRIDE tail must be impossible.
+    plan = _rollback_plan(strategy=UpdateStrategy.DEV)
+    changes = [_stack_change("dev1")]
+    with pytest.raises(RuntimeError, match="requires a production"):
+        _group_changes_for_prs(changes, plan, _rollback_config(), Mock())
+
+
+def test_rollback_grouping_is_first_branch_before_is_wave():
+    # config.deploy_strategy.is_wave is False for ROLLBACK (models.py), so this also
+    # proves the rollback branch does not depend on is_wave routing at all.
+    assert DeployStrategy.ROLLBACK.is_wave is False
+    stacks = ["dev1", "prod1", "prod2"]
+    changes = [_stack_change(s) for s in stacks]
+    groups = _group_changes_for_prs(changes, _rollback_plan(), _rollback_config(), Mock())
+    assert len(groups) == 1
+    assert groups[0]["wave_number"] == 0
+
+
+# --- (b) PR plan: no auto-merge, ⏪ ROLLBACK title, reason in body -----------------
+
+
+def test_rollback_pr_plan_never_auto_merges_and_has_rollback_title():
+    plan = _rollback_plan()
+    config = _rollback_config()
+    pr_group = {
+        "stacks": ["dev1", "prod1", "prod2"],
+        "changes": [_stack_change(s) for s in ["dev1", "prod1", "prod2"]],
+        "base_branch": "main",
+        "pr_type": "wave",
+        "wave_number": 0,
+        "labels": [wave_label(0), deploy_label(DeployStrategy.ROLLBACK)],
+    }
+    pr_plan = _create_pr_plan(pr_group, plan, config)
+
+    assert pr_plan.auto_merge is False
+    assert pr_plan.pr_title.startswith("⏪ ROLLBACK")
+    assert plan.helm_chart in pr_plan.pr_title
+    assert plan.image_tag in pr_plan.pr_title
+
+
+def test_rollback_pr_body_contains_reason_when_set():
+    plan = _rollback_plan(metadata={"source": {"reason": "prod-1.2.3 broke checkout"}})
+    config = _rollback_config()
+    pr_group = {
+        "stacks": ["dev1", "prod1", "prod2"],
+        "changes": [_stack_change(s) for s in ["dev1", "prod1", "prod2"]],
+        "base_branch": "main",
+        "pr_type": "wave",
+        "wave_number": 0,
+        "labels": [wave_label(0), deploy_label(DeployStrategy.ROLLBACK)],
+    }
+    pr_plan = _create_pr_plan(pr_group, plan, config)
+
+    assert "prod-1.2.3 broke checkout" in pr_plan.pr_body
+    assert "**Reason:**" in pr_plan.pr_body
+
+
+def test_rollback_pr_body_omits_reason_when_absent():
+    plan = _rollback_plan(metadata={})
+    config = _rollback_config()
+    pr_group = {
+        "stacks": ["dev1"],
+        "changes": [_stack_change("dev1")],
+        "base_branch": "main",
+        "pr_type": "wave",
+        "wave_number": 0,
+        "labels": [wave_label(0), deploy_label(DeployStrategy.ROLLBACK)],
+    }
+    pr_plan = _create_pr_plan(pr_group, plan, config)
+
+    assert "**Reason:**" not in pr_plan.pr_body
+
+
+# --- (c) manifest context: rollback display_name/instance_id + image_tag/extra_tags
+
+
+def test_rollback_manifest_context_shape(monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "16234567890")
+    plan = _rollback_plan(
+        helm_chart="connection",
+        image_tag="production-1.2.3",
+        extra_tags=[],
+        metadata={"source": {"pr_author": "zajca"}},
+    )
+    config = _rollback_config()
+
+    ctx = _build_manifest_context(plan, config)
+
+    assert ctx["display_name"] == "ROLLBACK connection → production-1.2.3"
+    assert ctx["instance_id"] == compute_rollback_instance_id(
+        "connection", "production-1.2.3", [], "16234567890"
+    )
+    assert ctx["source_pr_author"] == "zajca"
+    assert ctx["image_tag"] == "production-1.2.3"
+    assert ctx["extra_tags"] == []
+
+
+def test_rollback_manifest_context_falls_back_to_local_run_id(monkeypatch):
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+    plan = _rollback_plan(helm_chart="connection", image_tag="production-1.2.3", extra_tags=[])
+    config = _rollback_config()
+
+    ctx = _build_manifest_context(plan, config)
+
+    assert ctx["instance_id"] == compute_rollback_instance_id(
+        "connection", "production-1.2.3", [], "local"
+    )
+
+
+def test_non_rollback_manifest_context_carries_image_tag_and_extra_tags():
+    # (ALL strategies) get the two new context keys, not just rollback.
+    plan = Mock()
+    plan.helm_chart = "connection"
+    plan.image_tag = "production-abc"
+    plan.extra_tags = [{"path": "a.b", "value": "1"}]
+    plan.metadata = {}
+
+    ctx = _build_manifest_context(plan)  # no config -> non-rollback shape (back-compat)
+
+    assert ctx["image_tag"] == "production-abc"
+    assert ctx["extra_tags"] == [{"path": "a.b", "value": "1"}]
+    assert ctx["display_name"] == "connection@production-abc"  # unchanged non-rollback shape
+
+
+# --- (d) zero-diff: rollback-specific error mentions promoter:abandon-release -----
+
+
+def _make_tag_yaml(path, tag="production-1.2.3"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(f"image:\n  tag: {tag}\n")
+
+
+@pytest.fixture
+def rollback_stacks(tmp_path):
+    """One real prod stack already on the target tag -> zero diff for a rollback."""
+    prod = tmp_path / "kbc-us-east-1"
+    _make_tag_yaml(prod / "test-chart" / "tag.yaml", tag="production-1.2.3")
+    return {"base_dir": tmp_path, "prod": prod}
+
+
+def _io_layer(dry_run=True):
+    return IOLayer(Mock(), Mock(), dry_run=dry_run, approve_github_repo=Mock())
+
+
+def test_rollback_zero_diff_raises_abandon_release_guidance(rollback_stacks):
+    os.chdir(rollback_stacks["base_dir"])
+    env = {
+        "HELM_CHART": "test-chart",
+        "IMAGE_TAG": "production-1.2.3",  # already the tag on disk -> zero diff
+        "GH_TOKEN": "t",
+        "GH_APPROVE_TOKEN": "a",
+        "DEPLOY_STRATEGY": "rollback",
+        "DRY_RUN": "true",
+        "TARGET_PATH": str(rollback_stacks["base_dir"]),
+    }
+    config = EnvironmentConfig.from_env(env)
+    assert config.deploy_strategy == DeployStrategy.ROLLBACK
+
+    with pytest.raises(RuntimeError, match="promoter:abandon-release"):
+        prepare_plan(config, _io_layer())
+
+
+def test_non_rollback_zero_diff_keeps_existing_message(rollback_stacks):
+    # Non-rollback zero-diff must NOT mention promoter:abandon-release -- the existing
+    # noop message is unchanged.
+    os.chdir(rollback_stacks["base_dir"])
+    env = {
+        "HELM_CHART": "test-chart",
+        "IMAGE_TAG": "production-1.2.3",  # already the tag on disk -> zero diff
+        "GH_TOKEN": "t",
+        "GH_APPROVE_TOKEN": "a",
+        "DEPLOY_STRATEGY": "standard",
+        "DRY_RUN": "true",
+        "TARGET_PATH": str(rollback_stacks["base_dir"]),
+    }
+    config = EnvironmentConfig.from_env(env)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        prepare_plan(config, _io_layer())
+    assert "promoter:abandon-release" not in str(exc_info.value)
+    assert "noop change" in str(exc_info.value)
+
+
+# --- (e) prepare_plan wires manifest_context + idempotency guard for rollback ------
+
+
+@pytest.fixture
+def rollback_change_stacks(tmp_path):
+    """A real prod stack that DIFFERS from the target tag -> a genuine rollback diff."""
+    prod = tmp_path / "kbc-us-east-1"
+    _make_tag_yaml(prod / "test-chart" / "tag.yaml", tag="production-old")
+    return {"base_dir": tmp_path, "prod": prod}
+
+
+def test_prepare_plan_rollback_sets_manifest_context_one_wave0_pr(rollback_change_stacks):
+    os.chdir(rollback_change_stacks["base_dir"])
+    env = {
+        "HELM_CHART": "test-chart",
+        "IMAGE_TAG": "production-new",
+        "GH_TOKEN": "t",
+        "GH_APPROVE_TOKEN": "a",
+        "DEPLOY_STRATEGY": "rollback",
+        "DRY_RUN": "true",
+        "TARGET_PATH": str(rollback_change_stacks["base_dir"]),
+    }
+    config = EnvironmentConfig.from_env(env)
+    assert config.validate() == []
+
+    plan = prepare_plan(config, _io_layer())
+
+    assert plan.manifest_context is not None
+    assert plan.manifest_context["instance_id"].startswith("test-chart-rollback-")
+    assert len(plan.pr_plans) == 1
+    assert plan.pr_plans[0].wave_number == 0
+    assert plan.pr_plans[0].auto_merge is False
+    assert plan.pr_plans[0].labels == ["release:wave:0", "deploy:rollback"]
+
+
+def test_prepare_plan_rollback_invokes_idempotency_guard(rollback_change_stacks, monkeypatch):
+    monkeypatch.setenv("GITHUB_RUN_ID", "999")
+    os.chdir(rollback_change_stacks["base_dir"])
+    env = {
+        "HELM_CHART": "test-chart",
+        "IMAGE_TAG": "production-new",
+        "GH_TOKEN": "t",
+        "GH_APPROVE_TOKEN": "a",
+        "DEPLOY_STRATEGY": "rollback",
+        "DRY_RUN": "false",
+        "TARGET_PATH": str(rollback_change_stacks["base_dir"]),
+    }
+    config = EnvironmentConfig.from_env(env)
+
+    rollback_id = compute_rollback_instance_id("test-chart", "production-new", [], "999")
+    from helm_image_updater.manifest import build_manifest, manifest_block
+
+    anchor_body = manifest_block(build_manifest(
+        app="test-chart", instance_id=rollback_id, display_name="ROLLBACK test-chart → production-new",
+        waves={0: 9},
+    ))
+
+    io = IOLayer(Mock(), Mock(), dry_run=False, approve_github_repo=Mock())
+    io.find_open_release_anchors = Mock(return_value=[(9, anchor_body)])
+
+    with pytest.raises(RuntimeError, match="already has an open anchor"):
+        prepare_plan(config, io)
+
+
+def test_guard_called_directly_with_rollback_instance_id():
+    # Direct unit check that _guard_release_not_already_open works against a rollback
+    # id shape the same as any other instanceId (no rollback-specific behavior needed).
+    rollback_id = compute_rollback_instance_id("test-chart", "production-new", [], "999")
+    io = Mock()
+    io.find_open_release_anchors.return_value = [(9, f"```json\n{{\"manifestVersion\": \"v1\", "
+                                                       f"\"instanceId\": \"{rollback_id}\", "
+                                                       f"\"displayName\": \"x\", \"app\": \"test-chart\", "
+                                                       f"\"anchorWave\": 0, \"waves\": {{\"0\": 9}}}}\n```")]
+    with pytest.raises(RuntimeError, match="already has an open anchor"):
+        _guard_release_not_already_open(rollback_id, io)

--- a/tests/test_wave_grouping.py
+++ b/tests/test_wave_grouping.py
@@ -351,6 +351,37 @@ def test_build_manifest_context_no_source():
     assert ctx["instance_id"] == ctx2["instance_id"]
 
 
+def test_build_manifest_context_extra_tags_only_display_name():
+    """ST-4277 bugfix: an extra-tags-only deploy (empty image_tag) must NOT render a
+    truncated `<app>@` display_name that drops the extra tags — the promoter posts
+    displayName verbatim into Slack ("Release job-queue-daemon@ complete"). Use
+    build_tag_string so the extra tags appear, matching the PR title + search link."""
+    plan = Mock()
+    plan.helm_chart = "job-queue-daemon"
+    plan.image_tag = ""
+    plan.extra_tags = [{"path": "jobqueuelogshandlerimage.tag", "value": "production-900c37b"}]
+    plan.metadata = {"source": {}}
+
+    ctx = _build_manifest_context(plan)
+
+    assert ctx["display_name"] == "job-queue-daemon jobqueuelogshandlerimage.tag@production-900c37b"
+    assert not ctx["display_name"].endswith("@")
+
+
+def test_build_manifest_context_image_tag_plus_extra_tags_display_name():
+    """A deploy carrying BOTH an image tag and extra tags shows both (previously the
+    extra tags were dropped from display_name entirely)."""
+    plan = Mock()
+    plan.helm_chart = "connection"
+    plan.image_tag = "production-abc"
+    plan.extra_tags = [{"path": "sidecar.tag", "value": "1.2.3"}]
+    plan.metadata = {"source": {}}
+
+    ctx = _build_manifest_context(plan)
+
+    assert ctx["display_name"] == "connection@production-abc sidecar.tag@1.2.3"
+
+
 # ---------------------------------------------------------------------------
 # (4b) Composition test: _build_manifest_context instance_id matches
 #      compute_instance_id; and _guard_release_not_already_open matches on it.


### PR DESCRIPTION
Implements the **helm-image-updater** side of **[ST-4277](https://linear.app/keboola/issue/ST-4277/implement-rollback-strategy)** — a `rollback` deploy strategy. Follows `release-promoter`'s `docs/plans/ST-4277-rollback-strategy.md` (RFC rev 4) §3.2; tasks B1–B4.

## What this does
Adds `deploy-strategy: rollback` — a single-wave, fleet-converging recovery deploy. HIU fans out **one PR (wave 0)** over every stack whose `tag.yaml` differs from the target tag (dev + prod together), labeled `release:wave:0` + `deploy:rollback`, **never auto-merged** — the release-promoter preempts older in-flight releases of the same app and merges the rollback PR.

## ✅ E2E tests
https://github.com/keboola/helm-image-updater-testing/actions/runs/29690064870

## Changes (task-by-task)
- **B1** — `DeployStrategy.ROLLBACK` enum. `is_wave` excludes it (no 0..3 grouping); `is_promoter_managed` includes it. Env validation: `rollback` + `OVERRIDE_STACK` rejected; `rollback` requires a **production/semver-classified** target (load-bearing — a dev/canary target would route DEV/CANARY and silently skip preemption).
- **B2** — `compute_rollback_instance_id` → `<app>-rollback-<sig>-<GITHUB_RUN_ID>`, distinct from the ST-4190 `<app>-<tag>` id (avoids the promoter's duplicate-instanceId `Conflicted` deadlock) and idempotent for a re-run of the same run. New optional manifest fields `imageTag`/`extraTags` on **both** `build_manifest` and `build_manual_manifest` (all strategies).
- **B3** — the rollback plan: grouping branch (first, before `is_wave`) → one wave-0 PR / all changed stacks / correct labels, with a defensive hard-raise on a non-production target; `⏪ ROLLBACK <chart> → <tag>` PR title; `**Reason:**` body line from `metadata.source.reason`; no-auto-merge; a **rollback-specific zero-diff error** pointing to `promoter:abandon-release` (a rollback is a deploy, not a pure cancel — RFC §2); executor wiring so `imageTag`/`extraTags` reach the live PR body at both manifest call sites.
- **B4** — `action.yaml` `deploy-strategy` + `README.md` documentation.

## Verification
- `python3 -m pytest tests -q` → **306 passing** (271 baseline + 35 new: test_rollback.py 26 + test_manifest.py 5 + test_plan_executor.py 2 + test_wave_grouping.py 2; run via the repo `.venv`, Python 3.13).
- **Codex gate** (read-only sandbox, RFC §3.2): **SHIP** — 0 critical / important / minor; all seven review points (diff-membership + labels, instanceId shape/uniqueness/idempotency, the production/semver guard, no-auto-merge, manifest fields reaching the live PR, zero-diff guidance, no non-rollback regression) verified against the code.

## Merge-time steps (NOT in this PR)
- **Version: `v0.26.0`** — already bumped in `setup.py` on this branch (v0.25.0 was taken by st-4170/#48 on main). Tag `v0.26.0` at human merge time.
- Merge order (RFC §6): release-promoter first (already open), then this, then helm-image-updater-testing (e2e), then kbc-stacks (`rollback-image-tag.yaml` pinned to `v0.26.0` + the `deploy:rollback` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)