### PR TITLE
Add dev-keboola-gcp-e2e-tags to EXCLUDED_STACKS

### DIFF
--- a/helm_image_updater/config.py
+++ b/helm_image_updater/config.py
@@ -22,7 +22,7 @@ DEV_STACK_MAPPING = {
     "aws": "dev-keboola-aws-eu-west-1"
 }
 SUPPORTED_CLOUD_PROVIDERS = ["aws", "azure", "gcp"]
-EXCLUDED_STACKS = ["dev-keboola-gcp-us-east1-e2e", "dev-keboola-azure-east-us-2-e2e", "dev-keboola-aws-us-east-1-e2e"]
+EXCLUDED_STACKS = ["dev-keboola-gcp-us-east1-e2e", "dev-keboola-gcp-e2e-tags", "dev-keboola-azure-east-us-2-e2e", "dev-keboola-aws-us-east-1-e2e"]
 CANARY_STACKS = {
     "canary-orion": {
         "stack": "dev-keboola-canary-orion",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 setup(
     name="helm_image_updater",
-    version="0.24.0",
+    version="0.25.0",
     packages=find_packages(),
     install_requires=requirements,
     entry_points={


### PR DESCRIPTION
## Release Notes 
Add the new Connection E2E testing stack `dev-keboola-gcp-e2e-tags` to `EXCLUDED_STACKS` so helm-image-updater stops treating it as a production stack.

## Plans for customer communication
None.

## Impact analysis
Until this merges, every release commits a tag to the stack (it is Argo-registered and classified as production). After merge the stack only gets deploys via explicit `override-stack` dispatches — same behaviour as the other three e2e stacks. Full test suite passes locally (271 passed).

## Change type
Config — stack classification.

## Justification
New stack rollout [ST-4170](https://linear.app/keboola/issue/ST-4170/novy-gcp-e2e-stack-pro-connection-testy) ([deployment plan](https://linear.app/keboola/document/deployment-plan-dev-keboola-gcp-e2e-tags-8b210d638263)); flagged by @kacurez in the issue.

## Deployment
Per the README release process (the action runs code from the pinned tag):
1. Merge this PR (includes the `setup.py` version bump to **0.25.0** — CI fails the release if tag ≠ setup.py)
2. Tag & push: `git tag v0.25.0 && git push origin v0.25.0` → release workflow runs tests, builds sdist, publishes the GitHub Release
3. Bump the consumer pin in kbc-stacks: [kbc-stacks#21137](https://github.com/keboola/kbc-stacks/pull/21137) (`keboola/helm-image-updater@v0.25.0`)

## Rollback plan
Revert of this PR.

## Post release support plan
None.
